### PR TITLE
Improve CI: store extra logs to artifacts directory

### DIFF
--- a/build/root/usr/local/bin/run
+++ b/build/root/usr/local/bin/run
@@ -69,6 +69,15 @@ if [[ "${INSIDE_CI_IMAGE:-}" == "y" ]]; then
 
     CI_IMAGE_GPU_COMMIT_CI_REPO="https://github.com/NVIDIA/gpu-operator/"
     CI_IMAGE_GPU_COMMIT_CI_REF="master"
+
+    if [ -z "${ARTIFACT_DIR:-}" ]; then
+        echo "No ARTIFACT_DIR configured."
+    else
+        ARTIFACT_EXTRA_LOGS_DIR="${ARTIFACT_DIR}/${1:-}/extra_logs"
+        ANSIBLE_OPTS="$ANSIBLE_OPTS -e artifact_extra_logs_dir=${ARTIFACT_EXTRA_LOGS_DIR}"
+        mkdir -p "${ARTIFACT_EXTRA_LOGS_DIR}"
+        echo "Using ${ARTIFACT_EXTRA_LOGS_DIR} for storing extra log files."
+    fi
 fi
 
 [[ "${INSIDE_CI_IMAGE:-}" == "y" ]] && set -x

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -54,3 +54,7 @@ parse_machine_set: "roles/openshift_node/files/aws_machineset_json.sh"
 
 # GPU definition file, Cloud agnostic key=values
 gpu_machineset_def: "gpu_machineset_definition.json"
+
+# directory where extra debugging logs are stored
+# if empty, extra logs are not stored
+artifact_extra_logs_dir: ""

--- a/roles/nv_gpu/tasks/ci_checks.yml
+++ b/roles/nv_gpu/tasks/ci_checks.yml
@@ -31,7 +31,9 @@
         delay: 30
       rescue:
       - name: GFD logs (debug)
-        command: oc logs ds/gpu-feature-discovery -n gpu-operator-resources
+        shell: "oc logs ds/gpu-feature-discovery -n gpu-operator-resources > {{ artifact_extra_logs_dir }}/gpu_gfd_logs"
+        ignore_errors: true
+        when: artifact_extra_logs_dir | default('', true) | trim != ''
 
     - block:
       - name: check that the nvidia-dcgm-exporter Pod is responding appropriately
@@ -61,20 +63,25 @@
         delay: 20
       rescue:
       - name: DCGM logs (debug)
-        command: oc logs ds/nvidia-dcgm-exporter -n gpu-operator-resources
+        shell: "oc logs ds/nvidia-dcgm-exporter -n gpu-operator-resources > {{ artifact_extra_logs_dir }}/gpu_dcgm_logs"
+        when: artifact_extra_logs_dir | default('', true) | trim != ''
         ignore_errors: true
       - fail:
           msg: Failed to get DCGM metrics
 
   always:
     - name: capture GPU Pods states
-      command: oc get pods -owide -n gpu-operator-resources
+      shell: "oc get pods -owide -n gpu-operator-resources > {{ artifact_extra_logs_dir }}/gpu_pods_list"
       ignore_errors: true
+      when: artifact_extra_logs_dir | default('', true) | trim != ''
     - name: capture Pod images
-      command:
+      shell:
         oc get pods -n gpu-operator-resources
                     -o=jsonpath='{range .items[*]}{"\n"}{.metadata.name}{":\t"}{range .spec.containers[*]}{.image}{", "}{end}{end}'
+                    > {{ artifact_extra_logs_dir }}/gpu_pods_image
       ignore_errors: true
+      when: artifact_extra_logs_dir | default('', true) | trim != ''
     - name: capture GPU Nodes states
-      command: oc describe node -lnvidia.com/gpu.present=true
+      shell: "oc describe node -lnvidia.com/gpu.present=true > {{ artifact_extra_logs_dir }}/gpu_nodes_description"
       ignore_errors: true
+      when: artifact_extra_logs_dir | default('', true) | trim != ''

--- a/roles/nv_gpu/tasks/ci_checks.yml
+++ b/roles/nv_gpu/tasks/ci_checks.yml
@@ -32,7 +32,6 @@
       rescue:
       - name: GFD logs (debug)
         command: oc logs ds/gpu-feature-discovery -n gpu-operator-resources
-        ignore_errors: true
 
     - block:
       - name: check that the nvidia-dcgm-exporter Pod is responding appropriately

--- a/roles/nv_gpu/tasks/verbose_failure.yml
+++ b/roles/nv_gpu/tasks/verbose_failure.yml
@@ -4,27 +4,33 @@
 
 - name: get gpu-operator-resources Pods (debug)
   ignore_errors: true
-  command: oc get pods -n gpu-operator-resources -owide
+  shell: "oc get pods -n gpu-operator-resources -owide > {{ artifact_extra_logs_dir }}/debug_gpu_pods_list"
+  when: artifact_extra_logs_dir | default('', true) | trim != ''
 
 - name: get gpu-operator-resources DaemonSets (debug)
   ignore_errors: true
-  command: oc get ds -n gpu-operator-resources
+  shell: "oc get ds -n gpu-operator-resources > {{ artifact_extra_logs_dir }}/debug_all_gpu_ds_list"
+  when: artifact_extra_logs_dir | default('', true) | trim != ''
 
 - name: get driver-container logs (debug)
   ignore_errors: true
-  command: oc logs ds/nvidia-driver-daemonset -n gpu-operator-resources
+  shell: "oc logs ds/nvidia-driver-daemonset -n gpu-operator-resources > {{ artifact_extra_logs_dir }}/debug_gpu_driver_logs"
+  when: artifact_extra_logs_dir | default('', true) | trim != ''
 
 - name: get GPU nodes (debug)
   ignore_errors: true
-  command: oc get nodes -l nvidia.com/gpu.present=true
+  shell: "oc get nodes -l nvidia.com/gpu.present=true > {{ artifact_extra_logs_dir }}/debug_all_gpu_nodes_list"
+  when: artifact_extra_logs_dir | default('', true) | trim != ''
 
 - name: get all nodes (debug)
   ignore_errors: true
-  command: oc get nodes
+  shell: "oc get nodes > {{ artifact_extra_logs_dir }}/debug_all_nodes_list"
+  when: artifact_extra_logs_dir | default('', true) | trim != ''
 
 - name: get all machines (debug)
   ignore_errors: true
-  command: oc get machines -A
+  shell: "oc get machines -A > {{ artifact_extra_logs_dir }}/debug_all_machines_list"
+  when: artifact_extra_logs_dir | default('', true) | trim != ''
 
 - name: end of verbose failure (debug)
   debug:


### PR DESCRIPTION
- efae8c0 removes the `ignore_errors` flag on the GFD flag, now that `master` and `1.5.2` are passing it successfully
- cfa402a removes extra debugging output logs from the main logs, and moves them to `/tmp/artifacts/`, and hopefully these files will be made available in the `artifacts` linked with the test execution