### PR TITLE
build/root/usr/local/bin/run: remove USER workaround that cannot work

### DIFF
--- a/build/root/usr/local/bin/run
+++ b/build/root/usr/local/bin/run
@@ -18,11 +18,6 @@ then
 fi
 echo "Kubeconfiug found at ${KUBECONFIG}, proceeding with tests"
 
-# allow us to make a temporary user and group account for our OpenShift user
-echo "tempuser❌$(id -u):$(id -g):,,,:${HOME}:/bin/bash" >> /etc/passwd
-echo "tempuser❌$(id -G | cut -d' ' -f 2)" >> /etc/group
-exec id 
-
 cd ${WORK_DIR}
 
 INVENTORY_ARG="-i inventory/hosts"


### PR DESCRIPTION
This PR removes a buggy workaround on the CI code that prevents the `master` branch from properly testing the GPU operator

see https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/periodic-ci-openshift-psap-ci-artifacts-master-gpu-operator-e2e/1338997427285266432/artifacts/gpu-operator-e2e/nightly/container-logs/test.log

```
===> Running GPU CI Test suite<===
Kubeconfiug found at /tmp/tmp.BU55psNfBG, proceeding with tests
uid=1011810000 gid=0(root) groups=0(root),1011810000
```

Signed-off-by: Kevin Pouget <kpouget@redhat.com>