### PR TITLE
roles/nv_gpu/tasks/install.yml: give more delay for the GPU Operator CRD to be applied

### DIFF
--- a/roles/nv_gpu/tasks/install.yml
+++ b/roles/nv_gpu/tasks/install.yml
@@ -61,8 +61,8 @@
       command: oc apply -f "{{ gpu_operator_crd }}"
       register: test_clusterpolicy_cr
       until: test_clusterpolicy_cr.rc != 1
-      retries: 5
-      delay: 5
+      retries: 10
+      delay: 10
   rescue:
     - name: Failed when creating the clusterpolicy CR for the GPU Operator
       fail:


### PR DESCRIPTION
This should solve this error on the CI:

```
fatal: [localhost]: FAILED! => {
    "attempts": 5,
    "cmd": [
        "oc",
        "apply",
        "-f",
        "roles/nv_gpu/files/042_customresources.yaml"
    ],
    "msg": "non-zero return code",
    "stderr": "error: unable to recognize \"roles/nv_gpu/files/042_customresources.yaml\": no matches for kind \"ClusterPolicy\" in version \"nvidia.com/v1\"",
}

TASK [nv_gpu : Failed when creating the clusterpolicy CR for the GPU Operator] ***
```