### PR TITLE
toolbox: entitlement: new set of tools

### DIFF
--- a/build/root/usr/local/bin/run
+++ b/build/root/usr/local/bin/run
@@ -15,6 +15,7 @@ ci_banner() {
     echo "===> $0 $@ <=="
 
     git show --quiet || echo "Could not access git history ..."
+    echo
     git show HEAD~ --quiet || true
 
     echo
@@ -69,25 +70,25 @@ prechecks() {
 }
 
 entitle() {
-    # TODO: this should become an ansible playbook properly waiting
-    # for the deployment of the entitlement
-
-    if [[ "${SKIP_ENTITLEMENT:-n}" == y ]]; then
-        echo "Skipping entitlement (SKIP_ENTITLEMENT=${SKIP_ENTITLEMENT})"
+    if toolbox/entitlement/test.sh; then
+        echo "Cluster already entitled, skipping entitlement."
         return
     fi
 
-    PSAP_ENTITLEMENT="/var/run/psap-entitlement-secret/01-cluster-wide-machineconfigs.yaml"
-    if [ ! -f "$PSAP_ENTITLEMENT" ]; then
-        echo "FATAL: PSAP entitlement resources not found ($PSAP_ENTITLEMENT)"
+    ENTITLEMENT_RESOURCES=${ENTITLEMENT_RESOURCES:-/var/run/psap-entitlement-secret/01-cluster-wide-machineconfigs.yaml}
+    if [ -z "$ENTITLEMENT_RESOURCES" ]; then
+        echo "FATAL: Cluster isn't entitled, and no entitlement resource provided (ENTITLEMENT_RESOURCES)"
+        exit 1
+    elif [ ! -f "$ENTITLEMENT_RESOURCES" ]; then
+        echo "FATAL: Entitlement resource file not found ($ENTITLEMENT_RESOURCES)"
         exit 1
     fi
 
-    if ! oc get mc/50-entitlement-pem -oname 2>/dev/null | grep -q 50-entitlement-pem; then
-        echo "===> Apply entitlement manifests from ${PSAP_ENTITLEMENT} <=="
-        oc create -f "${PSAP_ENTITLEMENT}" && sleep 300
-    else
-        echo "===> Entitlement already instanciated <=="
+    echo "Deploying the entitlement from resources in ${ENTITLEMENT_RESOURCES}"
+    toolbox/entitlement/deploy.sh --machine-configs ${ENTITLEMENT_RESOURCES}
+    if ! toolbox/entitlement/wait.sh; then
+        echo "FATAL: Failed to properly entitle the cluster, cannot continue."
+        exit 1
     fi
 }
 

--- a/playbooks/entitlement.yml
+++ b/playbooks/entitlement.yml
@@ -1,0 +1,8 @@
+---
+#
+- name: Deploy and test OpenShift entitlement
+  hosts: localhost
+  connection: local
+  gather_facts: true
+  roles:
+    - role: entitlement

--- a/roles/entitlement/files/apply_template.py
+++ b/roles/entitlement/files/apply_template.py
@@ -1,0 +1,19 @@
+#! /usr/bin/python3
+
+import fileinput
+import base64
+import sys
+
+template = sys.argv[1]
+keyname = sys.argv[2]
+filename = sys.argv[3]
+print(f"Replacing '{keyname}' with the content of '{filename}'", file=sys.stderr)
+
+with open(filename, "rb") as f:
+    file_b64 = base64.b64encode(f.read()).decode()
+
+found = False
+for line in fileinput.input(files=[template]):
+    if keyname in line: found = True
+    print(line.replace(keyname, file_b64), end="")
+exit(0 if found else 1)

--- a/roles/entitlement/files/mc_pem.yml
+++ b/roles/entitlement/files/mc_pem.yml
@@ -1,0 +1,35 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: worker
+  name: 50-entitlement-pem
+spec:
+  config:
+    ignition:
+      version: 3.2.0
+    storage:
+      files:
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,BASE64_ENCODED_PEM_FILE
+        filesystem: root
+        mode: 0644
+        path: /etc/pki/entitlement/entitlement.pem
+---
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: worker
+  name: 50-entitlement-key-pem
+spec:
+  config:
+    ignition:
+      version: 3.2.0
+    storage:
+      files:
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,BASE64_ENCODED_PEM_FILE
+        filesystem: root
+        mode: 0644
+        path: /etc/pki/entitlement/entitlement-key.pem

--- a/roles/entitlement/files/mc_rhsm.yml
+++ b/roles/entitlement/files/mc_rhsm.yml
@@ -1,0 +1,17 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: worker
+  name: 50-rhsm-conf
+spec:
+  config:
+    ignition:
+      version: 3.2.0
+    storage:
+      files:
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,BASE64_ENCODED_RHSM_FILE
+        filesystem: root
+        mode: 0644
+        path: /etc/rhsm/rhsm.conf

--- a/roles/entitlement/files/rhsm.conf
+++ b/roles/entitlement/files/rhsm.conf
@@ -1,0 +1,109 @@
+# Red Hat Subscription Manager Configuration File:
+
+# Unified Entitlement Platform Configuration
+[server]
+# Server hostname:
+hostname = subscription.rhsm.redhat.com
+
+# Server prefix:
+prefix = /subscription
+
+# Server port:
+port = 443
+
+# Set to 1 to disable certificate validation:
+insecure = 0
+
+# Set the depth of certs which should be checked
+# when validating a certificate
+ssl_verify_depth = 3
+
+# an http proxy server to use
+proxy_hostname =
+
+# The scheme to use for the proxy when updating repo definitions, if needed
+# e.g. http or https
+proxy_scheme = http
+
+# port for http proxy server
+proxy_port =
+
+# user name for authenticating to an http proxy, if needed
+proxy_user =
+
+# password for basic http proxy auth, if needed
+proxy_password =
+
+# host/domain suffix blacklist for proxy, if needed
+no_proxy =
+
+[rhsm]
+# Content base URL:
+baseurl = https://cdn.redhat.com
+
+# Repository metadata GPG key URL:
+repomd_gpg_url =
+
+# Server CA certificate location:
+ca_cert_dir = /etc/rhsm/ca/
+
+# Default CA cert to use when generating yum repo configs:
+repo_ca_cert = %(ca_cert_dir)sredhat-uep.pem
+
+# Where the certificates should be stored
+productCertDir = /etc/pki/product
+entitlementCertDir = /etc/pki/entitlement
+consumerCertDir = /etc/pki/consumer
+
+# Manage generation of yum repositories for subscribed content:
+manage_repos = 1
+
+# Refresh repo files with server overrides on every yum command
+full_refresh_on_yum = 0
+
+# If set to zero, the client will not report the package profile to
+# the subscription management service.
+report_package_profile = 1
+
+# The directory to search for subscription manager plugins
+pluginDir = /usr/share/rhsm-plugins
+
+# The directory to search for plugin configuration files
+pluginConfDir = /etc/rhsm/pluginconf.d
+
+# Manage automatic enabling of yum/dnf plugins (product-id, subscription-manager)
+auto_enable_yum_plugins = 1
+
+# Run the package profile on each yum/dnf transaction
+package_profile_on_trans = 0
+
+# Inotify is used for monitoring changes in directories with certificates.
+# Currently only the /etc/pki/consumer directory is monitored by the
+# rhsm.service. When this directory is mounted using a network file system
+# without inotify notification support (e.g. NFS), then disabling inotify
+# is strongly recommended. When inotify is disabled, periodical directory
+# polling is used instead.
+inotify = 1
+
+[rhsmcertd]
+# Interval to run cert check (in minutes):
+certCheckInterval = 240
+# Interval to run auto-attach (in minutes):
+autoAttachInterval = 1440
+# If set to zero, the checks done by the rhsmcertd daemon will not be splayed (randomly offset)
+splay = 1
+# If set to 1, rhsmcertd will not execute.
+disable = 0
+
+[rhsmd]
+# The time in seconds we will allow the rhsmd cron job to run before terminating the process.
+processTimeout = 300
+
+[logging]
+default_log_level = INFO
+# subscription_manager = DEBUG
+# subscription_manager.managercli = DEBUG
+# rhsm = DEBUG
+# rhsm.connection = DEBUG
+# rhsm-app = DEBUG
+# rhsm-app.rhsmd = DEBUG

--- a/roles/entitlement/files/test_pod.yml
+++ b/roles/entitlement/files/test_pod.yml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+ name: entitlement-tester
+spec:
+ containers:
+   - name: entitlement-tester
+     image: registry.access.redhat.com/ubi8/ubi
+     command:
+       - /bin/sh
+       - -c
+       - "uname -a
+          && cat /etc/os-release
+          && (md5sum /etc/rhsm/rhsm.conf /etc/pki/entitlement-host/entitlement*.pem || true)
+          && dnf info kernel-core"
+ restartPolicy: Never

--- a/roles/entitlement/tasks/deploy.yml
+++ b/roles/entitlement/tasks/deploy.yml
@@ -1,0 +1,22 @@
+---
+- block:
+  - name: "Deploy entitlement from resource file '{{ entitlement_resources }}'"
+    command: oc create -f "{{ entitlement_resources }}"
+  - meta: end_play
+  when: entitlement_resources | default('', true) | trim != ''
+
+- block:
+  - name: "Deploy RHSM from file '{{ entitlement_rhsm }}'"
+    shell:
+      python3 "{{ entitlement_py_apply }}"
+        "{{ entitlement_mc_rhsm }}" BASE64_ENCODED_RHSM_FILE "{{ entitlement_rhsm }}"
+      | oc create -f-
+  when: entitlement_rhsm | default('', true) | trim != ''
+
+- block:
+  - name: "Deploy the pem and key-pem from file '{{ entitlement_pem }}'"
+    shell:
+      python3 "{{ entitlement_py_apply }}"
+        "{{ entitlement_mc_pem }}" BASE64_ENCODED_PEM_FILE "{{ entitlement_pem }}"
+      | oc create -f-
+  when: entitlement_pem | default('', true) | trim != ''

--- a/roles/entitlement/tasks/inspect.yml
+++ b/roles/entitlement/tasks/inspect.yml
@@ -1,0 +1,20 @@
+---
+- name: List entitlement MachineConfig objects
+  command: oc get MachineConfig 50-entitlement-key-pem 50-entitlement-pem 50-rhsm-conf
+  ignore_errors: true
+
+- name: List all the MachineConfig objects
+  command: oc get MachineConfigs
+  ignore_errors: true
+
+- name: Get the list of MachineConfigPools
+  command: oc get MachineConfigPools
+  ignore_errors: true
+
+- name: Get the description of the worker MachineConfigPool
+  command: oc describe MachineConfigPool/worker
+  ignore_errors: true
+
+- name: Get the state of the nodes
+  command: oc nodes
+  ignore_errors: true

--- a/roles/entitlement/tasks/main.yml
+++ b/roles/entitlement/tasks/main.yml
@@ -1,0 +1,17 @@
+---
+- block:
+  - include_tasks: roles/entitlement/tasks/deploy.yml
+    when: entitlement_deploy == 'yes'
+  - include_tasks: roles/entitlement/tasks/test_wait.yml
+    when: entitlement_test == 'yes'
+  rescue:
+  - include_tasks: roles/entitlement/tasks/inspect.yml
+  - name: Failing because of a previous error
+    fail:
+      msg: Failed because of a previous error
+
+- include_tasks: roles/entitlement/tasks/inspect.yml
+  when: entitlement_inspect == 'yes'
+
+- include_tasks: roles/entitlement/tasks/undeploy.yml
+  when: entitlement_undeploy == 'yes'

--- a/roles/entitlement/tasks/test_wait.yml
+++ b/roles/entitlement/tasks/test_wait.yml
@@ -1,0 +1,45 @@
+---
+- name: Set the number of retry loop to 1 if waiting not requested
+  set_fact:
+    entitlement_retries: 1
+  when: entitlement_test_wait != 'yes'
+
+- name: Specify the number of retries to perform to wait for the entitlement
+  set_fact:
+    nb_entitlement_retries: 10
+  when: entitlement_test_wait == 'yes'
+
+- name: "Set the number of retry loop to {{ nb_entitlement_retries }} if waiting is requested"
+  set_fact:
+    entitlement_retries: "{{ nb_entitlement_retries }}"
+  when: entitlement_test_wait == 'yes'
+
+- block:
+  - name: Wait for the entitlement Pod to succeed
+    shell: |
+      oc delete -f "{{ entitlement_test_pod }}" --ignore-not-found=true;
+      oc create -f "{{ entitlement_test_pod }}";
+      i=0;
+      CMD="oc get pod/entitlement-tester
+                -o custom-columns=:.status.phase
+                --no-headers
+                ";
+      while ! $CMD | egrep 'Succeeded|Error|Failed'; do
+          echo "Waiting for Pod completion ... (#${i})";
+          sleep 10;
+          i=$(($i+1));
+      done;
+      $CMD;
+      $CMD | egrep 'Succeeded';
+    register: entitlement_wait
+    until: entitlement_wait.rc == 0
+    retries: "{{ entitlement_retries}}"
+    delay: 30
+
+  always:
+  - name: Get the test Pod logs
+    command: oc logs pod/entitlement-tester
+    when: entitlement_inspect == "yes" or entitlement_wait.rc != 0
+
+  - name: Delete the test Pod
+    command: oc delete -f "{{ entitlement_test_pod }}"

--- a/roles/entitlement/tasks/undeploy.yml
+++ b/roles/entitlement/tasks/undeploy.yml
@@ -1,0 +1,3 @@
+---
+- name: Delete the entitlement MachineConfig objects
+  command: oc delete MachineConfig 50-entitlement-key-pem 50-entitlement-pem 50-rhsm-conf

--- a/roles/entitlement/vars/main.yml
+++ b/roles/entitlement/vars/main.yml
@@ -1,0 +1,26 @@
+---
+# deploy the entitlement on the cluster?
+entitlement_deploy: 'yes'
+# undeploy the entitlement on the cluster?
+entitlement_undeploy: 'no'
+# path to the pre-prepared yaml resources of the entitlement
+entitlement_resources: ''
+# path to the PEM file of the entitlement
+entitlement_pem: ''
+# path to the RHSM file of the entitlement
+entitlement_rhsm: 'roles/entitlement/files/rhsm.conf'
+
+# test the successfull deployment of the entitlement?
+entitlement_test: 'yes'
+# wait for the successfull deployment of the entitlement?
+entitlement_test_wait: 'yes'
+
+# gather information about entitlement deployment
+# (done anyway in case of test failure)
+entitlement_inspect: 'no'
+
+# template files for the MachineConfig resources
+entitlement_mc_rhsm: 'roles/entitlement/files/mc_rhsm.yml'
+entitlement_mc_pem: 'roles/entitlement/files/mc_pem.yml'
+entitlement_py_apply: 'roles/entitlement/files/apply_template.py'
+entitlement_test_pod: 'roles/entitlement/files/test_pod.yml'

--- a/toolbox/entitlement/deploy.sh
+++ b/toolbox/entitlement/deploy.sh
@@ -1,0 +1,32 @@
+#! /bin/bash -e
+
+THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+source ${THIS_DIR}/../_common.sh
+
+usage() {
+    echo "Usage: $0 (--pem|--machine-configs) </path/to/file>"
+}
+
+if ! [ "$#" -eq 2 ]; then
+    echo "ERROR: please pass two arguments."
+    usage
+    exit 1
+fi
+
+if [[ "$1" == "--pem" ]]; then
+    ANSIBLE_OPTS="${ANSIBLE_OPTS} -e entitlement_pem=$2"
+    echo "Using '$2' as PEM key"
+elif [[ "$1" == "--machine-configs" ]]; then
+    ANSIBLE_OPTS="${ANSIBLE_OPTS} -e entitlement_resources=$2"
+    echo "Using '$2' as entitlement resources"
+else
+    echo "ERROR: please pass a valid flag."
+    usage
+    exit 1
+fi
+
+ANSIBLE_OPTS="${ANSIBLE_OPTS} -e entitlement_deploy=yes"
+ANSIBLE_OPTS="${ANSIBLE_OPTS} -e entitlement_test=no"
+ANSIBLE_OPTS="${ANSIBLE_OPTS} -e entitlement_test_wait=no"
+
+exec ansible-playbook ${INVENTORY_ARG} ${ANSIBLE_OPTS} playbooks/entitlement.yml

--- a/toolbox/entitlement/inspect.sh
+++ b/toolbox/entitlement/inspect.sh
@@ -1,0 +1,11 @@
+#! /bin/bash -e
+
+THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+source ${THIS_DIR}/../_common.sh
+
+ANSIBLE_OPTS="${ANSIBLE_OPTS} -e entitlement_deploy=no"
+ANSIBLE_OPTS="${ANSIBLE_OPTS} -e entitlement_test=yes"
+ANSIBLE_OPTS="${ANSIBLE_OPTS} -e entitlement_test_wait=no"
+ANSIBLE_OPTS="${ANSIBLE_OPTS} -e entitlement_inspect=yes"
+
+exec ansible-playbook ${INVENTORY_ARG} ${ANSIBLE_OPTS} playbooks/entitlement.yml

--- a/toolbox/entitlement/test.sh
+++ b/toolbox/entitlement/test.sh
@@ -1,0 +1,10 @@
+#! /bin/bash -e
+
+THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+source ${THIS_DIR}/../_common.sh
+
+ANSIBLE_OPTS="${ANSIBLE_OPTS} -e entitlement_deploy=no"
+ANSIBLE_OPTS="${ANSIBLE_OPTS} -e entitlement_test=yes"
+ANSIBLE_OPTS="${ANSIBLE_OPTS} -e entitlement_test_wait=no"
+
+exec ansible-playbook ${INVENTORY_ARG} ${ANSIBLE_OPTS} playbooks/entitlement.yml

--- a/toolbox/entitlement/undeploy.sh
+++ b/toolbox/entitlement/undeploy.sh
@@ -1,0 +1,11 @@
+#! /bin/bash -e
+
+THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+source ${THIS_DIR}/../_common.sh
+
+ANSIBLE_OPTS="${ANSIBLE_OPTS} -e entitlement_deploy=no"
+ANSIBLE_OPTS="${ANSIBLE_OPTS} -e entitlement_test=no"
+ANSIBLE_OPTS="${ANSIBLE_OPTS} -e entitlement_test_wait=no"
+ANSIBLE_OPTS="${ANSIBLE_OPTS} -e entitlement_undeploy=yes"
+
+exec ansible-playbook ${INVENTORY_ARG} ${ANSIBLE_OPTS} playbooks/entitlement.yml

--- a/toolbox/entitlement/wait.sh
+++ b/toolbox/entitlement/wait.sh
@@ -1,0 +1,11 @@
+#! /bin/bash -e
+
+THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+source ${THIS_DIR}/../_common.sh
+
+ANSIBLE_OPTS="${ANSIBLE_OPTS} -e entitlement_deploy=no"
+ANSIBLE_OPTS="${ANSIBLE_OPTS} -e entitlement_test=yes"
+ANSIBLE_OPTS="${ANSIBLE_OPTS} -e entitlement_test_wait=yes"
+ANSIBLE_OPTS="${ANSIBLE_OPTS} -e entitlement_undeploy=no"
+
+exec ansible-playbook ${INVENTORY_ARG} ${ANSIBLE_OPTS} playbooks/entitlement.yml


### PR DESCRIPTION
```
toolbox/entitlement/deploy.sh
```
deploys either from a pre-prepared YAML resource file (CI) or from a PEM key

```
toolbox/entitlement/undeploy.sh
```
deletes our MachineConfig objects

```
toolbox/entitlement/test.sh
```
tests if `dnf info kernel-core` completes successfully
```
toolbox/entitlement/wait.sh
```
tests if `dnf info kernel-core` completes successfully within `10*30` seconds
```
toolbox/entitlement/inspect.sh
```
tests if `dnf info kernel-core` completes successfully and gathers extra information about the MachineConfig(Pools), to help debugging entitlement problems