### PR TITLE
Run CI on local cluster

### DIFF
--- a/build/root/usr/local/bin/run
+++ b/build/root/usr/local/bin/run
@@ -83,6 +83,7 @@ fi
 [[ "${INSIDE_CI_IMAGE:-}" == "y" ]] && set -x
 
 ANSIBLE_OPTS=${ANSIBLE_OPTS:--v}
+ANSIBLE_OPTS="${ANSIBLE_OPTS} ${EXTRA_ANSIBLE_OPTS:-}"
 
 INVENTORY_ARG="-i inventory/hosts"
 

--- a/playbooks/build-psap-ci.yml
+++ b/playbooks/build-psap-ci.yml
@@ -1,0 +1,10 @@
+---
+# Build and run the CI on OpenShift
+- name: Build CI image
+  hosts: localhost
+  connection: local
+  gather_facts: true
+  vars:
+    kubeconfig: "{{ ansible_env.KUBECONFIG }}"
+  roles:
+    - role: build_ci_image

--- a/playbooks/deploy-gpu-operator-from-commit.yml
+++ b/playbooks/deploy-gpu-operator-from-commit.yml
@@ -3,7 +3,5 @@
   hosts: localhost
   connection: local
   gather_facts: true
-  vars:
-    kubeconfig: "{{ ansible_env.KUBECONFIG }}"
   roles:
     - role: nv_gpu_install_from_commit

--- a/playbooks/deploy-gpu-operator-from-operatorhub.yml
+++ b/playbooks/deploy-gpu-operator-from-operatorhub.yml
@@ -2,7 +2,5 @@
   hosts: localhost
   connection: local
   gather_facts: true
-  vars:
-    kubeconfig: "{{ ansible_env.KUBECONFIG }}"
   roles:
     - role: nv_gpu

--- a/playbooks/gpu-burst.yml
+++ b/playbooks/gpu-burst.yml
@@ -3,7 +3,5 @@
   hosts: localhost
   connection: local
   gather_facts: true
-  vars:
-    kubeconfig: "{{ ansible_env.KUBECONFIG }}"
   roles:
     - openshift_node

--- a/playbooks/nvidia-gpu-operator-ci.yml
+++ b/playbooks/nvidia-gpu-operator-ci.yml
@@ -4,8 +4,6 @@
   hosts: localhost
   connection: local
   gather_facts: true
-  vars:
-    kubeconfig: "{{ ansible_env.KUBECONFIG }}"
   roles:
     - openshift_node
 # Install and test GPU Operator
@@ -13,7 +11,5 @@
   hosts: localhost
   connection: local
   gather_facts: true
-  vars:
-    kubeconfig: "{{ ansible_env.KUBECONFIG }}"
   roles:
     - role: nv_gpu

--- a/playbooks/nvidia-gpu-operator-commit-ci.yml
+++ b/playbooks/nvidia-gpu-operator-commit-ci.yml
@@ -3,8 +3,6 @@
   hosts: localhost
   connection: local
   gather_facts: true
-  vars:
-    kubeconfig: "{{ ansible_env.KUBECONFIG }}"
   roles:
     - openshift_node
 # Install and test GPU Operator from a custom commit
@@ -12,7 +10,5 @@
   hosts: localhost
   connection: local
   gather_facts: false
-  vars:
-    kubeconfig: "{{ ansible_env.KUBECONFIG }}"
   roles:
     - role: nv_gpu_install_from_commit

--- a/playbooks/openshift-odh-ci.yml
+++ b/playbooks/openshift-odh-ci.yml
@@ -4,8 +4,6 @@
   hosts: localhost
   connection: local
   gather_facts: true
-  vars:
-    kubeconfig: "{{ ansible_env.KUBECONFIG }}"
   roles:
     - role: openshift_odh
       when: test_odh == "yes"

--- a/playbooks/openshift-psap-ci.yml
+++ b/playbooks/openshift-psap-ci.yml
@@ -4,8 +4,6 @@
   hosts: localhost
   connection: local
   gather_facts: true
-  vars:
-    kubeconfig: "{{ ansible_env.KUBECONFIG }}"
   roles:
     - role: openshift_nfd
       when: test_nfd == "yes"
@@ -15,8 +13,6 @@
   hosts: localhost
   connection: local
   gather_facts: true
-  vars:
-    kubeconfig: "{{ ansible_env.KUBECONFIG }}"
   roles:
     - role: openshift_sro
       when: test_sro == "yes"

--- a/playbooks/scaleup-gpu-node.yml
+++ b/playbooks/scaleup-gpu-node.yml
@@ -4,7 +4,5 @@
   hosts: localhost
   connection: local
   gather_facts: true
-  vars:
-    kubeconfig: "{{ ansible_env.KUBECONFIG }}"
   roles:
     - openshift_node

--- a/roles/build_ci_image/files/execution_pod.yml
+++ b/roles/build_ci_image/files/execution_pod.yml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: ci-artifacts
+  name: ci-artifacts
+  namespace: ci-artifacts
+spec:
+  containers:
+  - name: ci-artifacts
+    command:
+    - /bin/bash
+    - -xc
+    - "{{ local_ci_command }}"
+    image: "image-registry.openshift-image-registry.svc:5000/ci-artifacts/ci-artifacts:{{ local_ci_image_tag }}" # set by `build.yaml` ansible script
+    imagePullPolicy: Always
+    env:
+    - name: EXTRA_ANSIBLE_OPTS
+      value: -e use_aws=no
+    - name: KUBECONFIG
+      value: /etc/kubeconfig/kubeconfig
+    volumeMounts:
+    - mountPath: /etc/kubeconfig
+      name: kubeconfig-secret
+      readOnly: true
+  restartPolicy: Never
+  volumes:
+  - name: kubeconfig-secret
+    secret:
+      secretName: kubeconfig-secret

--- a/roles/build_ci_image/files/helm_deploy_operator.sh
+++ b/roles/build_ci_image/files/helm_deploy_operator.sh
@@ -1,0 +1,98 @@
+#! /bin/bash
+
+set -Eeuo pipefail
+
+set -x
+if [ "$#" -gt 4 ]; then
+    echo "Usage: $0 deploy|undeploy <gpu_operator_git_repo> <gpu_operator_git_ref> <gpu_operator_image_tag>"
+    exit 1
+fi
+
+action="$1"
+OPERATOR_GIT_REPO="$2"
+OPERATOR_GIT_REF="$3"
+OPERATOR_IMAGE_TAG="$4"
+
+OPERATOR_NAME="gpu-operator-from-source"
+OPERATOR_NAMESPACE="gpu-operator-ci"
+HELM_SOURCE="./deployments/gpu-operator"
+
+# https://stackoverflow.com/a/21189044/341106
+function parse_yaml {
+   local prefix=$2
+   local s='[[:space:]]*' w='[a-zA-Z0-9_]*' fs=$(echo @|tr @ '\034')
+   sed -ne "s|^\($s\):|\1|" \
+        -e "s|^\($s\)\($w\)$s:$s[\"']\(.*\)[\"']$s\$|\1$fs\2$fs\3|p" \
+        -e "s|^\($s\)\($w\)$s:$s\(.*\)$s\$|\1$fs\2$fs\3|p"  $1 |
+   awk -F$fs '{
+      indent = length($1)/2;
+      vname[indent] = $2;
+      for (i in vname) {if (i > indent) {delete vname[i]}}
+      if (length($3) > 0) {
+         vn=""; for (i=0; i<indent; i++) {vn=(vn)(vname[i])("_")}
+         printf("%s%s%s=\"%s\"\n", "'$prefix'",vn, $2, $3);
+      }
+   }'
+}
+
+deploy() {
+    cd /tmp
+    rm -rf gpu-operator
+    git clone $OPERATOR_GIT_REPO -b $OPERATOR_GIT_REF --depth 1 gpu-operator
+
+    cd gpu-operator
+
+    set +x
+    declare -A HELM_values
+    while read line; do
+        key=$(echo $line | cut -d= -f1)
+        value=$(echo $line | cut -d= -f2 | sed 's/^"//' | sed 's/"$//')
+        HELM_values[$key]=$value
+    done <<< $(parse_yaml deployments/gpu-operator/values.yaml "")
+    set -x
+
+    SKIP_BROKEN_UBI8_DEVICE_PLUGIN=1
+    if [ $SKIP_BROKEN_UBI8_DEVICE_PLUGIN == 1 ]; then
+        echo "Using default (ubuntu) device plugin image"
+        device_plugin_version=${HELM_values[devicePlugin_version]}
+    else
+        echo "Using ubi8 (maybe broken) device plugin image"
+        device_plugin_version=${HELM_values[devicePlugin_version]/-ubuntu*/}-ubi8
+    fi
+
+    helm uninstall --namespace $OPERATOR_NAMESPACE $OPERATOR_NAME || true
+    #helm template --debug # <-- this is for debugging helm install
+    exec helm install \
+     $OPERATOR_NAME $HELM_SOURCE \
+     --devel \
+     \
+     --set operator.repository=image-registry.openshift-image-registry.svc:5000/gpu-operator-ci \
+     --set operator.image=gpu-operator-ci \
+     --set operator.version=${OPERATOR_IMAGE_TAG} \
+     \
+     --set platform.openshift=true \
+     --set operator.defaultRuntime=crio \
+     --set nfd.enabled=false \
+     \
+     --set toolkit.version=${HELM_values[toolkit_version]/-ubuntu*/}-ubi8 \
+     --set devicePlugin.version=${device_plugin_version} \
+     --set dcgmExporter.version=${HELM_values[dcgmExporter_version]/-ubuntu*/}-ubi8 \
+     \
+     --namespace $OPERATOR_NAMESPACE \
+     --wait
+}
+
+undeploy() {
+    exec helm uninstall --namespace $OPERATOR_NAMESPACE $OPERATOR_NAME
+}
+
+if [ "$action" == deploy ];
+then
+    deploy
+elif [ "$action" == undeploy ];
+then
+    undeploy
+else
+    echo "Unknown action command '$action' ..."
+    exit 1
+fi

--- a/roles/build_ci_image/files/image_builder.yml
+++ b/roles/build_ci_image/files/image_builder.yml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: BuildConfig
+metadata:
+  labels:
+    app: ci-artifacts
+  name: image-builder
+  namespace: ci-artifacts
+spec:
+  output:
+    to:
+      kind: ImageStreamTag
+      name: ci-artifacts:{{ local_ci_image_tag }}
+      namespace: ci-artifacts
+  resources: {}
+  source:
+    type: Git
+    git:
+      uri: "{{ local_ci_git_repo }}" # set by `build.yaml` ansible script
+      ref: "{{ local_ci_git_ref }}" # set by `build.yaml` ansible script
+    contextDir: ./
+  triggers:
+  - type: "ConfigChange"
+  strategy:
+    type: Docker
+    dockerStrategy:
+      dockerfilePath: build/Dockerfile
+      from:
+        kind: DockerImage
+        name: registry.access.redhat.com/ubi8/ubi

--- a/roles/build_ci_image/files/imagestream.yml
+++ b/roles/build_ci_image/files/imagestream.yml
@@ -1,0 +1,8 @@
+kind: ImageStream
+apiVersion: v1
+metadata:
+  name: ci-artifacts
+  namespace: ci-artifacts
+  labels:
+    app: ci-artifacts
+spec: {}

--- a/roles/build_ci_image/files/namespace.yml
+++ b/roles/build_ci_image/files/namespace.yml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ci-artifacts
+  labels:
+    app: ci-artifacts

--- a/roles/build_ci_image/files/operator_ci_utils.yml
+++ b/roles/build_ci_image/files/operator_ci_utils.yml
@@ -1,0 +1,16 @@
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: gpu-operator-ci-utils
+  labels:
+    app: gpu-operator-ci
+spec: {}
+---
+kind: ImageStream
+apiVersion: v1
+metadata:
+  name: gpu-operator-ci-utils
+  namespace: gpu-operator-ci-utils
+  labels:
+    app: gpu-operator-ci
+spec: {}

--- a/roles/build_ci_image/files/operator_ci_utils_namespace.yml
+++ b/roles/build_ci_image/files/operator_ci_utils_namespace.yml
@@ -1,0 +1,7 @@
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: gpu-operator-ci-utils
+  labels:
+    app: gpu-operator-ci
+spec: {}

--- a/roles/build_ci_image/files/operator_helper_image_builder.yml
+++ b/roles/build_ci_image/files/operator_helper_image_builder.yml
@@ -1,0 +1,60 @@
+apiVersion: build.openshift.io/v1
+kind: BuildConfig
+metadata:
+  labels:
+    app: gpu-operator-ci
+  name: helper-image-builder
+  namespace: gpu-operator-ci-utils
+spec:
+  output:
+    to:
+      kind: ImageStreamTag
+      name: gpu-operator-ci-utils:builder_helper
+      namespace: gpu-operator-ci-utils
+  source:
+    type: Dockerfile
+    dockerfile: |
+      # stable/Dockerfile
+      #
+      # https://developers.redhat.com/blog/2019/08/14/best-practices-for-running-buildah-in-a-container/
+      #
+      # Build a Buildah container image from the latest
+      # stable version of Buildah on the Fedoras Updates System.
+      # https://bodhi.fedoraproject.org/updates/?search=buildah
+      # This image can be used to create a secured container
+      # that runs safely with privileges within the container.
+      #
+      # --> adapted to use podman instead of buildah
+      FROM quay.io/fedora/fedora:32-x86_64
+
+      # Don't include container-selinux and remove
+      # directories used by dnf that are just taking
+      # up space.
+      RUN yum -y install podman fuse-overlayfs; rm -rf /var/cache /var/log/dnf* /var/log/yum.*
+
+      # Adjust storage.conf to enable Fuse storage.
+      RUN sed -i 's|# Storage options to be passed to underlying storage drivers|# Storage options to be passed to underlying storage drivers\nmount_program = "/usr/bin/fuse-overlayfs"|' /etc/containers/storage.conf
+
+      RUN sed -i 's|additionalimagestores = \[|additionalimagestores = \[\n  "/var/lib/shared"|' /etc/containers/storage.conf
+
+      RUN [ -c /dev/fuse ] || mknod /dev/fuse c 10 229
+
+      RUN mkdir -p /var/lib/shared/overlay-images /var/lib/shared/overlay-layers; touch /var/lib/shared/overlay-images/images.lock; touch /var/lib/shared/overlay-layers/layers.lock
+
+      # Set up environment variables to note that this is
+      # not starting with user namespace and default to
+      # isolate the filesystem with chroot.
+      ENV _BUILDAH_STARTED_IN_USERNS="" BUILDAH_ISOLATION=chroot
+
+      # GPU-operator-CI specific
+
+      RUN yum -y install git make
+
+  strategy:
+    dockerStrategy:
+      from:
+        kind: DockerImage
+        name: quay.io/fedora/fedora:32-x86_64
+    type: Docker
+  triggers:
+  - type: ConfigChange

--- a/roles/build_ci_image/files/operator_image_builder_script.yml
+++ b/roles/build_ci_image/files/operator_image_builder_script.yml
@@ -1,0 +1,38 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: gpu-operator-ci
+  name: operator-image-builder-script
+  namespace: gpu-operator-ci
+data:
+  run_operator_image_builder.sh: |
+    #! /bin/bash
+    set -ex
+
+    IMAGE_STREAM=image-registry.openshift-image-registry.svc:5000/${IMAGESTREAM_NAME}:${IMAGESTREAM_TAG}
+
+    mkdir /work && cd /work
+
+    git clone ${OPERATOR_GIT_REPO} gpu-operator -b ${OPERATOR_GIT_REF} --depth 1
+
+    cd gpu-operator
+
+    if [ ! -z "${BUILDER_FROM_IMAGE}" ]; then
+      sed "s|FROM golang:1.13|FROM ${BUILDER_FROM_IMAGE}|" -i ./docker/Dockerfile.ubi8.prod
+    fi
+
+    # avoid docker.io quotas ...
+    sed -i 's|FROM nvidia/cuda:|FROM nvcr.io/nvidia/cuda:|' ./docker/Dockerfile.ubi8.prod
+
+    make DOCKER="podman --cgroup-manager=cgroupfs" prod-image
+
+    # push the image locally
+
+    AUTH="--tls-verify=false --authfile /tmp/.dockercfg"
+    cp /var/run/secrets/openshift.io/push/.dockercfg /tmp
+    (echo "{ \"auths\": " ; cat /var/run/secrets/openshift.io/push/.dockercfg ; echo "}") > /tmp/.dockercfg
+
+    podman push $AUTH nvidia/gpu-operator:latest $IMAGE_STREAM
+
+    echo "GPU-operator from $OPERATOR_GIT_REPO / $OPERATOR_GIT_REF pushed to $IMAGE_STREAM"

--- a/roles/build_ci_image/files/tuned_module_fuse.yml
+++ b/roles/build_ci_image/files/tuned_module_fuse.yml
@@ -1,0 +1,20 @@
+# oc label node/$NODE_NAME tuned.module.fuse=
+apiVersion: tuned.openshift.io/v1
+kind: Tuned
+metadata:
+  name: tuned-module-fuse
+  namespace: openshift-cluster-node-tuning-operator
+spec:
+  profile:
+  - data: |
+      [main]
+      summary=An OpenShift profile to load 'fuse' module
+      include=openshift-node
+      [modules]
+      fuse=+r
+    name: openshift-fuse
+  recommend:
+  - match:
+    - label: tuned.module.fuse
+    profile: "openshift-fuse"
+    priority: 5

--- a/roles/build_ci_image/meta/main.yml
+++ b/roles/build_ci_image/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - role: check_deps

--- a/roles/build_ci_image/tasks/build.yml
+++ b/roles/build_ci_image/tasks/build.yml
@@ -1,0 +1,53 @@
+---
+- name: ensure that LOCAL_CI_COMMAND is set
+  shell:
+    echo "{{ local_ci_command }}";
+    test ! -z "{{ local_ci_command }}"
+
+- name: apply namespace manifest
+  command: oc apply -f "{{ local_ci_namespace }}"
+
+- name: apply imagestream manifest
+  command: oc apply -f "{{ local_ci_imagestream }}"
+
+- name: delete kubeconfig secret
+  shell: oc delete secret -n ci-artifacts kubeconfig-secret || true
+
+- name: create kubeconfig secret
+  shell: oc create secret -n ci-artifacts generic kubeconfig-secret --from-file $KUBECONFIG
+
+- name: prepare CI Image
+  block:
+  - name: search if the image exists
+    command: oc get imagestreamtag -n ci-artifacts "ci-artifacts:{{ local_ci_image_tag }}" -oname
+  rescue:
+  - name: delete any old image builder manifest
+    shell: oc delete -f "{{ local_ci_image_builder }}" || true
+
+  - name: apply ci artifacts image builder manifest
+    shell: cat "{{ local_ci_image_builder }}" \
+       | sed 's|{{ '{{' }} local_ci_git_repo {{ '}}' }}|{{ local_ci_git_repo }}|' \
+       | sed 's|{{ '{{' }} local_ci_git_ref {{ '}}' }}|{{ local_ci_git_ref }}|' \
+       | sed 's|{{ '{{' }} local_ci_image_tag {{ '}}' }}|{{ local_ci_image_tag }}|' \
+       | oc apply -f-
+    args:
+      warn: false # don't warn about using sed here
+
+  - name: wait for the image to be built
+    shell: oc logs -f bc/image-builder -n ci-artifacts > /dev/null
+
+- name: ensure that the image exists
+  command: oc get imagestreamtag -n ci-artifacts "ci-artifacts:{{ local_ci_image_tag }}" -oname
+
+- name: delete any stalled CI execution Pod
+  shell: oc delete -f "{{ local_ci_execution_pod }}" || true
+
+- name: trigger the CI execution in a Pod
+  shell: cat "{{ local_ci_execution_pod }}" \
+       | sed 's|{{ '{{' }} local_ci_image_tag {{ '}}' }}|{{ local_ci_image_tag }}|' \
+       | sed 's|{{ '{{' }} local_ci_command {{ '}}' }}|{{ local_ci_command }}|' \
+       | oc apply -f-
+
+- name: Local CI execution launched.
+  debug:
+    msg: oc get pod/ci-artifacts -n ci-artifacts; oc logs -f pod/ci-artifacts -n ci-artifacts

--- a/roles/build_ci_image/tasks/cleanup.yml
+++ b/roles/build_ci_image/tasks/cleanup.yml
@@ -1,0 +1,4 @@
+---
+- name: delete namespace and everything it contains
+  command: oc delete -f "{{ local_ci_namespace }}"
+  ignore_errors: true

--- a/roles/build_ci_image/tasks/main.yml
+++ b/roles/build_ci_image/tasks/main.yml
@@ -1,0 +1,8 @@
+---
+- name: Build the CI image
+  import_tasks: roles/build_ci_image/tasks/build.yml
+  when: local_ci_deploy == "yes"
+
+- name: Cleanup the CI image
+  import_tasks: roles/build_ci_image/tasks/cleanup.yml
+  when: local_ci_cleanup == "yes"

--- a/roles/build_ci_image/vars/main.yml
+++ b/roles/build_ci_image/vars/main.yml
@@ -1,0 +1,14 @@
+---
+# Manifest for installing NV GPU operator from a custom commit
+local_ci_namespace: roles/build_ci_image/files/namespace.yml
+local_ci_imagestream: roles/build_ci_image/files/imagestream.yml
+local_ci_image_builder: roles/build_ci_image/files/image_builder.yml
+local_ci_execution_pod: roles/build_ci_image/files/execution_pod.yml
+
+local_ci_helm_install: roles/build_ci_image/files/helm_deploy_operator.sh
+local_ci_image_tag: "ci-artifacts-{{ local_ci_image_tag_uid }}"
+
+local_ci_command: "{{ lookup('env', 'LOCAL_CI_COMMAND') }}"
+
+local_ci_deploy: "yes"
+local_ci_cleanup: "no"

--- a/roles/check_deps/tasks/main.yml
+++ b/roles/check_deps/tasks/main.yml
@@ -2,15 +2,6 @@
 - name: Check for 'oc'
   command: >
     type -a oc
-  register: oc_cli
-  ignore_errors: true
-
-- name: If oc does not exist, check for 'kubectl'
-  command: >
-    type -a kubectl
-  register: kubectl_cli
-  ignore_errors: true
-  when: oc_cli is failed
 
 - name: Check for 'jq', needed for parsing and debugging oc outputs
   command: >
@@ -18,23 +9,24 @@
   register: jq_cli
   ignore_errors: true
 
+- name: Get the KUBECONFIG value
+  shell: echo $KUBECONFIG
+  register: kubeconfig_value
+
 - name: check if the kubeconfig file exists
   stat:
-    path: "{{ kubeconfig }}"
+    path: "{{ kubeconfig_value.stdout }}"
   register: kubeconfig_file
 
-- name: Kubeconfig file stat
+- name: Verify that KUBECONFIG file exists
   fail:
-    msg: "Kubeconfig not found at {{ kubeconfig }}"
+    msg: "Kubeconfig not found at {{ kubeconfig.stdout }}"
   when: kubeconfig_file.stat.exists != true
 
 - name: Get oc user
   command: >
-    oc whoami --kubeconfig={{ kubeconfig }}
-  register: oc_user
+    oc whoami
 
-- block:
-  - name: End play if user does not have oc or kubectl in PATH
-    debug:
-      msg: 'Could not find kubectl or oc CLI tools. Please update your PATH env variable or install kubectl/oc'
-  when: kubectl_cli is failed and oc_cli is failed
+- name: Get oc version
+  command: >
+    oc version

--- a/roles/openshift_node/tasks/scaleup_checks.yml
+++ b/roles/openshift_node/tasks/scaleup_checks.yml
@@ -2,7 +2,7 @@
 # This task file is run with import_role for localhost from gpu-burst.yml
 - name: Get cluster worker nodes
   command: >
-    bash -c "oc get nodes --kubeconfig '{{ kubeconfig }}' --output=name --selector='node-role.kubernetes.io/worker'"
+    bash -c "oc get nodes --output=name --selector='node-role.kubernetes.io/worker'"
   register: oc_get_workers
   until:
   - oc_get_workers.stdout != ''
@@ -11,7 +11,7 @@
 
 - name: Get worker machineset name
   command: >
-    bash -c "oc get machinesets -n openshift-machine-api --kubeconfig '{{ kubeconfig }}' |grep worker |awk '{ print $1 }'"
+    bash -c "oc get machinesets -n openshift-machine-api | grep worker |awk '{ print $1 }'"
   register: oc_get_machinesets
   until:
   - oc_get_machinesets.stdout != ''
@@ -20,7 +20,7 @@
 
 - name: Get worker machineset template
   command: >
-     bash -c "oc get machineset '{{ oc_get_machinesets.stdout_lines[0] }}' --kubeconfig '{{ kubeconfig }}' -n openshift-machine-api -o json"
+     bash -c "oc get machineset '{{ oc_get_machinesets.stdout_lines[0] }}' -n openshift-machine-api -o json"
   register: worker_machine_set
   until:
   - worker_machine_set != ''

--- a/toolbox/local-ci/cleanup.sh
+++ b/toolbox/local-ci/cleanup.sh
@@ -1,0 +1,9 @@
+#! /bin/bash -e
+
+THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+source ${THIS_DIR}/../_common.sh
+
+ANSIBLE_OPTS="${ANSIBLE_OPTS} -e local_ci_deploy=no"
+ANSIBLE_OPTS="${ANSIBLE_OPTS} -e local_ci_cleanup=yes"
+
+exec ansible-playbook ${INVENTORY_ARG} ${ANSIBLE_OPTS} playbooks/build-psap-ci.yml

--- a/toolbox/local-ci/deploy.sh
+++ b/toolbox/local-ci/deploy.sh
@@ -1,0 +1,35 @@
+#! /bin/bash -e
+
+THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+source ${THIS_DIR}/../_common.sh
+
+if [ "$#" -lt 2 ]; then
+    set +x
+    echo "Usage:   $0 <ci command> <git repository> <git reference> [gpu_operator_image_tag_uid]"
+    echo "Example: $0 'run gpu-ci' https://github.com/openshift-psap/ci-artifacts.git master"
+    exit 1
+fi
+
+ci_command=$1
+git_repo=$2
+git_ref=$3
+
+if [ "$#" -eq 4 ]; then
+    image_tag_uid=$4
+else
+    image_tag_uid=$(cat /proc/sys/kernel/random/uuid | cut -b-8)
+fi
+
+echo "Using Git repository ${git_repo} with ref ${git_ref} and tag_uid ${image_tag_uid}"
+echo "CI command to run: '$ci_command'"
+
+ANSIBLE_OPTS="${ANSIBLE_OPTS} -e local_ci_git_repo=${git_repo}"
+ANSIBLE_OPTS="${ANSIBLE_OPTS} -e local_ci_git_ref=${git_ref}"
+ANSIBLE_OPTS="${ANSIBLE_OPTS} -e local_ci_image_tag_uid=${image_tag_uid}"
+
+ANSIBLE_OPTS="${ANSIBLE_OPTS} -e local_ci_deploy=yes"
+ANSIBLE_OPTS="${ANSIBLE_OPTS} -e local_ci_undeploy=no"
+
+export LOCAL_CI_COMMAND="$ci_command"
+
+exec ansible-playbook ${INVENTORY_ARG} ${ANSIBLE_OPTS} playbooks/build-psap-ci.yml


### PR DESCRIPTION
This PR allows running a given commit of the `ci-artifact` repository on a local OpenShift cluster:

Example:
```
./build/root/usr/local/bin/run ci-builder https://github.com/openshift-psap/ci-artifacts.git master
```

I mark this PR as draft because the command to run on the CI pod is currently hardcoded in `roles/build_ci_image/files/execution_pod.yaml`:

```
spec:
  containers:
  - name: ci-artifacts
    command:
    - /bin/sh
    - -c
    - bash -x run gpu-commit-ci https://gitlab.com/kpouget_psap/gpu-operator devel
```

I would like to be able to pass `run gpu-commit-ci https://gitlab.com/kpouget_psap/gpu-operator devel` in the `run` command-line above, as `ANSIBLE_OPTS` or directly on the command-line.