### PR TITLE
Improve GPU-operator CI, switch to v1.5.1 and extend the toolbox

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -37,8 +37,10 @@ test_nfd: 'yes'
 test_sro: 'yes'
 test_odh: 'no'
 
-# Undeploy the GPU-operator from custom commit with helm
-undeploy_gpu_operator: 'yes'
+# Undeploy the GPU-operator
+# - from custom commit with helm (nv_gpu_install_from_commit role)
+# - from OperatorHub (nv_gpu_role)
+undeploy_gpu_operator: 'no'
 
 # json raw template from running workers
 gpu_machineset_template: "gpu_machineset_aws_template.json"

--- a/roles/nv_gpu/files/032_operator_sub.yml
+++ b/roles/nv_gpu/files/032_operator_sub.yml
@@ -9,4 +9,4 @@ spec:
   name: gpu-operator-certified
   source: certified-operators
   sourceNamespace: openshift-marketplace
-  startingCSV: gpu-operator-certified.v1.4.0
+  startingCSV: gpu-operator-certified.v1.5.1

--- a/roles/nv_gpu/files/042_customresources.yml
+++ b/roles/nv_gpu/files/042_customresources.yml
@@ -1,5 +1,5 @@
-# Operator version 1.4.0
-# Jan 18 2021
+# Operator version 1.5.1
+# Feb 05 2021
 apiVersion: nvidia.com/v1
 kind: ClusterPolicy
 metadata:
@@ -24,7 +24,7 @@ spec:
     podSecurityContext: {}
     repository: nvcr.io/nvidia
     securityContext: {}
-    version: 'sha256:45b459c59d13a1ebf37260a33c4498046d4ade7cc243f2ed71115cd81054cd85'
+    version: 'sha256:4762b5ba832e498b17d5736224bb90c2f538e593ceb7731cbd2506a80ab8a610'
     image: k8s-device-plugin
     tolerations: []
   driver:
@@ -49,7 +49,7 @@ spec:
     podSecurityContext: {}
     repository: nvcr.io/nvidia
     securityContext: {}
-    version: 'sha256:82e6f61b715d710c60ac14be78953336ea5dbc712244beb51036139d1cc8d526'
+    version: 'sha256:12959cb7dc6419cfb085d62d9801a0fb286b7d000c5efc4d7b4d8759f702dab0'
     image: gpu-feature-discovery
     tolerations: []
     migStrategy: none
@@ -70,6 +70,6 @@ spec:
     podSecurityContext: {}
     repository: nvcr.io/nvidia/k8s
     securityContext: {}
-    version: 'sha256:b3f48033d7d9e1d5703b6ecffe35d219a45a17bdcf85374d78924dee9c8917be'
+    version: 'sha256:cfc343ebe6ff4fcd85bace556923fd7fc0494c569f7d1276a6eceaca7a424ad4'
     image: container-toolkit
     tolerations: []

--- a/roles/nv_gpu/tasks/install_nfd.yml
+++ b/roles/nv_gpu/tasks/install_nfd.yml
@@ -2,27 +2,13 @@
   command: oc apply -f "{{ nfd_operator_namespace }}"
 
 - name: Create the OperatorGroup object
-  block:
-    - name: apply operatorGroup manifest
-      command: oc apply -f "{{ nfd_operator_operatorgroup }}"
-      register: test_operatorgroup
-  rescue:
-    - name: Failed when creating the OperatorGroup object for the NFD Operator
-      fail:
-        msg: "{{ test_operatorgroup }}"
+  command: oc apply -f "{{ nfd_operator_operatorgroup }}"
 
-- name: Create the OperatorHub subscription for the NFD Operator
-  block:
-    - name: "apply operatorhub subscription manifest (nfd_channel = {{ nfd_channel }})"
-      shell: sed 's|{{ '{{' }} nfd_channel {{ '}}' }}|{{ nfd_channel }}|' "{{ nfd_operator_operatorhub_sub }}" \
-           | oc apply -f-
-      register: nfd_operatorhub_sub
-      args:
-        warn: false # don't warn about using sed here
-  rescue:
-    - name: Failed when creating the test operatorHub subscription for the NFD Operator
-      fail:
-        msg: "{{ nfd_operatorhub_sub }}"
+- name: "Create the OperatorHub subscription for the NFD Operator (nfd_channel = {{ nfd_channel }})"
+  shell: sed 's|{{ '{{' }} nfd_channel {{ '}}' }}|{{ nfd_channel }}|' "{{ nfd_operator_operatorhub_sub }}" \
+       | oc apply -f-
+  args:
+    warn: false # don't warn about using sed here
 
 - name: Create the NodeFeatureDiscovery CR for the NFD Operator
   block:

--- a/roles/nv_gpu/tasks/install_nv.yml
+++ b/roles/nv_gpu/tasks/install_nv.yml
@@ -1,32 +1,12 @@
 - name: Create the namespace for the GPU Operator
-  block:
-    - name: apply namespace manifest
-      command: oc apply -f "{{ gpu_operator_namespace }}"
-      register: test_namespace
-  rescue:
-    - name: Failed when creating the test namespace for the GPU Operator
-      fail:
-        msg: "{{ test_namespace }}"
+  command: oc apply -f "{{ gpu_operator_namespace }}"
 
 - name: Create the OperatorHub subscription for the GPU Operator
-  block:
-    - name: apply operatorhub subscription manifest
-      command: oc apply -f "{{ gpu_operator_operatorhub_sub }}"
-      register: test_operatorhub_sub
-  rescue:
-    - name: Failed when creating the OperatorHub subscription for the GPU Operator
-      fail:
-        msg: "{{ test_operatorhub_sub }}"
+  command: oc apply -f "{{ gpu_operator_operatorhub_sub }}"
 
-- name: Create the clusterPolicy CR for the GPU Operator
-  block:
-    - name: apply clusterpolicy manifest
-      command: oc apply -f "{{ gpu_operator_crd }}"
-      register: test_clusterpolicy_cr
-      until: test_clusterpolicy_cr.rc != 1
-      retries: 20
-      delay: 15
-  rescue:
-    - name: Failed when creating the clusterpolicy CR for the GPU Operator
-      fail:
-        msg: "{{ test_clusterpolicy_cr }}"
+- name: Create the clusterPolicy CRD for the GPU Operator
+  command: oc apply -f "{{ gpu_operator_crd }}"
+  register: test_clusterpolicy_cr
+  until: test_clusterpolicy_cr.rc != 1
+  retries: 20
+  delay: 15

--- a/roles/nv_gpu/tasks/main.yml
+++ b/roles/nv_gpu/tasks/main.yml
@@ -15,3 +15,7 @@
   - name: Failing because of a previous error
     fail:
       msg: "Failing because of a previous error"
+
+- name: Uninstall GPU-operator from OperatorHub
+  include_tasks: uninstall_nv.yml
+  when: undeploy_gpu_operator == "yes"

--- a/roles/nv_gpu/tasks/uninstall_nv.yml
+++ b/roles/nv_gpu/tasks/uninstall_nv.yml
@@ -1,0 +1,23 @@
+---
+- name: Delete the OperatorHub subscription for the GPU Operator
+  command: oc delete -f "{{ gpu_operator_operatorhub_sub }}"
+  ignore_errors: true
+
+- name: Get the name of the GPU Operator ClusterServiceVersion
+  shell: oc get ClusterServiceVersion -n openshift-operators -oname | grep gpu-operator
+  register: operator_csv_name
+  ignore_errors: true
+
+- name: Delete the ClusterServiceVersion of the GPU Operator
+  with_items: "{{ operator_csv_name.stdout_lines }}"
+  shell: "oc delete {{ item }} -n openshift-operators"
+  #ignore_errors: true
+  when: operator_csv_name.rc == 0
+
+- name: Delete the clusterPolicy CRD of the GPU Operator
+  command: oc delete -f "{{ gpu_operator_crd }}"
+  ignore_errors: true
+
+- name: Delete the namespace of the GPU Operator
+  command: oc delete -f "{{ gpu_operator_namespace }}"
+  ignore_errors: true

--- a/roles/nv_gpu/tasks/verbose_failure.yml
+++ b/roles/nv_gpu/tasks/verbose_failure.yml
@@ -1,24 +1,31 @@
 - name: beginning of verbose failure (debug)
   debug:
     msg: "Beginning of verbose failure"
+
 - name: get gpu-operator-resources Pods (debug)
   ignore_errors: true
   command: oc get pods -n gpu-operator-resources -owide
+
 - name: get gpu-operator-resources DaemonSets (debug)
   ignore_errors: true
   command: oc get ds -n gpu-operator-resources
+
 - name: get driver-container logs (debug)
   ignore_errors: true
   command: oc logs ds/nvidia-driver-daemonset -n gpu-operator-resources
+
 - name: get GPU nodes (debug)
   ignore_errors: true
   command: oc get nodes -l nvidia.com/gpu.present=true
+
 - name: get all nodes (debug)
   ignore_errors: true
   command: oc get nodes
+
 - name: get all machines (debug)
   ignore_errors: true
   command: oc get machines -A
+
 - name: end of verbose failure (debug)
   debug:
     msg: "End of verbose failure"

--- a/toolbox/deploy_nfd_from_operatorhub.sh
+++ b/toolbox/deploy_nfd_from_operatorhub.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#! /bin/bash -e
 
 THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 source ${THIS_DIR}/_common.sh

--- a/toolbox/gpu-operator/deploy_from_commit.sh
+++ b/toolbox/gpu-operator/deploy_from_commit.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#! /bin/bash -e
 
 THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 source ${THIS_DIR}/../_common.sh

--- a/toolbox/gpu-operator/deploy_from_operatorhub.sh
+++ b/toolbox/gpu-operator/deploy_from_operatorhub.sh
@@ -5,6 +5,7 @@ source ${THIS_DIR}/_common.sh
 
 ANSIBLE_OPTS="${ANSIBLE_OPTS} -e install_nfd_operator_from_hub=no"
 ANSIBLE_OPTS="${ANSIBLE_OPTS} -e install_gpu_operator_from_hub=yes"
+ANSIBLE_OPTS="${ANSIBLE_OPTS} -e undeploy_gpu_operator=no"
 ANSIBLE_OPTS="${ANSIBLE_OPTS} -e user_mode=not-ci"
 
 exec ansible-playbook ${INVENTORY_ARG} ${ANSIBLE_OPTS} playbooks/deploy-gpu-operator-from-operatorhub.yml

--- a/toolbox/gpu-operator/deploy_from_operatorhub.sh
+++ b/toolbox/gpu-operator/deploy_from_operatorhub.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#! /bin/bash -e
 
 THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 source ${THIS_DIR}/../_common.sh

--- a/toolbox/gpu-operator/deploy_from_operatorhub.sh
+++ b/toolbox/gpu-operator/deploy_from_operatorhub.sh
@@ -1,7 +1,7 @@
 #! /bin/bash
 
 THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-source ${THIS_DIR}/_common.sh
+source ${THIS_DIR}/../_common.sh
 
 ANSIBLE_OPTS="${ANSIBLE_OPTS} -e install_nfd_operator_from_hub=no"
 ANSIBLE_OPTS="${ANSIBLE_OPTS} -e install_gpu_operator_from_hub=yes"

--- a/toolbox/gpu-operator/run_ci_checks.yml
+++ b/toolbox/gpu-operator/run_ci_checks.yml
@@ -1,4 +1,4 @@
-#! /bin/bash
+#! /bin/bash -e
 
 THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 source ${THIS_DIR}/../_common.sh

--- a/toolbox/gpu-operator/undeploy_from_commit.sh
+++ b/toolbox/gpu-operator/undeploy_from_commit.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#! /bin/bash -e
 
 THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 source ${THIS_DIR}/../_common.sh

--- a/toolbox/gpu-operator/undeploy_from_operatorhub.sh
+++ b/toolbox/gpu-operator/undeploy_from_operatorhub.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#! /bin/bash -e
 
 THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 source ${THIS_DIR}/../_common.sh

--- a/toolbox/gpu-operator/undeploy_from_operatorhub.sh
+++ b/toolbox/gpu-operator/undeploy_from_operatorhub.sh
@@ -1,0 +1,11 @@
+#! /bin/bash
+
+THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+source ${THIS_DIR}/../_common.sh
+
+ANSIBLE_OPTS="${ANSIBLE_OPTS} -e install_nfd_operator_from_hub=no"
+ANSIBLE_OPTS="${ANSIBLE_OPTS} -e install_gpu_operator_from_hub=no"
+ANSIBLE_OPTS="${ANSIBLE_OPTS} -e undeploy_gpu_operator=yes"
+ANSIBLE_OPTS="${ANSIBLE_OPTS} -e user_mode=not-ci"
+
+exec ansible-playbook ${INVENTORY_ARG} ${ANSIBLE_OPTS} playbooks/deploy-gpu-operator-from-operatorhub.yml

--- a/toolbox/scaleup_gpu_node.sh
+++ b/toolbox/scaleup_gpu_node.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#! /bin/bash -e
 
 THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 source ${THIS_DIR}/_common.sh


### PR DESCRIPTION
* 7ee0d4f - roles/nv_gpu/tasks/ci_checks.yml: capture the GPU-Operator image
* 77c645e - roles/nv_gpu: update GPU Operator OperatorHub deployment to v1.5.1
* 04878c6 - toolbox: use '#! /bin/bash -e' to catch errors before source '_common.sh'
* b83ca4d - toolbox/gpu-operator/deploy_from_operatorhub.sh: fix path to _common.sh
* ab1ab03 - toolbox: gpu-operator/undeploy_from_operatorhub.sh: new script
* fb4b504 - roles/nv_gpu/tasks/uninstall_nv.yml: new task book to undeploy after an OperatorHub deployment
* eef781f - group_vars/all.yml: undeploy_gpu_operator: default to 'no'
* 5239cd3 - roles/nv_gpu/tasks/verbose_failure.yml: make the file easier to read
* 526d64e - roles/nv_gpu/tasks/install_nfd.yml: remove unnecessary block/rescue
* 93bd254 - roles/nv_gpu/tasks/install_nv.yml: remove unnecessary block/rescue