### PR TITLE
.github/workflows/sync-release-branches.yml: don't use the force to push

### DIFF
--- a/.github/workflows/sync-release-branches.yml
+++ b/.github/workflows/sync-release-branches.yml
@@ -27,5 +27,7 @@ jobs:
           set -x;
           for branch in release-4.{5,6,7,8,9,next};
           do
-            git push origin HEAD:$branch --force;
+            git checkout $branch;
+            git pull . master;
+            git push origin
           done


### PR DESCRIPTION
Protected branch don't like it ...