### PR TITLE
roles/nv_gpu: allow installing an older version

### DIFF
--- a/build/root/usr/local/bin/run
+++ b/build/root/usr/local/bin/run
@@ -144,18 +144,28 @@ case ${1:-} in
         ;;
 
     "gpu-ci")
+        if [ ! -z "${2:-}" ]; then
+            OPERATOR_VERSION="$2"
+        else
+            OPERATOR_VERSION="" # latest version
+        fi
         prepare_cluster_for_gpu_operator
-        toolbox/gpu-operator/deploy_from_operatorhub.sh
+        toolbox/gpu-operator/deploy_from_operatorhub.sh ${OPERATOR_VERSION}
         toolbox/gpu-operator/run_ci_checks.sh
 
 	exit 0
         ;;
 
     "gpu-helm-ci")
-        prepare_cluster_for_gpu_operator
+        if [ -z "${2:-}" ]; then
+            echo "FATAL: $0 $1 should receive the operator version as parameter."
+            exit 1
+        fi
+        OPERATOR_VERSION="$2"
 
+        prepare_cluster_for_gpu_operator
         toolbox/gpu-operator/list_version_from_helm.sh
-        toolbox/gpu-operator/deploy_with_helm.sh 1.4.0
+        toolbox/gpu-operator/deploy_with_helm.sh ${OPERATOR_VERSION}
         toolbox/gpu-operator/run_ci_checks.sh
 
         exit 0

--- a/roles/nv_gpu/files/gpu/020_operator_sub.yml
+++ b/roles/nv_gpu/files/gpu/020_operator_sub.yml
@@ -5,7 +5,8 @@ metadata:
   namespace: openshift-operators
 spec:
   channel: stable
-  installPlanApproval: Automatic
+  installPlanApproval: Manual
   name: gpu-operator-certified
   source: certified-operators
   sourceNamespace: openshift-marketplace
+  startingCSV: "{{ startingCSV }}"

--- a/roles/nv_gpu/tasks/install_nv.yml
+++ b/roles/nv_gpu/tasks/install_nv.yml
@@ -9,14 +9,70 @@
 
 - name: Save the GPU Operator PackageManifest (debug)
   ignore_errors: true
-  shell: "oc get packagemanifests/gpu-operator-certified -o yaml > {{ artifact_extra_logs_dir }}/gpu_operator_packagemanifest.yml"
+  shell:
+    oc get packagemanifests/gpu-operator-certified -o yaml
+    > {{ artifact_extra_logs_dir }}/gpu_operator_packagemanifest.yml
   when: artifact_extra_logs_dir | default('', true) | trim != ''
 
-- name: Get the version of the GPU Operator on OperatorHub
+- block:
+  - name: Get the version of the GPU Operator on OperatorHub
+    shell:
+      oc get packagemanifests/gpu-operator-certified -n openshift-marketplace -ojson
+      | jq -r .status.channels[0].currentCSV
+    register: gpu_operator_csv_name_cmd
+  - name: Store the CSV version
+    set_fact:
+      gpu_operator_csv_name: "{{ gpu_operator_csv_name_cmd.stdout }}"
+  when: gpu_operator_operatorhub_version == ''
+
+- block:
+  - name: Get the version of the GPU Operator on OperatorHub
+    command: echo "gpu-operator-certified.v{{ gpu_operator_operatorhub_version }}"
+    register: gpu_operator_csv_name_cmd
+  - name: Store the CSV version
+    set_fact:
+      gpu_operator_csv_name: "{{ gpu_operator_csv_name_cmd.stdout }}"
+  when: gpu_operator_operatorhub_version != ''
+
+- name: "Create the OperatorHub subscription for {{ gpu_operator_csv_name }}"
+  debug:
+    msg: "{{ gpu_operator_csv_name }}"
+
+- name: "Create the OperatorHub subscription for {{ gpu_operator_csv_name }}"
   shell:
-    oc get packagemanifests/gpu-operator-certified -n openshift-marketplace -ojson
-    | jq -r .status.channels[0].currentCSV
-  register: gpu_operator_csv_name
+    cat {{ gpu_operator_operatorhub_sub }}
+    | sed 's|{{ '{{' }} startingCSV {{ '}}' }}|{{ gpu_operator_csv_name }}|'
+    | oc apply -f-
+  args:
+    warn: false # don't warn about using sed here
+
+- name: "Find the GPU Operator OperatorHub InstallPlan"
+  command:
+    oc get installplan
+      -oname
+      -loperators.coreos.com/gpu-operator-certified.openshift-operators
+      -n openshift-operators
+  register: gpu_operator_installplan_name
+  until: gpu_operator_installplan_name.stdout != ""
+  retries: 10
+  delay: 15
+
+- name: "Approve the GPU Operator OperatorHub InstallPlan"
+  command:
+    oc patch {{ gpu_operator_installplan_name.stdout }}
+       -n openshift-operators
+       --type merge
+       --patch '{"spec":{"approved":true}}'
+
+- name: "Wait for the GPU Operator OperatorHub ClusterServiceVersion"
+  command:
+    oc get  ClusterServiceVersion/{{ gpu_operator_csv_name }}
+      -oname
+      -n openshift-operators
+  register: gpu_operator_installplan_name
+  until: gpu_operator_installplan_name.stdout != ""
+  retries: 20
+  delay: 30
 
 - name: Create a temporary file for the GPU Operator clusterpolicy
   ansible.builtin.tempfile:
@@ -24,12 +80,18 @@
     suffix: .clusterpolicy.temp.yaml
   register: gpu_operator_clusterpolicy_tempfile
 
-- name: Get the clusterpolicy of the GPU Operator from OperatorHub
+- name: Get the clusterpolicy of the GPU Operator from OperatorHub CSV
   shell:
-    oc get packagemanifests/gpu-operator-certified -n openshift-marketplace -ojson
-    | jq -r '.status.channels[0].currentCSVDesc.annotations."alm-examples"'
+    set -o pipefail;
+    oc get ClusterServiceVersion/{{ gpu_operator_csv_name }}
+       -n openshift-operators
+       -ojson
+    | jq -r '.metadata.annotations."alm-examples"'
     | jq .[0] > {{ gpu_operator_clusterpolicy_tempfile.path }}
   register: operatorhub_clusterpolicy
+  until: operatorhub_clusterpolicy.rc == 0
+  retries: 20
+  delay: 15
 
 - name: Save the clusterpolicy of the GPU Operator from OperatorHub (debug)
   copy:
@@ -38,9 +100,6 @@
   delegate_to: localhost
   when: artifact_extra_logs_dir | default('', true) | trim != ''
   ignore_errors: true
-
-- name: Create the OperatorHub subscription for the GPU Operator
-  command: oc apply -f "{{ gpu_operator_operatorhub_sub }}"
 
 - block:
   - name: Create the clusterPolicy CR for the GPU Operator
@@ -62,7 +121,7 @@
   - name: Get the ClusterServiceVersion status (debug)
     shell:
       (oc get ClusterServiceVersion -A &&
-       oc describe "ClusterServiceVersion/{{ gpu_operator_csv_name.stdout }}" -n openshift-operators)
+       oc describe "ClusterServiceVersion/{{ gpu_operator_csv_name }}" -n openshift-operators)
        > {{ artifact_extra_logs_dir }}/gpu_operator_ClusterServiceVersion.log
     when: artifact_extra_logs_dir | default('', true) | trim != ''
     ignore_errors: true

--- a/roles/nv_gpu/tasks/uninstall_nv.yml
+++ b/roles/nv_gpu/tasks/uninstall_nv.yml
@@ -1,6 +1,16 @@
 ---
+- name: Get the name of the GPU Operator ClusterPolicy CR
+  command: oc get ClusterPolicy -oname
+  register: gpu_operator_cr_name
+  ignore_errors: true
+
+- name: Delete the clusterPolicy CR of the GPU Operator
+  command: oc delete "{{ gpu_operator_cr_name.stdout }}"
+  when: gpu_operator_cr_name.rc == 0
+  ignore_errors: true
+
 - name: Delete the OperatorHub subscription for the GPU Operator
-  command: oc delete -f "{{ gpu_operator_operatorhub_sub }}"
+  command: oc delete Subscription/gpu-operator-certified -n openshift-operators
   ignore_errors: true
 
 - name: Get the name of the GPU Operator ClusterServiceVersion
@@ -13,10 +23,6 @@
   shell: "oc delete {{ item }} -n openshift-operators"
   ignore_errors: true
   when: operator_csv_name.rc == 0
-
-- name: Delete the clusterPolicy CR of the GPU Operator
-  command: oc delete -f "{{ gpu_operator_cr }}"
-  ignore_errors: true
 
 - name: Delete the CRD of the GPU Operator
   command: oc delete crd clusterpolicies.nvidia.com

--- a/roles/nv_gpu/vars/main.yml
+++ b/roles/nv_gpu/vars/main.yml
@@ -11,3 +11,7 @@ gpu_operator_packagemanifests: gpu-operator-certified
 gpu_operator_namespace: roles/nv_gpu/files/gpu/010_namespace.yml
 gpu_operator_operatorgroup: roles/nv_gpu/files/gpu/015_operatorgroup.yml
 gpu_operator_operatorhub_sub: roles/nv_gpu/files/gpu/020_operator_sub.yml
+gpu_operator_install_plan: roles/nv_gpu/files/gpu/030_install_plan.yml
+
+# Empty to use the latest version, or set to force a given version
+gpu_operator_operatorhub_version: ""

--- a/toolbox/gpu-operator/deploy_from_operatorhub.sh
+++ b/toolbox/gpu-operator/deploy_from_operatorhub.sh
@@ -8,4 +8,15 @@ ANSIBLE_OPTS="${ANSIBLE_OPTS} -e install_gpu_operator_from_hub=yes"
 ANSIBLE_OPTS="${ANSIBLE_OPTS} -e undeploy_gpu_operator=no"
 ANSIBLE_OPTS="${ANSIBLE_OPTS} -e user_mode=not-ci"
 
+if [ "$#" -gt 1 ]; then
+    echo "FATAL: expected 0 or 1 parameter ... (got '$@')"
+    echo "Usage: $0 [gpu_operator_operatorhub_version]"
+    exit 1
+elif [ "$#" -eq 1 ]; then
+    ANSIBLE_OPTS="${ANSIBLE_OPTS} -e gpu_operator_operatorhub_version=$1"
+    echo "Deploying the GPU Operator from OperatorHub using version '$1'."
+else
+    echo "Deploying the GPU Operator from OperatorHub using the latest version available."
+fi
+
 exec ansible-playbook ${INVENTORY_ARG} ${ANSIBLE_OPTS} playbooks/deploy-gpu-operator-from-operatorhub.yml


### PR DESCRIPTION
This PR allows installing an older version of the GPU Operator from OperatorHub, but requested a specific ClusterServiceVersion and marking the as Manual.

By default, no `gpu_operator_operatorhub_version` is empty, so the last release available on OperatorHub is installed.

The toolbox is extended to receive an optional version identifier as argument
```
toolbox/gpu-operator/deploy_from_operatorhub.sh [<version to install>]
```

The CI `run` command is extended to receive an optional version identifier as argument:
```
build/root/usr/local/bin/run gpu-ci [version]
build/root/usr/local/bin/run gpu-helm-ci <version>
```

A follow-up PR on OpenShift-release will integrate the testing of older versions in the CI