### PR TITLE
roles/openshift_node: fix issue with GPU node scale-up

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -43,4 +43,4 @@ gpu_instance_type: "g4dn.xlarge"
 parse_machine_set: "roles/openshift_node/files/aws_machineset_json.sh"
 
 # GPU definition file, Cloud agnostic key=values
-gpu_machineset_deff: "gpu_machineset_definition.json"
+gpu_machineset_def: "gpu_machineset_definition.json"

--- a/roles/openshift_node/files/aws_machineset_json.sh
+++ b/roles/openshift_node/files/aws_machineset_json.sh
@@ -11,4 +11,5 @@ echo ${json_input} |jq --arg instance_type "${instance_type}" '.spec.template.sp
 	|jq --arg machinesetname "${machinesetname}" '.metadata.name = $machinesetname' \
 	|jq --arg machinesetname "${machinesetname}" '.spec.selector.matchLabels."machine.openshift.io/cluster-api-machineset" = $machinesetname' \
 	|jq -c --arg machinesetname "${machinesetname}" '.spec.template.metadata.labels."machine.openshift.io/cluster-api-machineset" = $machinesetname' \
-	|jq -c 'del(.status)|del(.metadata.selfLink)|del(.metadata.uid)'
+	|jq -c 'del(.status)|del(.metadata.selfLink)|del(.metadata.uid)' \
+	|jq '.spec.replicas = 1' 

--- a/roles/openshift_node/tasks/create_machine.yml
+++ b/roles/openshift_node/tasks/create_machine.yml
@@ -2,13 +2,17 @@
 # This task file is run with import_role for localhost from gpu-burst.yml
 
 - name: Create OpenShift object
-  command: >
-    bash -c "oc create -f '{{ gpu_machineset_deff }}' --kubeconfig '{{ kubeconfig }}'"
+  command: oc create -f '{{ gpu_machineset_def }}' --kubeconfig '{{ kubeconfig }}'
   register: oc_create_gpu
 
 - name: Check machine is provisioned
-  command: >
-    bash -c "oc get machines --kubeconfig '{{ kubeconfig }}' -n openshift-machine-api |grep '{{ gpu_instance_type }}' |awk '{ print $2 }'"
+  shell: |
+    oc get machines --kubeconfig '{{ kubeconfig }}' -n openshift-machine-api \
+      | grep '{{ gpu_instance_type }}' \
+      | awk '{ print $2 }' \
+      | grep Running \
+      | head -1
+
   register: gpu_machine_state
   until:
   - gpu_machine_state.stdout == 'Running'

--- a/roles/openshift_node/tasks/scaleup_checks.yml
+++ b/roles/openshift_node/tasks/scaleup_checks.yml
@@ -13,7 +13,7 @@
   command: >
     bash -c "oc get machinesets -n openshift-machine-api --kubeconfig '{{ kubeconfig }}' |grep worker |awk '{ print $1 }'"
   register: oc_get_machinesets
-  until: 
+  until:
   - oc_get_machinesets.stdout != ''
   retries: 30
   delay: 5
@@ -27,23 +27,23 @@
   retries: 30
   delay: 5
 
-- name: Save machineset json template    
-  copy: 
-    content: "{{ worker_machine_set.stdout }}" 
+- name: Save machineset json template
+  copy:
+    content: "{{ worker_machine_set.stdout }}"
     dest: "{{ ansible_env.PWD }}/{{ gpu_machineset_template }}"
-  delegate_to: localhost    
+  delegate_to: localhost
 
 - name: Generate GPU machine set file
   shell: >
-    {{ parse_machine_set | quote}} {{ gpu_machineset_template }} {{ gpu_instance_type }} 
+    {{ parse_machine_set | quote}} {{ gpu_machineset_template }} {{ gpu_instance_type }}
   register: gpu_machine_set_file
   until:
   - gpu_machine_set_file != ''
   retries: 30
   delay: 5
 
-- name: Save machineset definition file    
-  copy: 
-    content: "{{ gpu_machine_set_file.stdout }}" 
-    dest: "{{ ansible_env.PWD }}/{{ gpu_machineset_deff }}"
-  delegate_to: localhost    
+- name: Save machineset definition file
+  copy:
+    content: "{{ gpu_machine_set_file.stdout }}"
+    dest: "{{ ansible_env.PWD }}/{{ gpu_machineset_def }}"
+  delegate_to: localhost


### PR DESCRIPTION
The code was previously spinning up 2 replicas of GPU machines,
because the source machineset (the default worker one) had 2 replicas
by default.

The task in charge of checking the GPU node deployment was failing
because it was seeing 2x 'Running' while expecting only one.

Also fix 'deff' typo and remove trailing while spaces.