### PR TITLE
Small fixes

### DIFF
--- a/roles/nv_gpu/tasks/install_nv.yml
+++ b/roles/nv_gpu/tasks/install_nv.yml
@@ -1,10 +1,13 @@
+- name: Ensure that the GPU Operator PackageManifest exists
+  command: oc get packagemanifests/gpu-operator-certified
+
 - name: Create the namespace for the GPU Operator
   command: oc apply -f "{{ gpu_operator_namespace }}"
 
 - name: Create the OperatorGroup object
   command: oc apply -f "{{ gpu_operator_operatorgroup }}"
 
-- name: Save the GPU Operator PackageManifests (debug)
+- name: Save the GPU Operator PackageManifest (debug)
   ignore_errors: true
   shell: "oc get packagemanifests/gpu-operator-certified -o yaml > {{ artifact_extra_logs_dir }}/gpu_operator_packagemanifest.yml"
   when: artifact_extra_logs_dir | default('', true) | trim != ''

--- a/roles/nv_gpu_install_from_commit/files/helm_deploy_operator.sh
+++ b/roles/nv_gpu_install_from_commit/files/helm_deploy_operator.sh
@@ -103,7 +103,7 @@ deploy_operator() {
     done <<< $(parse_yaml ${YAML_VALUES} "")
     set -x
 
-    device_plugin_version=${HELM_values[devicePlugin_version]/-ubuntu*/}-ubi8
+    device_plugin_version=${HELM_values[devicePlugin_version]/%-*}-ubi8
     if [[ "$device_plugin_version" == "v0.7.1-ubi8" ]]; then
         echo "WARNING: cannot use devicePlugin.version=$device_plugin_version"
         device_plugin_version="v0.7.3-ubi8"
@@ -124,9 +124,9 @@ deploy_operator() {
      --set operator.defaultRuntime=crio \
      --set nfd.enabled=${NFD_ENABLED} \
      \
-     --set toolkit.version=${HELM_values[toolkit_version]/-ubuntu*/}-ubi8 \
+     --set toolkit.version=${HELM_values[toolkit_version]%-*}-ubi8 \
      --set devicePlugin.version=${device_plugin_version} \
-     --set dcgmExporter.version=${HELM_values[dcgmExporter_version]/-ubuntu*/}-ubi8 \
+     --set dcgmExporter.version=${HELM_values[dcgmExporter_version]%-*}-ubi8 \
      \
      --namespace $OPERATOR_NAMESPACE \
      --wait

--- a/roles/nv_gpu_install_from_commit/files/helm_deploy_operator.sh
+++ b/roles/nv_gpu_install_from_commit/files/helm_deploy_operator.sh
@@ -113,8 +113,8 @@ deploy_operator() {
     helm uninstall --namespace $OPERATOR_NAMESPACE $OPERATOR_NAME || true
     oc delete crd/clusterpolicies.nvidia.com || true
 
-    #helm template --debug # <-- this is for debugging helm install
-    exec helm install \
+    #exec helm install \
+    helm_args="\
      $OPERATOR_NAME $HELM_SOURCE \
      --devel \
      \
@@ -129,7 +129,16 @@ deploy_operator() {
      --set dcgmExporter.version=${HELM_values[dcgmExporter_version]%-*}-ubi8 \
      \
      --namespace $OPERATOR_NAMESPACE \
-     --wait
+     --wait"
+
+    if [ ! -z "${ARTIFACT_DIR:-}" ]; then
+        ARTIFACT_EXTRA_LOGS_DIR="${ARTIFACT_DIR}/helm_deploy_operator/extra_logs"
+        mkdir -p "${ARTIFACT_EXTRA_LOGS_DIR}"
+
+        helm template --debug $helm_args > "${ARTIFACT_EXTRA_LOGS_DIR}/helm_deploy.yaml"
+    fi
+
+    exec helm install $helm_args
 }
 
 undeploy() {


### PR DESCRIPTION
* 9168c2d - roles/nv_gpu/tasks/install_nv.yml: Ensure that the GPU Operator PackageManifest exists


Without this patch, the following commands may erroneously succeed
(if not ignored), because of the `| jq`...

Example:

    TASK: nv_gpu : Get the version of the GPU Operator on OperatorHub
    changed: True

    <command> oc get packagemanifests/gpu-operator-certified -n openshift-marketplace -ojson | jq -r .status.channels[0].currentCSV

    <stderr> Error from server (NotFound): packagemanifests.packages.operators.coreos.com "gpu-operator-certified" not found

---

* 541c5da - roles/nv_gpu_install_from_commit/files/helm_deploy_operator.sh: fix image name transformation

The default `version` of the `devicePlugin` image changed a few days
ago [1] to use the `-ubi8` image by default. This broke the automated
image name transformation that only worked with `-ubuntu*` or no `-*`
suffix.

This patch simply transforms `<anything>-OS` into `<anything>-ubi8` or
`<anything>` into `<anything>-ubi8`.

Expect it to break when an image named `<anything>` (without an OS
suffix) will come ...

1: https://github.com/NVIDIA/gpu-operator/commit/de819f431b05a5eed8c5fd9aaa4483bbeb4fa6b5#diff-aecfc7542f3194d151b0a0812fa08dca7a2147da1c6bc06f41f19aa2b4f934afR99

---

* 480e798 - roles/nv_gpu_install_from_commit/files/helm_deploy_operator.sh: save helm-generated resources before creating them

This patch stores in the `$ARTIFACT_DIR` the YAML description of
resources that will be instantiated from the helm chart.