### PR TITLE
Use container dev team Buildah Dockerfile

### DIFF
--- a/install_dir/.openshift_install.log
+++ b/install_dir/.openshift_install.log
@@ -1,0 +1,3 @@
+time="2021-01-27T20:01:29-05:00" level=debug msg="OpenShift Installer 4.6.15"
+time="2021-01-27T20:01:29-05:00" level=debug msg="Built from commit 26aab99447a65a1a3d46342318486bd1dd11b1e2"
+time="2021-01-27T20:01:29-05:00" level=fatal msg="Failed while preparing to destroy cluster: open install_dir/metadata.json: no such file or directory"

--- a/install_dir/.openshift_install.log
+++ b/install_dir/.openshift_install.log
@@ -1,3 +1,0 @@
-time="2021-01-27T20:01:29-05:00" level=debug msg="OpenShift Installer 4.6.15"
-time="2021-01-27T20:01:29-05:00" level=debug msg="Built from commit 26aab99447a65a1a3d46342318486bd1dd11b1e2"
-time="2021-01-27T20:01:29-05:00" level=fatal msg="Failed while preparing to destroy cluster: open install_dir/metadata.json: no such file or directory"

--- a/roles/nv_gpu_install_from_commit/files/operator_helper_image_builder.yml
+++ b/roles/nv_gpu_install_from_commit/files/operator_helper_image_builder.yml
@@ -34,38 +34,46 @@ spec:
       # to the container.
       # Finally remove the buildah directory and a few other packages
       # that are needed for building but not running Buildah
-      RUN useradd build; yum -y update; yum -y reinstall shadow-utils; yum -y install --enablerepo=updates-testing \
-           make \
-           golang \
-           bats \
-           btrfs-progs-devel \
-           device-mapper-devel \
-           glib2-devel \
-           gpgme-devel \
-           libassuan-devel \
-           libseccomp-devel \
-           git \
-           bzip2 \
-           xz \
-           go-md2man \
-           runc \
-           fuse-overlayfs \
-           fuse3 \
-           containers-common; \
-           mkdir /root/buildah; \
-           git clone https://github.com/containers/buildah /root/buildah/src/github.com/containers/buildah; \
-           cd /root/buildah/src/github.com/containers/buildah; \
-           make;\
-           make install;\
-           rm -rf /root/buildah/*; \
-           yum -y remove bats golang go-md2man; \
-           yum clean all;
+      RUN useradd build \
+          && yum -y update \
+          && yum -y reinstall shadow-utils \
+          && yum -y install --enablerepo=updates-testing \
+            make \
+            golang \
+            bats \
+            btrfs-progs-devel \
+            device-mapper-devel \
+            glib2-devel \
+            gpgme-devel \
+            libassuan-devel \
+            libseccomp-devel \
+            git \
+            bzip2 \
+            xz \
+            go-md2man \
+            runc \
+            fuse-overlayfs \
+            fuse3 \
+            containers-common \
+          && mkdir /root/buildah \
+          && git clone https://github.com/containers/buildah /root/buildah/src/github.com/containers/buildah \
+          && cd /root/buildah/src/github.com/containers/buildah \
+          && make \
+          && make install \
+          && rm -rf /root/buildah/* \
+          && yum -y remove bats golang go-md2man \
+          && yum clean all
       
       ADD https://raw.githubusercontent.com/containers/buildah/master/contrib/buildahimage/stable/containers.conf /etc/containers/
       
       # Adjust storage.conf to enable Fuse storage.
-      RUN chmod 644 /etc/containers/containers.conf; sed -i -e 's|^#mount_program|mount_program|g' -e '/additionalimage.*/a "/var/lib/shared",' -e 's|^mountopt[[:space:]]*=.*$|mountopt = "nodev,fsync=0"|g' /etc/containers/storage.conf
-      RUN mkdir -p /var/lib/shared/overlay-images /var/lib/shared/overlay-layers /var/lib/shared/vfs-images /var/lib/shared/vfs-layers; touch /var/lib/shared/overlay-images/images.lock; touch /var/lib/shared/overlay-layers/layers.lock; touch /var/lib/shared/vfs-images/images.lock; touch /var/lib/shared/vfs-layers/layers.lock
+      RUN chmod 644 /etc/containers/containers.conf \
+        && sed -i -e 's|^#mount_program|mount_program|g' -e '/additionalimage.*/a "/var/lib/shared",' -e 's|^mountopt[[:space:]]*=.*$|mountopt = "nodev,fsync=0"|g' /etc/containers/storage.conf
+      RUN mkdir -p /var/lib/shared/overlay-images /var/lib/shared/overlay-layers /var/lib/shared/vfs-images /var/lib/shared/vfs-layers \
+        && touch /var/lib/shared/overlay-images/images.lock \
+        && touch /var/lib/shared/overlay-layers/layers.lock \
+        && touch /var/lib/shared/vfs-images/images.lock \
+        && touch /var/lib/shared/vfs-layers/layers.lock
       
       # Set an environment variable to default to chroot isolation for RUN
       # instructions and "buildah run".

--- a/roles/nv_gpu_install_from_commit/files/operator_helper_image_builder.yml
+++ b/roles/nv_gpu_install_from_commit/files/operator_helper_image_builder.yml
@@ -14,47 +14,68 @@ spec:
   source:
     type: Dockerfile
     dockerfile: |
-      # stable/Dockerfile
-      #
-      # https://developers.redhat.com/blog/2019/08/14/best-practices-for-running-buildah-in-a-container/
+      # git/Dockerfile
+      # https://github.com/containers/buildah/blob/master/contrib/buildahimage/upstream/Dockerfile
       #
       # Build a Buildah container image from the latest
-      # stable version of Buildah on the Fedoras Updates System.
-      # https://bodhi.fedoraproject.org/updates/?search=buildah
+      # upstream version of Buildah on GitHub.
+      # https://github.com/containers/buildah
       # This image can be used to create a secured container
       # that runs safely with privileges within the container.
+      # The containers created by this image also come with a
+      # Buildah development environment in /root/buildah.
       #
-      # --> adapted to use podman instead of buildah
-      FROM quay.io/fedora/fedora:32-x86_64
-
-      # Don't include container-selinux and remove
-      # directories used by dnf that are just taking
-      # up space.
-      RUN yum -y install podman fuse-overlayfs; rm -rf /var/cache /var/log/dnf* /var/log/yum.*
-
+      FROM registry.fedoraproject.org/fedora:latest
+      ENV GOPATH=/root/buildah
+      
+      # Install the software required to build Buildah.
+      # Then create a directory and clone from the Buildah
+      # GitHub repository, make and install Buildah
+      # to the container.
+      # Finally remove the buildah directory and a few other packages
+      # that are needed for building but not running Buildah
+      RUN useradd build; yum -y update; yum -y reinstall shadow-utils; yum -y install --enablerepo=updates-testing \
+           make \
+           golang \
+           bats \
+           btrfs-progs-devel \
+           device-mapper-devel \
+           glib2-devel \
+           gpgme-devel \
+           libassuan-devel \
+           libseccomp-devel \
+           git \
+           bzip2 \
+           xz \
+           go-md2man \
+           runc \
+           fuse-overlayfs \
+           fuse3 \
+           containers-common; \
+           mkdir /root/buildah; \
+           git clone https://github.com/containers/buildah /root/buildah/src/github.com/containers/buildah; \
+           cd /root/buildah/src/github.com/containers/buildah; \
+           make;\
+           make install;\
+           rm -rf /root/buildah/*; \
+           yum -y remove bats golang go-md2man; \
+           yum clean all;
+      
+      ADD https://raw.githubusercontent.com/containers/buildah/master/contrib/buildahimage/stable/containers.conf /etc/containers/
+      
       # Adjust storage.conf to enable Fuse storage.
-      RUN sed -i 's|# Storage options to be passed to underlying storage drivers|# Storage options to be passed to underlying storage drivers\nmount_program = "/usr/bin/fuse-overlayfs"|' /etc/containers/storage.conf
-
-      RUN sed -i 's|additionalimagestores = \[|additionalimagestores = \[\n  "/var/lib/shared"|' /etc/containers/storage.conf
-
-      RUN [ -c /dev/fuse ] || mknod /dev/fuse c 10 229
-
-      RUN mkdir -p /var/lib/shared/overlay-images /var/lib/shared/overlay-layers; touch /var/lib/shared/overlay-images/images.lock; touch /var/lib/shared/overlay-layers/layers.lock
-
-      # Set up environment variables to note that this is
-      # not starting with user namespace and default to
-      # isolate the filesystem with chroot.
-      ENV _BUILDAH_STARTED_IN_USERNS="" BUILDAH_ISOLATION=chroot
-
-      # GPU-operator-CI specific
-
-      RUN yum -y install git make
+      RUN chmod 644 /etc/containers/containers.conf; sed -i -e 's|^#mount_program|mount_program|g' -e '/additionalimage.*/a "/var/lib/shared",' -e 's|^mountopt[[:space:]]*=.*$|mountopt = "nodev,fsync=0"|g' /etc/containers/storage.conf
+      RUN mkdir -p /var/lib/shared/overlay-images /var/lib/shared/overlay-layers /var/lib/shared/vfs-images /var/lib/shared/vfs-layers; touch /var/lib/shared/overlay-images/images.lock; touch /var/lib/shared/overlay-layers/layers.lock; touch /var/lib/shared/vfs-images/images.lock; touch /var/lib/shared/vfs-layers/layers.lock
+      
+      # Set an environment variable to default to chroot isolation for RUN
+      # instructions and "buildah run".
+      ENV BUILDAH_ISOLATION=chroot
 
   strategy:
     dockerStrategy:
       from:
         kind: DockerImage
-        name: quay.io/fedora/fedora:32-x86_64
+        name: registry.fedoraproject.org/fedora:latest
     type: Docker
   triggers:
   - type: ConfigChange

--- a/roles/nv_gpu_install_from_commit/files/operator_helper_image_builder.yml
+++ b/roles/nv_gpu_install_from_commit/files/operator_helper_image_builder.yml
@@ -40,6 +40,7 @@ spec:
           && yum -y install --enablerepo=updates-testing \
             make \
             golang \
+            podman \
             bats \
             btrfs-progs-devel \
             device-mapper-devel \

--- a/roles/nv_gpu_install_from_commit/tasks/build.yml
+++ b/roles/nv_gpu_install_from_commit/tasks/build.yml
@@ -112,7 +112,7 @@
       command: oc get pods -n gpu-operator-ci
       ignore_errors: true
     - name: get logs of image build failure
-      command: oc logs pod/operator-image-builder-pod
+      command: oc logs pod/operator-image-builder-pod -n gpu-operator-ci
       ignore_errors: true
     - name: operator image failed to build
       fail:


### PR DESCRIPTION
We are currently using a Dockerfile from a blog post from 2019, this
Dockerfile is the latest upstream version at
https://github.com/containers/buildah/blob/master/contrib/buildahimage/upstream/Dockerfile
maintained by the buildah dev team

Signed-off-by: Carlos Eduardo Arango Gutierrez <carangog@redhat.com>