### PR TITLE
gpu-operator: run CI checks against a given git commit

### DIFF
--- a/build/root/usr/local/bin/run
+++ b/build/root/usr/local/bin/run
@@ -51,6 +51,9 @@ if [[ "${INSIDE_CI_IMAGE:-}" == "y" ]]; then
     OCP_VERSION="$(oc version -o json | jq --raw-output '.openshiftVersion' | cut -b-3)"
     ANSIBLE_OPTS="-vvv"
     ANSIBLE_OPTS="$ANSIBLE_OPTS -e openshift_release=$OCP_VERSION"
+
+    CI_IMAGE_GPU_COMMIT_CI_REPO="https://gitlab.com/kpouget_psap/gpu-operator.git"
+    CI_IMAGE_GPU_COMMIT_CI_REF="ci-testing"
 fi
 
 [[ "${INSIDE_CI_IMAGE:-}" == "y" ]] && set -x
@@ -60,6 +63,27 @@ ANSIBLE_OPTS=${ANSIBLE_OPTS:--v}
 INVENTORY_ARG="-i inventory/hosts"
 
 case ${1:-} in
+    "gpu-commit-ci")
+        if [[ "${INSIDE_CI_IMAGE:-}" == "y" ]]; then
+            git_repo=${CI_IMAGE_GPU_COMMIT_CI_REPO}
+            git_ref=${CI_IMAGE_GPU_COMMIT_CI_REF}
+        else
+            if [ "$#" -lt 2 ]; then
+                echo "Usage: $0 $1 <git repository> <git reference>"
+                exit 1
+            fi
+            git_repo=$2
+            git_ref=$3
+        fi
+
+        echo "Using Git repository ${git_repo} with ref ${git_ref}"
+
+        ANSIBLE_OPTS="${ANSIBLE_OPTS} -e gpu_operator_git_repo=${git_repo}"
+        ANSIBLE_OPTS="${ANSIBLE_OPTS} -e gpu_operator_git_ref=${git_ref}"
+        ANSIBLE_OPTS="${ANSIBLE_OPTS} -e gpu_operator_image_tag_uid=$(cat /proc/sys/kernel/random/uuid | cut -b-8)"
+
+	exec ansible-playbook ${INVENTORY_ARG} ${ANSIBLE_OPTS} playbooks/nvidia-gpu-operator-commit-ci.yml
+        ;;
     "gpu-ci")
 	exec ansible-playbook ${INVENTORY_ARG} ${ANSIBLE_OPTS} playbooks/nvidia-gpu-operator-ci.yml
 	;;

--- a/build/root/usr/local/bin/run
+++ b/build/root/usr/local/bin/run
@@ -26,7 +26,7 @@ echo "Kubeconfig found at ${KUBECONFIG}, proceeding with tests"
 if ! which oc &>/dev/null && [ ${1:-} == gpu-commit-ci ];
 then
     echo "OpenShift client not found, downloading it ..."
-    mkdir bin -p
+    mkdir -p bin
     cd bin
     wget --quiet https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/latest/openshift-client-linux.tar.gz
     tar xvf openshift-client-linux.tar.gz
@@ -38,7 +38,7 @@ fi
 if ! which helm &>/dev/null;
 then
     echo "Helm not found, downloading it ..."
-    mkdir bin -p
+    mkdir -p bin
     cd bin
 
     HELM_VERSION="v3.5.1"

--- a/build/root/usr/local/bin/run
+++ b/build/root/usr/local/bin/run
@@ -23,7 +23,7 @@ then
 fi
 echo "Kubeconfig found at ${KUBECONFIG}, proceeding with tests"
 
-if ! which oc &>/dev/null;
+if ! which oc &>/dev/null && [ ${1:-} == gpu-commit-ci ];
 then
     echo "OpenShift client not found, downloading it ..."
     mkdir bin -p
@@ -31,6 +31,21 @@ then
     wget --quiet https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/latest/openshift-client-linux.tar.gz
     tar xvf openshift-client-linux.tar.gz
     rm openshift-client-linux.tar.gz
+    export PATH=$PWD:$PATH
+    cd ..
+fi
+
+if ! which helm &>/dev/null;
+then
+    echo "Helm not found, downloading it ..."
+    mkdir bin -p
+    cd bin
+
+    HELM_VERSION="v3.5.1"
+    wget https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz --quiet
+    tar xvf helm-${HELM_VERSION}-linux-amd64.tar.gz linux-amd64/helm
+    mv linux-amd64/helm .
+    rmdir linux-amd64
     export PATH=$PWD:$PATH
     cd ..
 fi

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -10,6 +10,8 @@ aws_add_gpu_node: '{{ use_aws }}'
 # Force reinstallation of all operators, CRDs, etc.?
 force_reinstall: 'yes'
 
+install_operator_from_hub: 'yes'
+
 # user mode, set the behaviour of the playbook, available modes:
 # - install: basic install of desired operators operators
 # - uninstall: if installed, uninstall desired operators

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -35,6 +35,9 @@ test_nfd: 'yes'
 test_sro: 'yes'
 test_odh: 'no'
 
+# Undeploy the GPU-operator from custom commit with helm
+undeploy_gpu_operator: 'yes'
+
 # json raw template from running workers
 gpu_machineset_template: "gpu_machineset_aws_template.json"
 

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -5,6 +5,7 @@ openshift_release: '4.6'
 # AWS deployment
 use_aws: 'yes'
 aws_check: '{{ use_aws }}'
+aws_add_gpu_node: '{{ use_aws }}'
 
 # Force reinstallation of all operators, CRDs, etc.?
 force_reinstall: 'yes'

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -10,7 +10,8 @@ aws_add_gpu_node: '{{ use_aws }}'
 # Force reinstallation of all operators, CRDs, etc.?
 force_reinstall: 'yes'
 
-install_operator_from_hub: 'yes'
+install_nfd_operator_from_hub: 'yes'
+install_gpu_operator_from_hub: 'yes'
 
 # user mode, set the behaviour of the playbook, available modes:
 # - install: basic install of desired operators operators

--- a/playbooks/nvidia-gpu-operator-commit-ci.yml
+++ b/playbooks/nvidia-gpu-operator-commit-ci.yml
@@ -1,9 +1,17 @@
----
+# Create a machineset GPU enabled
+- name: Scaling up an OCP GPU ready node
+  hosts: localhost
+  connection: local
+  gather_facts: true
+  vars:
+    kubeconfig: "{{ ansible_env.KUBECONFIG }}"
+  roles:
+    - openshift_node
 # Install and test GPU Operator from a custom commit
 - name: Install and NVidia GPU operator From Given Commit
   hosts: localhost
   connection: local
-  gather_facts: true
+  gather_facts: false
   vars:
     kubeconfig: "{{ ansible_env.KUBECONFIG }}"
   roles:

--- a/playbooks/nvidia-gpu-operator-commit-ci.yml
+++ b/playbooks/nvidia-gpu-operator-commit-ci.yml
@@ -1,0 +1,10 @@
+---
+# Install and test GPU Operator from a custom commit
+- name: Install and NVidia GPU operator From Given Commit
+  hosts: localhost
+  connection: local
+  gather_facts: true
+  vars:
+    kubeconfig: "{{ ansible_env.KUBECONFIG }}"
+  roles:
+    - role: nv_gpu_install_from_commit

--- a/roles/nv_gpu/tasks/ci_checks.yml
+++ b/roles/nv_gpu/tasks/ci_checks.yml
@@ -25,7 +25,7 @@
       ignore_errors: true
     - name: capture Pod images
       command: |
-        oc get pods -o=jsonpath='{range .items[*]}{"\n"}{.metadata.name}{":\t"}{range .spec.containers[*]}{.image}{", "}{end}{end}'
+        oc get pods -n gpu-operator-resources -o=jsonpath='{range .items[*]}{"\n"}{.metadata.name}{":\t"}{range .spec.containers[*]}{.image}{", "}{end}{end}'
       ignore_errors: true
     - name: capture GPU Nodes states
       command: oc describe node -lnvidia.com/gpu.present=true

--- a/roles/nv_gpu/tasks/install_nfd.yml
+++ b/roles/nv_gpu/tasks/install_nfd.yml
@@ -1,4 +1,3 @@
----
 - name: Create the namespace for the NFD Operator
   command: oc apply -f "{{ nfd_operator_namespace }}"
 
@@ -40,36 +39,3 @@
     - name: Failed when creating the test clusterpolicy CR for the GPU Operator
       fail:
         msg: "{{ nfd_cr }}"
-
-- name: Create the namespace for the GPU Operator
-  block:
-    - name: apply namespace manifest
-      command: oc apply -f "{{ gpu_operator_namespace }}"
-      register: test_namespace
-  rescue:
-    - name: Failed when creating the test namespace for the GPU Operator
-      fail:
-        msg: "{{ test_namespace }}"
-
-- name: Create the OperatorHub subscription for the GPU Operator
-  block:
-    - name: apply operatorhub subscription manifest
-      command: oc apply -f "{{ gpu_operator_operatorhub_sub }}"
-      register: test_operatorhub_sub
-  rescue:
-    - name: Failed when creating the OperatorHub subscription for the GPU Operator
-      fail:
-        msg: "{{ test_operatorhub_sub }}"
-
-- name: Create the clusterPolicy CR for the GPU Operator
-  block:
-    - name: apply clusterpolicy manifest
-      command: oc apply -f "{{ gpu_operator_crd }}"
-      register: test_clusterpolicy_cr
-      until: test_clusterpolicy_cr.rc != 1
-      retries: 20
-      delay: 15
-  rescue:
-    - name: Failed when creating the clusterpolicy CR for the GPU Operator
-      fail:
-        msg: "{{ test_clusterpolicy_cr }}"

--- a/roles/nv_gpu/tasks/install_nv.yml
+++ b/roles/nv_gpu/tasks/install_nv.yml
@@ -1,0 +1,32 @@
+- name: Create the namespace for the GPU Operator
+  block:
+    - name: apply namespace manifest
+      command: oc apply -f "{{ gpu_operator_namespace }}"
+      register: test_namespace
+  rescue:
+    - name: Failed when creating the test namespace for the GPU Operator
+      fail:
+        msg: "{{ test_namespace }}"
+
+- name: Create the OperatorHub subscription for the GPU Operator
+  block:
+    - name: apply operatorhub subscription manifest
+      command: oc apply -f "{{ gpu_operator_operatorhub_sub }}"
+      register: test_operatorhub_sub
+  rescue:
+    - name: Failed when creating the OperatorHub subscription for the GPU Operator
+      fail:
+        msg: "{{ test_operatorhub_sub }}"
+
+- name: Create the clusterPolicy CR for the GPU Operator
+  block:
+    - name: apply clusterpolicy manifest
+      command: oc apply -f "{{ gpu_operator_crd }}"
+      register: test_clusterpolicy_cr
+      until: test_clusterpolicy_cr.rc != 1
+      retries: 20
+      delay: 15
+  rescue:
+    - name: Failed when creating the clusterpolicy CR for the GPU Operator
+      fail:
+        msg: "{{ test_clusterpolicy_cr }}"

--- a/roles/nv_gpu/tasks/main.yml
+++ b/roles/nv_gpu/tasks/main.yml
@@ -1,13 +1,15 @@
----
 - block:
-  - name: Install GPU-operator from OperatorHub
-    include_tasks: roles/nv_gpu/tasks/install.yml
-    when: install_operator_from_hub == "yes"
+  - name: Install NFD-operator from OperatorHub
+    include_tasks: roles/nv_gpu/tasks/install_nfd.yml
+    when: install_nfd_operator_from_hub == "yes"
 
-  # Ci block
-  - block:
-    - include_tasks: ci_checks.yml
-      when: user_mode == 'ci'
+  - name: Install GPU-operator from OperatorHub
+    include_tasks: roles/nv_gpu/tasks/install_nv.yml
+    when: install_gpu_operator_from_hub == "yes"
+
+  - include_tasks: ci_checks.yml
+    when: user_mode == 'ci'
+
   rescue:
   - include_tasks: verbose_failure.yml
   - name: Failing because of a previous error

--- a/roles/nv_gpu/tasks/main.yml
+++ b/roles/nv_gpu/tasks/main.yml
@@ -1,7 +1,8 @@
 ---
-- name: Check if NVidia GPU operator has been deployed
-  block:
-  - include_tasks: roles/nv_gpu/tasks/install.yml
+- block:
+  - name: Install GPU-operator from OperatorHub
+    include_tasks: roles/nv_gpu/tasks/install.yml
+    when: install_operator_from_hub == "yes"
 
   # Ci block
   - block:

--- a/roles/nv_gpu_install_from_commit/files/helm_deploy_operator.sh
+++ b/roles/nv_gpu_install_from_commit/files/helm_deploy_operator.sh
@@ -17,6 +17,8 @@ OPERATOR_NAME="gpu-operator-from-source"
 OPERATOR_NAMESPACE="gpu-operator-ci"
 HELM_SOURCE="./deployments/gpu-operator"
 
+NFD_ENABLED="${NFD_ENABLED:-false}"
+
 # https://stackoverflow.com/a/21189044/341106
 function parse_yaml {
    local prefix=$2
@@ -72,7 +74,7 @@ deploy() {
      \
      --set platform.openshift=true \
      --set operator.defaultRuntime=crio \
-     --set nfd.enabled=false \
+     --set nfd.enabled=${NFD_ENABLED} \
      \
      --set toolkit.version=${HELM_values[toolkit_version]/-ubuntu*/}-ubi8 \
      --set devicePlugin.version=${device_plugin_version} \

--- a/roles/nv_gpu_install_from_commit/files/helm_deploy_operator.sh
+++ b/roles/nv_gpu_install_from_commit/files/helm_deploy_operator.sh
@@ -1,0 +1,98 @@
+#! /bin/bash
+
+set -Eeuo pipefail
+
+set -x
+if [ "$#" -gt 4 ]; then
+    echo "Usage: $0 deploy|undeploy <gpu_operator_git_repo> <gpu_operator_git_ref> <gpu_operator_image_tag>"
+    exit 1
+fi
+
+action="$1"
+OPERATOR_GIT_REPO="$2"
+OPERATOR_GIT_REF="$3"
+OPERATOR_IMAGE_TAG="$4"
+
+OPERATOR_NAME="gpu-operator-from-source"
+OPERATOR_NAMESPACE="gpu-operator-ci"
+HELM_SOURCE="./deployments/gpu-operator"
+
+# https://stackoverflow.com/a/21189044/341106
+function parse_yaml {
+   local prefix=$2
+   local s='[[:space:]]*' w='[a-zA-Z0-9_]*' fs=$(echo @|tr @ '\034')
+   sed -ne "s|^\($s\):|\1|" \
+        -e "s|^\($s\)\($w\)$s:$s[\"']\(.*\)[\"']$s\$|\1$fs\2$fs\3|p" \
+        -e "s|^\($s\)\($w\)$s:$s\(.*\)$s\$|\1$fs\2$fs\3|p"  $1 |
+   awk -F$fs '{
+      indent = length($1)/2;
+      vname[indent] = $2;
+      for (i in vname) {if (i > indent) {delete vname[i]}}
+      if (length($3) > 0) {
+         vn=""; for (i=0; i<indent; i++) {vn=(vn)(vname[i])("_")}
+         printf("%s%s%s=\"%s\"\n", "'$prefix'",vn, $2, $3);
+      }
+   }'
+}
+
+deploy() {
+    cd /tmp
+    rm -rf gpu-operator
+    git clone $OPERATOR_GIT_REPO -b $OPERATOR_GIT_REF --depth 1 gpu-operator
+
+    cd gpu-operator
+
+    set +x
+    declare -A HELM_values
+    while read line; do
+        key=$(echo $line | cut -d= -f1)
+        value=$(echo $line | cut -d= -f2 | sed 's/^"//' | sed 's/"$//')
+        HELM_values[$key]=$value
+    done <<< $(parse_yaml deployments/gpu-operator/values.yaml "")
+    set -x
+
+    SKIP_BROKEN_UBI8_DEVICE_PLUGIN=1
+    if [ $SKIP_BROKEN_UBI8_DEVICE_PLUGIN == 1 ]; then
+        echo "Using default (ubuntu) device plugin image"
+        device_plugin_version=${HELM_values[devicePlugin_version]}
+    else
+        echo "Using ubi8 (maybe broken) device plugin image"
+        device_plugin_version=${HELM_values[devicePlugin_version]/-ubuntu*/}-ubi8
+    fi
+
+    helm uninstall --namespace $OPERATOR_NAMESPACE $OPERATOR_NAME || true
+    #helm template --debug # <-- this is for debugging helm install
+    exec helm install \
+     $OPERATOR_NAME $HELM_SOURCE \
+     --devel \
+     \
+     --set operator.repository=image-registry.openshift-image-registry.svc:5000/gpu-operator-ci \
+     --set operator.image=gpu-operator-ci \
+     --set operator.version=${OPERATOR_IMAGE_TAG} \
+     \
+     --set platform.openshift=true \
+     --set operator.defaultRuntime=crio \
+     --set nfd.enabled=false \
+     \
+     --set toolkit.version=${HELM_values[toolkit_version]/-ubuntu*/}-ubi8 \
+     --set devicePlugin.version=${device_plugin_version} \
+     --set dcgmExporter.version=${HELM_values[dcgmExporter_version]/-ubuntu*/}-ubi8 \
+     \
+     --namespace $OPERATOR_NAMESPACE \
+     --wait
+}
+
+undeploy() {
+    exec helm uninstall --namespace $OPERATOR_NAMESPACE $OPERATOR_NAME
+}
+
+if [ "$action" == deploy ];
+then
+    deploy
+elif [ "$action" == undeploy ];
+then
+    undeploy
+else
+    echo "Unknown action command '$action' ..."
+    exit 1
+fi

--- a/roles/nv_gpu_install_from_commit/files/operator_ci_utils.yaml
+++ b/roles/nv_gpu_install_from_commit/files/operator_ci_utils.yaml
@@ -1,0 +1,16 @@
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: gpu-operator-ci-utils
+  labels:
+    app: gpu-operator-ci
+spec: {}
+---
+kind: ImageStream
+apiVersion: v1
+metadata:
+  name: gpu-operator-ci-utils
+  namespace: gpu-operator-ci-utils
+  labels:
+    app: gpu-operator-ci
+spec: {}

--- a/roles/nv_gpu_install_from_commit/files/operator_ci_utils_namespace.yml
+++ b/roles/nv_gpu_install_from_commit/files/operator_ci_utils_namespace.yml
@@ -1,0 +1,7 @@
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: gpu-operator-ci-utils
+  labels:
+    app: gpu-operator-ci
+spec: {}

--- a/roles/nv_gpu_install_from_commit/files/operator_helper_image_builder.yaml
+++ b/roles/nv_gpu_install_from_commit/files/operator_helper_image_builder.yaml
@@ -1,0 +1,60 @@
+apiVersion: build.openshift.io/v1
+kind: BuildConfig
+metadata:
+  labels:
+    app: gpu-operator-ci
+  name: helper-image-builder
+  namespace: gpu-operator-ci-utils
+spec:
+  output:
+    to:
+      kind: ImageStreamTag
+      name: gpu-operator-ci-utils:builder_helper
+      namespace: gpu-operator-ci-utils
+  source:
+    type: Dockerfile
+    dockerfile: |
+      # stable/Dockerfile
+      #
+      # https://developers.redhat.com/blog/2019/08/14/best-practices-for-running-buildah-in-a-container/
+      #
+      # Build a Buildah container image from the latest
+      # stable version of Buildah on the Fedoras Updates System.
+      # https://bodhi.fedoraproject.org/updates/?search=buildah
+      # This image can be used to create a secured container
+      # that runs safely with privileges within the container.
+      #
+      # --> adapted to use podman instead of buildah
+      FROM quay.io/fedora/fedora:32-x86_64
+
+      # Don't include container-selinux and remove
+      # directories used by dnf that are just taking
+      # up space.
+      RUN yum -y install podman fuse-overlayfs; rm -rf /var/cache /var/log/dnf* /var/log/yum.*
+
+      # Adjust storage.conf to enable Fuse storage.
+      RUN sed -i 's|# Storage options to be passed to underlying storage drivers|# Storage options to be passed to underlying storage drivers\nmount_program = "/usr/bin/fuse-overlayfs"|' /etc/containers/storage.conf
+
+      RUN sed -i 's|additionalimagestores = \[|additionalimagestores = \[\n  "/var/lib/shared"|' /etc/containers/storage.conf
+
+      RUN [ -c /dev/fuse ] || mknod /dev/fuse c 10 229
+
+      RUN mkdir -p /var/lib/shared/overlay-images /var/lib/shared/overlay-layers; touch /var/lib/shared/overlay-images/images.lock; touch /var/lib/shared/overlay-layers/layers.lock
+
+      # Set up environment variables to note that this is
+      # not starting with user namespace and default to
+      # isolate the filesystem with chroot.
+      ENV _BUILDAH_STARTED_IN_USERNS="" BUILDAH_ISOLATION=chroot
+
+      # GPU-operator-CI specific
+
+      RUN yum -y install git make
+
+  strategy:
+    dockerStrategy:
+      from:
+        kind: DockerImage
+        name: quay.io/fedora/fedora:32-x86_64
+    type: Docker
+  triggers:
+  - type: ConfigChange

--- a/roles/nv_gpu_install_from_commit/files/operator_image_builder_pod.yaml
+++ b/roles/nv_gpu_install_from_commit/files/operator_image_builder_pod.yaml
@@ -1,0 +1,48 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: gpu-operator-ci
+  name: operator-image-builder-pod
+  namespace: gpu-operator-ci
+spec:
+  containers:
+  - command:
+    - /bin/sh
+    - /mnt/helper/run_operator_image_builder.sh
+    image: image-registry.openshift-image-registry.svc:5000/gpu-operator-ci-utils/gpu-operator-ci-utils:builder_helper
+    name: operator-image-builder
+    imagePullPolicy: Always
+    securityContext:
+      privileged: true
+    env:
+      - name: OPERATOR_GIT_REPO
+        value: "{{ gpu_operator_git_repo }}" # set by `build.yaml` ansible script
+      - name: OPERATOR_GIT_REF
+        value: "{{ gpu_operator_git_ref }}" # set by `build.yaml` ansible script
+      - name: IMAGESTREAM_NAME
+        value: "gpu-operator-ci/gpu-operator-ci"
+      - name: IMAGESTREAM_TAG
+        value: "{{ gpu_operator_image_tag }}" # set by `build.yaml` ansible script
+      - name: BUILDER_FROM_IMAGE
+        value: "quay.io/openshift-psap/golang:1.13" # avoid using docker.io and its quotas...
+    volumeMounts:
+    - mountPath: /mnt/helper/run_operator_image_builder.sh
+      name: operator-image-builder-script
+      readOnly: true
+      subPath: run_operator_image_builder.sh
+    - mountPath: /var/run/secrets/openshift.io/push
+      name: builder-dockercfg-push
+      readOnly: true
+  nodeSelector:
+    tuned.module.fuse: ""
+  restartPolicy: Never
+  volumes:
+  - configMap:
+      defaultMode: 511
+      name: operator-image-builder-script
+    name: operator-image-builder-script
+  - name: builder-dockercfg-push
+    secret:
+      defaultMode: 384
+      secretName: "{{ builder_secret }}" # set by `build.yaml` ansible script

--- a/roles/nv_gpu_install_from_commit/files/operator_image_builder_script.yaml
+++ b/roles/nv_gpu_install_from_commit/files/operator_image_builder_script.yaml
@@ -1,0 +1,38 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: gpu-operator-ci
+  name: operator-image-builder-script
+  namespace: gpu-operator-ci
+data:
+  run_operator_image_builder.sh: |
+    #! /bin/bash
+    set -ex
+
+    IMAGE_STREAM=image-registry.openshift-image-registry.svc:5000/${IMAGESTREAM_NAME}:${IMAGESTREAM_TAG}
+
+    mkdir /work && cd /work
+
+    git clone ${OPERATOR_GIT_REPO} gpu-operator -b ${OPERATOR_GIT_REF} --depth 1
+
+    cd gpu-operator
+
+    if [ ! -z "${BUILDER_FROM_IMAGE}" ]; then
+      sed "s|FROM golang:1.13|FROM ${BUILDER_FROM_IMAGE}|" -i ./docker/Dockerfile.ubi8.prod
+    fi
+
+    # avoid docker.io quotas ...
+    sed -i 's|FROM nvidia/cuda:|FROM nvcr.io/nvidia/cuda:|' ./docker/Dockerfile.ubi8.prod
+
+    make DOCKER="podman --cgroup-manager=cgroupfs" prod-image
+
+    # push the image locally
+
+    AUTH="--tls-verify=false --authfile /tmp/.dockercfg"
+    cp /var/run/secrets/openshift.io/push/.dockercfg /tmp
+    (echo "{ \"auths\": " ; cat /var/run/secrets/openshift.io/push/.dockercfg ; echo "}") > /tmp/.dockercfg
+
+    podman push $AUTH nvidia/gpu-operator:latest $IMAGE_STREAM
+
+    echo "GPU-operator from $OPERATOR_GIT_REPO / $OPERATOR_GIT_REF pushed to $IMAGE_STREAM"

--- a/roles/nv_gpu_install_from_commit/files/operator_imagestream.yaml
+++ b/roles/nv_gpu_install_from_commit/files/operator_imagestream.yaml
@@ -1,0 +1,8 @@
+kind: ImageStream
+apiVersion: v1
+metadata:
+  name: gpu-operator-ci
+  namespace: gpu-operator-ci
+  labels:
+    app: gpu-operator-ci
+spec: {}

--- a/roles/nv_gpu_install_from_commit/files/operator_namespace.yaml
+++ b/roles/nv_gpu_install_from_commit/files/operator_namespace.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: gpu-operator
+  labels:
+    app: gpu-operator-ci
+---
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: gpu-operator-ci
+  labels:
+    app: gpu-operator-ci
+spec: {}
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: gpu-operator-resources
+  labels:
+    app: gpu-operator-ci

--- a/roles/nv_gpu_install_from_commit/files/tuned_module_fuse.yaml
+++ b/roles/nv_gpu_install_from_commit/files/tuned_module_fuse.yaml
@@ -1,0 +1,20 @@
+# oc label node/$NODE_NAME tuned.module.fuse=
+apiVersion: tuned.openshift.io/v1
+kind: Tuned
+metadata:
+  name: tuned-module-fuse
+  namespace: openshift-cluster-node-tuning-operator
+spec:
+  profile:
+  - data: |
+      [main]
+      summary=An OpenShift profile to load 'fuse' module
+      include=openshift-node
+      [modules]
+      fuse=+r
+    name: openshift-fuse
+  recommend:
+  - match:
+    - label: tuned.module.fuse
+    profile: "openshift-fuse"
+    priority: 5

--- a/roles/nv_gpu_install_from_commit/meta/main.yml
+++ b/roles/nv_gpu_install_from_commit/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - role: check_deps

--- a/roles/nv_gpu_install_from_commit/tasks/build.yml
+++ b/roles/nv_gpu_install_from_commit/tasks/build.yml
@@ -1,0 +1,99 @@
+---
+- name: find a node with our tuned label
+  command: oc get nodes -l "{{ tuned_module_fuse_label }}" -oname
+  register: fuse_nodes
+- name: find a worker node to label for loading tuned module
+  shell: oc get nodes -l node-role.kubernetes.io/worker -oname | head -1
+  when: fuse_nodes.stdout == ""
+  register: worker_nodes
+- name: mark node with our tuned label
+  command: oc label "{{ worker_nodes.stdout }}" "{{ tuned_module_fuse_label }}="
+  when: fuse_nodes.stdout == ""
+
+- name: apply tuned fuse profile manifest
+  command: oc apply -f "{{ tuned_module_fuse }}"
+
+- name: apply ci utils manifest
+  command: oc apply -f "{{ gpu_operator_ci_utils }}"
+
+- name: authorize ns/gpu-operator-ci Pods to access ns/gpu-operator-ci-utils images
+  command: oc policy add-role-to-user \
+             system:image-puller system:serviceaccount:gpu-operator-ci:default \
+             --namespace=gpu-operator-ci-utils
+
+- name: apply namespace manifest
+  command: oc apply -f "{{ gpu_operator_namespace }}"
+
+- name: apply imagestream manifest
+  command: oc apply -f "{{ gpu_operator_imagestream }}"
+
+- name: apply image helper builder manifest
+  command: oc apply -f "{{ gpu_operator_helper_image_builder }}"
+
+- name: wait for the helper image to be built
+  block:
+  - name: wait for the helper image to be built
+    shell: oc get pod --field-selector=status.phase=Succeeded,metadata.name=helper-image-builder-1-build --no-headers -oname -n gpu-operator-ci-utils | grep helper-image-builder-1-build
+    register: wait_helper_image
+    until: wait_helper_image.rc != 1
+    retries: 40
+    delay: 30
+  rescue:
+  - name: get info about helper image build failure
+    command: oc get pods -n gpu-operator-ci
+    ignore_errors: true
+  - name: get logs of helper image build failure
+    command: oc get logs bc/helper-image-builder -n gpu-operator-ci
+    ignore_errors: true
+  - name: get info about helper image build failure
+    command: oc describe build/helper-image-builder-1 -n gpu-operator-ci
+  - name: operator image failed to build
+    fail:
+      msg: operator image failed to build
+
+- name: apply operator image builder script manifest
+  command: oc apply -f "{{ gpu_operator_image_builder_script }}"
+
+- name: find the name of the builder-dockercfg secret
+  block:
+    - name: find the name of the builder-dockercfg secret
+      shell: oc get secrets -oname -n gpu-operator-ci | cut -d/ -f2 | grep builder-dockercfg
+      register: builder_secret
+  rescue:
+    - name: Failed to find the builder-dockercfg secret
+      fail:
+        msg: "No builder-dockercfg secret in the 'gpu-operator-ci' namespace ..."
+
+- name: delete operator image builder pod, if any
+  shell: oc delete -f "{{ gpu_operator_image_builder_pod }}" || true
+
+- name: delete operator image, if any
+  shell: oc delete imagestreamtag/gpu-operator-ci:gpu-operator -n gpu-operator-ci || true
+
+- name: apply operator image builder pod manifest
+  shell: sed 's|{{ '{{' }} builder_secret {{ '}}' }}|{{ builder_secret.stdout }}|' "{{ gpu_operator_image_builder_pod }}" \
+       | sed 's|{{ '{{' }} gpu_operator_git_repo {{ '}}' }}|{{ gpu_operator_git_repo }}|' \
+       | sed 's|{{ '{{' }} gpu_operator_git_ref {{ '}}' }}|{{ gpu_operator_git_ref }}|' \
+       | sed 's|{{ '{{' }} gpu_operator_image_tag {{ '}}' }}|{{ gpu_operator_image_tag }}|' \
+       | oc apply -f-
+  args:
+    warn: false # don't warn about using sed here
+
+- name: wait for the operator image to be built
+  block:
+  - name: wait for the operator image to be built
+    shell: oc get pod --field-selector=status.phase=Succeeded,metadata.name=operator-image-builder-pod --no-headers -oname -n gpu-operator-ci | grep operator-image-builder-pod
+    register: wait_image_builder_pod
+    until: wait_image_builder_pod.rc != 1
+    retries: 40
+    delay: 30
+  rescue:
+  - name: get info about operator image build failure
+    command: oc get pods -n gpu-operator-ci
+    ignore_errors: true
+  - name: get logs of image build failure
+    command: oc get logs pod/operator-image-builder-pod
+    ignore_errors: true
+  - name: operator image failed to build
+    fail:
+      msg: operator image failed to build

--- a/roles/nv_gpu_install_from_commit/tasks/cleanup.yml
+++ b/roles/nv_gpu_install_from_commit/tasks/cleanup.yml
@@ -1,0 +1,18 @@
+- name: Remove custom node label for tune
+  block:
+    - name: find a node with our tuned label
+      shell: oc get nodes -l "{{ tuned_module_fuse_label }}" -oname | head -1
+      register: fuse_node
+    - name: remove our tuned label on the node
+      command: oc label "{{ fuse_node.stdout }}" "{{ tuned_module_fuse_label }}-"
+  rescue:
+    - debug:
+        msg: "No node with our tuned label"
+
+- name: delete tuned fuse profile # in the openshift-cluster-node-tuning-operator namespace
+  command: oc delete -f "{{ tuned_module_fuse }}"
+  ignore_errors: true
+
+- name: delete namespace and everything it contains
+  command: oc delete -f "{{ gpu_operator_namespace }}"
+  ignore_errors: true

--- a/roles/nv_gpu_install_from_commit/tasks/deploy.yml
+++ b/roles/nv_gpu_install_from_commit/tasks/deploy.yml
@@ -1,0 +1,11 @@
+- name: delete possible stalled GPU-operator resources from failed undeployment
+  shell: |
+    oc delete ServiceAccount/gpu-operator -n gpu-operator || true
+    oc delete ClusterRole/gpu-operator || true
+    oc delete ClusterRoleBinding/gpu-operator || true
+    oc delete ClusterPolicy cluster-policy || true
+    oc delete SecurityContextConstraints restricted-readonly || true
+    oc delete Namespace/gpu-operator-resources || true
+
+- name: deploy the custom version of the GPU operator
+  command: bash roles/nv_gpu_install_from_commit/files/helm_deploy_operator.sh deploy "{{ gpu_operator_git_repo }}" "{{ gpu_operator_git_ref }}" "{{ gpu_operator_image_tag }}"

--- a/roles/nv_gpu_install_from_commit/tasks/main.yml
+++ b/roles/nv_gpu_install_from_commit/tasks/main.yml
@@ -1,4 +1,6 @@
 ---
+- name: Install GPU-operator from OperatorHub
+  include_tasks: roles/nv_gpu/tasks/install_nfd.yml
 
 - name: Build GPU-operator from custom commit
   import_tasks: roles/nv_gpu_install_from_commit/tasks/build.yml

--- a/roles/nv_gpu_install_from_commit/tasks/main.yml
+++ b/roles/nv_gpu_install_from_commit/tasks/main.yml
@@ -1,22 +1,28 @@
 ---
-- name: Install GPU-operator from OperatorHub
-  include_tasks: roles/nv_gpu/tasks/install_nfd.yml
+- block:
+  - name: Install NFD-operator from OperatorHub
+    include_role:
+      name: nv_gpu
+      tasks_from: install_nfd
+    when: install_nfd_operator_from_hub == "yes"
 
-- name: Build GPU-operator from custom commit
-  import_tasks: roles/nv_gpu_install_from_commit/tasks/build.yml
-- name: Deploy GPU-operator from custom commit with helm
-  import_tasks: roles/nv_gpu_install_from_commit/tasks/deploy.yml
+  - name: Build GPU-operator from custom commit
+    import_tasks: roles/nv_gpu_install_from_commit/tasks/build.yml
 
-# Ci block
-- name: Run CI and always undeploy
-  block:
+  - name: Deploy GPU-operator from custom commit with helm
+    import_tasks: roles/nv_gpu_install_from_commit/tasks/deploy.yml
+
   - include_tasks: roles/nv_gpu/tasks/ci_checks.yml
     register: test_ci
-  when: user_mode == 'ci'
+    when: user_mode == 'ci'
   rescue:
-    - name: Failed to run CI checks
-      fail:
-        msg: "FAILED {{ test_ci }}"
+  - name: Verbose Failure
+    include_role:
+      name: nv_gpu
+      tasks_from: verbose_failure
+  - name: Failing because of a previous error
+    fail:
+      msg: "Failing because of a previous error"
   always:
     - name: Undeploy GPU-operator from custom commit with helm
       import_tasks: roles/nv_gpu_install_from_commit/tasks/undeploy.yml

--- a/roles/nv_gpu_install_from_commit/tasks/main.yml
+++ b/roles/nv_gpu_install_from_commit/tasks/main.yml
@@ -18,6 +18,8 @@
   always:
     - name: Undeploy GPU-operator from custom commit with helm
       import_tasks: roles/nv_gpu_install_from_commit/tasks/undeploy.yml
+      when: undeploy_gpu_operator == 'yes'
 
 - name: Cleanup custom commit resources
   import_tasks: roles/nv_gpu_install_from_commit/tasks/cleanup.yml
+  when: undeploy_gpu_operator == 'yes'

--- a/roles/nv_gpu_install_from_commit/tasks/main.yml
+++ b/roles/nv_gpu_install_from_commit/tasks/main.yml
@@ -1,0 +1,23 @@
+---
+
+- name: Build GPU-operator from custom commit
+  import_tasks: roles/nv_gpu_install_from_commit/tasks/build.yml
+- name: Deploy GPU-operator from custom commit with helm
+  import_tasks: roles/nv_gpu_install_from_commit/tasks/deploy.yml
+
+# Ci block
+- name: Run CI and always undeploy
+  block:
+  - include_tasks: roles/nv_gpu/tasks/ci_checks.yml
+    register: test_ci
+  when: user_mode == 'ci'
+  rescue:
+    - name: Failed to run CI checks
+      fail:
+        msg: "FAILED {{ test_ci }}"
+  always:
+    - name: Undeploy GPU-operator from custom commit with helm
+      import_tasks: roles/nv_gpu_install_from_commit/tasks/undeploy.yml
+
+- name: Cleanup custom commit resources
+  import_tasks: roles/nv_gpu_install_from_commit/tasks/cleanup.yml

--- a/roles/nv_gpu_install_from_commit/tasks/undeploy.yml
+++ b/roles/nv_gpu_install_from_commit/tasks/undeploy.yml
@@ -1,0 +1,2 @@
+- name: undeploy the custom version of the GPU operator
+  command: bash roles/nv_gpu_install_from_commit/files/helm_deploy_operator.sh undeploy "{{ gpu_operator_git_repo }}" "{{ gpu_operator_git_ref }}" "{{ gpu_operator_image_tag }}"

--- a/roles/nv_gpu_install_from_commit/vars/main.yml
+++ b/roles/nv_gpu_install_from_commit/vars/main.yml
@@ -1,0 +1,12 @@
+---
+# Manifest for installing NV GPU operator from a custom commit
+tuned_module_fuse: roles/nv_gpu_install_from_commit/files/tuned_module_fuse.yaml
+tuned_module_fuse_label: tuned.module.fuse
+gpu_operator_ci_utils: roles/nv_gpu_install_from_commit/files/operator_ci_utils.yaml
+gpu_operator_namespace: roles/nv_gpu_install_from_commit/files/operator_namespace.yaml
+gpu_operator_imagestream: roles/nv_gpu_install_from_commit/files/operator_imagestream.yaml
+gpu_operator_image_builder_script: roles/nv_gpu_install_from_commit/files/operator_image_builder_script.yaml
+gpu_operator_helper_image_builder: roles/nv_gpu_install_from_commit/files/operator_helper_image_builder.yaml
+gpu_operator_image_builder_pod: roles/nv_gpu_install_from_commit/files/operator_image_builder_pod.yaml
+gpu_operator_helm_install: roles/nv_gpu_install_from_commit/files/helm_deploy_operator.sh
+gpu_operator_image_tag: "gpu-operator-{{ gpu_operator_image_tag_uid }}"

--- a/roles/openshift_node/tasks/main.yml
+++ b/roles/openshift_node/tasks/main.yml
@@ -1,3 +1,7 @@
 ---
-- include_tasks: roles/openshift_node/tasks/scaleup_checks.yml 
-- include_tasks: roles/openshift_node/tasks/create_machine.yml
+- name: Scale-up checks
+  import_tasks: roles/openshift_node/tasks/scaleup_checks.yml
+  when: aws_add_gpu_node == "yes"
+- name: Create machine
+  import_tasks: roles/openshift_node/tasks/create_machine.yml
+  when: aws_add_gpu_node == "yes"


### PR DESCRIPTION
This PR adds the ability to run non-regression testing on a particular GPU-operator commit.

This allows testing the PR by running this command:
```./build/root/usr/local/bin/run gpu-commit-ci https://gitlab.com/kpouget_psap/gpu-operator.git devel```
with a pre-configured cluster:

```
PLAY RECAP *************************************************************************************************
localhost                  : ok=31   changed=28   unreachable=0    failed=0    skipped=4    rescued=0    ignored=0

Thursday 17 December 2020  15:59:59 +0100 (0:00:38.643)       0:10:29.618 *****
===============================================================================
nv_gpu_install_from_commit : wait for the operator image to be built ------------------------------ 339.05s
nv_gpu_install_from_commit : cuda vector add validation status ------------------------------------ 158.44s
nv_gpu_install_from_commit : delete namespace and everything it contains --------------------------- 38.64s
nv_gpu_install_from_commit : deploy the custom version of the GPU operator ------------------------- 32.58s
nv_gpu_install_from_commit : delete possible stalled GPU-operator resources from failed undeployment -- 12.19s
nv_gpu_install_from_commit : undeploy the custom version of the GPU operator ------------------------ 9.07s
nv_gpu_install_from_commit : apply operator image builder pod manifest ------------------------------ 3.89s
nv_gpu_install_from_commit : apply namespace manifest ----------------------------------------------- 3.64s
nv_gpu_install_from_commit : apply ci utils manifest ------------------------------------------------ 3.42s
nv_gpu_install_from_commit : apply image helper builder manifest ------------------------------------ 2.71s
nv_gpu_install_from_commit : apply imagestream manifest --------------------------------------------- 2.66s
nv_gpu_install_from_commit : apply operator image builder script manifest --------------------------- 2.40s
nv_gpu_install_from_commit : wait for the helper image to be built ---------------------------------- 2.02s
nv_gpu_install_from_commit : apply tuned fuse profile manifest -------------------------------------- 1.87s
nv_gpu_install_from_commit : delete tuned fuse profile ---------------------------------------------- 1.64s
nv_gpu_install_from_commit : find a node with our tuned label --------------------------------------- 1.54s
nv_gpu_install_from_commit : delete operator image builder pod, if any ------------------------------ 1.50s
nv_gpu_install_from_commit : remove our tuned label on the node ------------------------------------- 1.45s
check_deps : Get oc user ---------------------------------------------------------------------------- 1.36s
```
