### PR TITLE
Fix entitlement failure

### DIFF
--- a/build/root/usr/local/bin/run
+++ b/build/root/usr/local/bin/run
@@ -70,6 +70,7 @@ prechecks() {
 }
 
 entitle() {
+    echo "Testing if the cluster is already entitled ..."
     if toolbox/entitlement/test.sh; then
         echo "Cluster already entitled, skipping entitlement."
         return
@@ -96,7 +97,6 @@ entitle() {
 
 prechecks
 ci_banner
-entitle
 
 ANSIBLE_OPTS="-vv"
 
@@ -111,7 +111,6 @@ else
 fi
 
 
-
 ANSIBLE_OPTS=${ANSIBLE_OPTS:--v}
 ANSIBLE_OPTS="${ANSIBLE_OPTS} ${EXTRA_ANSIBLE_OPTS:-}"
 
@@ -119,6 +118,12 @@ export ANSIBLE_OPTS
 export EXTRA_ANSIBLE_OPTS=
 
 echo "ANSIBLE_OPTS='$ANSIBLE_OPTS'"
+
+prepare_cluster_for_gpu_operator() {
+    entitle
+    toolbox/scaleup_cluster.sh
+    toolbox/nfd/deploy_from_operatorhub.sh
+}
 
 set -x
 case ${1:-} in
@@ -129,8 +134,7 @@ case ${1:-} in
 
         echo "Using Git repository ${CI_IMAGE_GPU_COMMIT_CI_REPO} with ref ${CI_IMAGE_GPU_COMMIT_CI_REF}"
 
-        toolbox/scaleup_cluster.sh
-        toolbox/nfd/deploy_from_operatorhub.sh
+        prepare_cluster_for_gpu_operator
         toolbox/gpu-operator/deploy_from_commit.sh "${CI_IMAGE_GPU_COMMIT_CI_REPO}" \
                                                    "${CI_IMAGE_GPU_COMMIT_CI_REF}" \
                                                    "${CI_IMAGE_GPU_COMMIT_CI_IMAGE_UID}"
@@ -140,8 +144,7 @@ case ${1:-} in
         ;;
 
     "gpu-ci")
-        toolbox/scaleup_cluster.sh
-        toolbox/nfd/deploy_from_operatorhub.sh
+        prepare_cluster_for_gpu_operator
         toolbox/gpu-operator/deploy_from_operatorhub.sh
         toolbox/gpu-operator/run_ci_checks.sh
 
@@ -149,8 +152,8 @@ case ${1:-} in
         ;;
 
     "gpu-helm-ci")
-        toolbox/scaleup_cluster.sh
-        toolbox/nfd/deploy_from_operatorhub.sh
+        prepare_cluster_for_gpu_operator
+
         toolbox/gpu-operator/list_version_from_helm.sh
         toolbox/gpu-operator/deploy_with_helm.sh 1.4.0
         toolbox/gpu-operator/run_ci_checks.sh

--- a/roles/entitlement/files/test_pod.yml
+++ b/roles/entitlement/files/test_pod.yml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Pod
 metadata:
  name: entitlement-tester
+ namespace: default
 spec:
  containers:
    - name: entitlement-tester

--- a/roles/entitlement/tasks/test_wait.yml
+++ b/roles/entitlement/tasks/test_wait.yml
@@ -23,6 +23,7 @@
       CMD="oc get pod/entitlement-tester
                 -o custom-columns=:.status.phase
                 --no-headers
+                -n default
                 ";
       while ! $CMD | egrep 'Succeeded|Error|Failed'; do
           echo "Waiting for Pod completion ... (#${i})";
@@ -38,7 +39,7 @@
 
   always:
   - name: Get the test Pod logs
-    command: oc logs pod/entitlement-tester
+    command: oc logs pod/entitlement-tester -n default
     when: entitlement_inspect == "yes" or entitlement_wait.rc != 0
 
   - name: Delete the test Pod

--- a/roles/entitlement/tasks/test_wait.yml
+++ b/roles/entitlement/tasks/test_wait.yml
@@ -17,6 +17,7 @@
 - block:
   - name: Wait for the entitlement Pod to succeed
     shell: |
+      set -o errexit;
       oc delete -f "{{ entitlement_test_pod }}" --ignore-not-found=true;
       oc create -f "{{ entitlement_test_pod }}";
       i=0;


### PR DESCRIPTION
The CI failed last night because the entitlement test did not succeed (nor properly fail):

```
/opt/ci-artifacts/src/playbooks/roles/entitlement/tasks/test_wait.yml:18
Tuesday 02 March 2021  23:35:40 +0000 (0:00:00.023)       0:00:01.262 ********* 
{"component":"entrypoint","file":"prow/entrypoint/run.go:165","func":"k8s.io/test-infra/prow/entrypoint.Options.ExecuteProcess","level":"error","msg":"Process did not finish before 2h0m0s timeout","severity":"error","time":"2021-03-03T01:35:38Z"}
{"component":"entrypoint","file":"prow/entrypoint/run.go:255","func":"k8s.io/test-infra/prow/entrypoint.gracefullyTerminate","level":"error","msg":"Process did not exit before 15s grace period","severity":"error","time":"2021-03-03T01:35:53Z"}
```
This PR fixes the issue.
