### PR TITLE
Enable Ansible to run on OpenShift Ci environment 

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -33,7 +33,7 @@ RUN sed -i '19s/roles\//\/opt\/ci-artifacts\/roles/' /etc/ansible/ansible.cfg
 ENV USER_UID=1001 \
     USER_NAME=psap-ci-runner \
     HOME=/opt/ci-artifacts/src/ \
-    OPTS="-v" \
+    OPTS="-vvv" \
     WORK_DIR=/opt/ci-artifacts/src/
 
 COPY group_vars ${HOME}/group_vars

--- a/build/root/usr/local/bin/run
+++ b/build/root/usr/local/bin/run
@@ -5,6 +5,8 @@
 #
 # SOURCE and HOME DIRECTORY: /opt/ci-artifacts/src
 
+echo "===> Running GPU CI Test suite<==="
+
 set -o pipefail
 set -o errexit
 set -o nounset
@@ -14,6 +16,12 @@ then
 		echo "No kubeconfig, can't continue"
 		exit 1
 fi
+echo "Kubeconfiug found at ${KUBECONFIG}, proceeding with tests"
+
+# allow us to make a temporary user and group account for our OpenShift user
+echo "tempuser❌$(id -u):$(id -g):,,,:${HOME}:/bin/bash" >> /etc/passwd
+echo "tempuser❌$(id -G | cut -d' ' -f 2)" >> /etc/group
+exec id 
 
 cd ${WORK_DIR}
 

--- a/build/root/usr/local/bin/user_setup
+++ b/build/root/usr/local/bin/user_setup
@@ -6,8 +6,8 @@ mkdir -p ${HOME}
 chown ${USER_UID}:0 ${HOME}
 chmod ug+rwx ${HOME}
 
-# runtime user will need to be able to self-insert in /etc/passwd
-chmod g+rw /etc/passwd
+# runtime user will need to be able to self-insert in /etc/passwd and /etc/group
+chmod g+rw /etc/passwd /etc/group
 
 # ensure that the ansible content is accessible
 chmod -R g+r ${WORK_DIR}


### PR DESCRIPTION
This Patch:
- elevates verbosity from `v` to `vvv`
- enables a user at runtime so Ansible doesn't errors `KeyError: 'getpwuid(): uid not found:` 