### PR TITLE
roles/check_deps/tasks/main.yml: simplify check_deps and compute openshift_release if not set

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -1,6 +1,6 @@
 # Which version/release of OpenShift? Include major version and major
-# release, no minor releases.
-openshift_release: '4.6'
+# release, no minor releases (computed from `oc version` if empty)
+openshift_release: ''
 
 # AWS deployment
 use_aws: 'yes'

--- a/roles/check_deps/tasks/main.yml
+++ b/roles/check_deps/tasks/main.yml
@@ -1,32 +1,20 @@
 ---
-- name: Check for 'oc'
-  command: >
-    type -a oc
+- name: Capture OpenShift version (debug)
+  command: oc version
 
-- name: Check for 'jq', needed for parsing and debugging oc outputs
-  command: >
-    type -a jq
-  register: jq_cli
-  ignore_errors: true
+- name: Fetch 'openshift_release' value and check dependencies
+  shell:
+    oc version -o json
+    | jq --raw-output '.openshiftVersion'
+    | cut -b-3
+  register: ocp_version
+  # Abort the play if anything goes wrong:
+  # - KUBECONFIG not valid
+  # - cannot join the server
+  # - oc or jq missing
+  failed_when: ocp_version.stdout == 'nul' or ocp_version.stdout == ""
 
-- name: Get the KUBECONFIG value
-  shell: echo $KUBECONFIG
-  register: kubeconfig_value
-
-- name: check if the kubeconfig file exists
-  stat:
-    path: "{{ kubeconfig_value.stdout }}"
-  register: kubeconfig_file
-
-- name: Verify that KUBECONFIG file exists
-  fail:
-    msg: "Kubeconfig not found at {{ kubeconfig_value.stdout }}"
-  when: kubeconfig_file.stat.exists != true
-
-- name: Get oc user
-  command: >
-    oc whoami
-
-- name: Get oc version
-  command: >
-    oc version
+- name: 'Store openshift_release={{ ocp_version.stdout }}'
+  set_fact:
+    openshift_release: "{{ ocp_version.stdout }}"
+  when: openshift_release | default('', true) | trim == ''

--- a/toolbox/_common.sh
+++ b/toolbox/_common.sh
@@ -8,11 +8,8 @@ set -o nounset
 ANSIBLE_OPTS="${ANSIBLE_OPTS:--vv}"
 INVENTORY_ARG="-i inventory/hosts"
 
-if [ -z "${OCP_VERSION:-}" ]; then
-    echo "Getting OpenShift version ..."
-    OCP_VERSION="$(oc version -o json | jq --raw-output '.openshiftVersion' | cut -b-3)"
-    echo "Getting OpenShift version ==> $OCP_VERSION"
+if [ ! -z "${OCP_VERSION:-}" ]; then
+    ANSIBLE_OPTS="$ANSIBLE_OPTS -e openshift_release=$OCP_VERSION"
 fi
-ANSIBLE_OPTS="$ANSIBLE_OPTS -e openshift_release=$OCP_VERSION"
 
 cd $TOP_DIR

--- a/toolbox/_common.sh
+++ b/toolbox/_common.sh
@@ -16,5 +16,3 @@ fi
 ANSIBLE_OPTS="$ANSIBLE_OPTS -e openshift_release=$OCP_VERSION"
 
 cd $TOP_DIR
-
-set -x


### PR DESCRIPTION
`roles/check_deps/tasks/main.yml` is executed at the beginning of every playbook / toolbox script.

This patch simplifies what is checked and automates the computation of `openshift_release`