### PR TITLE
build/root/usr/local/bin/entrypoint: make sure that USER is always set

### DIFF
--- a/build/root/usr/local/bin/entrypoint
+++ b/build/root/usr/local/bin/entrypoint
@@ -7,8 +7,11 @@
 # The current user's entry must be correctly defined in this file in order for
 # the `ssh` command to work within the created container.
 
+USER=${USER:-default}
+export USER
+
 if ! whoami &>/dev/null; then
-  echo "${USER:-default}:x:$(id -u):$(id -g):Default User:$HOME:/sbin/nologin" >> /etc/passwd
+  echo "${USER}:x:$(id -u):$(id -g):Default User:$HOME:/sbin/nologin" >> /etc/passwd
 fi
 
 exec "$@"


### PR DESCRIPTION
Trying to fix [this issue](https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-psap-ci-artifacts-master-gpu-operator-e2e/1348419454828023808) in the CI:

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/ansible/executor/task_executor.py", line 147, in run
    res = self._execute()
  File "/usr/local/lib/python3.6/site-packages/ansible/executor/task_executor.py", line 620, in _execute
    self._connection = self._get_connection(cvars, templar)
  File "/usr/local/lib/python3.6/site-packages/ansible/executor/task_executor.py", line 909, in _get_connection
    ansible_playbook_pid=to_text(os.getppid())
  File "/usr/local/lib/python3.6/site-packages/ansible/plugins/loader.py", line 573, in get
    obj = obj(*args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/ansible/plugins/connection/local.py", line 47, in __init__
    self.default_user = getpass.getuser()
  File "/usr/lib64/python3.6/getpass.py", line 169, in getuser
    return pwd.getpwuid(os.getuid())[0]
KeyError: 'getpwuid(): uid not found: 1279020000'
fatal: [localhost]: FAILED! => {
    "msg": "Unexpected failure during module execution.",
    "stdout": ""
}
```

which is caused by this code block:

```
    for name in ('LOGNAME', 'USER', 'LNAME', 'USERNAME'):
        user = os.environ.get(name)
        if user:
            return user    # If this fails, the exception will "explain" why
    import pwd
    return pwd.gpwd.getpwuid(os.getuid())[0]etpwuid(os.getuid())[0]
```