### PR TITLE
Add ability to test and wait for NFD-labelled GPU nodes

### DIFF
--- a/build/root/usr/local/bin/run
+++ b/build/root/usr/local/bin/run
@@ -121,8 +121,12 @@ echo "ANSIBLE_OPTS='$ANSIBLE_OPTS'"
 
 prepare_cluster_for_gpu_operator() {
     entitle
-    toolbox/scaleup_cluster.sh
+
     toolbox/nfd/deploy_from_operatorhub.sh
+    if ! toolbox/nfd/has_gpu_nodes.sh; then
+        toolbox/scaleup_cluster.sh
+        toolbox/nfd/wait_gpu_nodes.sh
+    fi
 }
 
 set -x

--- a/roles/nv_gpu/tasks/main.yml
+++ b/roles/nv_gpu/tasks/main.yml
@@ -3,6 +3,10 @@
     include_tasks: roles/nv_gpu/tasks/install_nfd.yml
     when: install_nfd_operator_from_hub == "yes"
 
+  - name: Wait for NFD-labeled GPU nodes to appear
+    include_tasks: roles/nv_gpu/tasks/test_nfd_gpu.yml
+    when: nfd_test_gpu_nodes == "yes"
+
   - name: Install GPU-operator from OperatorHub
     include_tasks: roles/nv_gpu/tasks/install_nv.yml
     when: install_gpu_operator_from_hub == "yes"

--- a/roles/nv_gpu/tasks/test_nfd_gpu.yml
+++ b/roles/nv_gpu/tasks/test_nfd_gpu.yml
@@ -1,0 +1,37 @@
+---
+- name: Set the number of retry to 0 if waiting not requested
+  set_fact:
+    nfd_wait_gpu_retries: 0
+  when: nfd_wait_gpu_nodes != 'yes'
+
+- name: Specify the number of retries to perform to wait for the GPU nodes
+  set_fact:
+    nb_nfd_wait_gpu_retries: 10
+  when: nfd_wait_gpu_nodes == 'yes'
+
+- name: "Set the number of retry loop to {{ nfd_wait_gpu_nodes }} if waiting is requested"
+  set_fact:
+    nfd_wait_gpu_retries: "{{ nb_nfd_wait_gpu_retries }}"
+  when: nfd_wait_gpu_nodes == 'yes'
+
+- block:
+  - name: Wait for the GPU podes to appear
+    # label list should be in sync with:
+    # https://github.com/NVIDIA/gpu-operator/blob/master/pkg/controller/clusterpolicy/state_manager.go#L26
+    shell:
+      (   oc get nodes -oname --ignore-not-found=false -l feature.node.kubernetes.io/pci-10de.present
+       || oc get nodes -oname --ignore-not-found=false -l feature.node.kubernetes.io/pci-0302_10de.present
+       || oc get nodes -oname --ignore-not-found=false -l feature.node.kubernetes.io/pci-0300_10de.present
+      ) | grep .
+    register: nfd_gpu_wait
+    until: nfd_gpu_wait.rc == 0
+    retries: "{{ nfd_wait_gpu_retries }}"
+    delay: 30
+
+  rescue:
+  - name: Get the labels of the worker nodes (debug)
+    shell: oc get nodes --show-labels --selector='!node-role.kubernetes.io/master' | tr , '\n'
+
+  - name: Failing because no GPU node showed up
+    fail:
+      msg: Failed because no GPU node showed up

--- a/roles/nv_gpu/vars/main.yml
+++ b/roles/nv_gpu/vars/main.yml
@@ -6,6 +6,11 @@ nfd_operator_operatorhub_sub: roles/nv_gpu/files/nfd/030_operator_sub.yml
 nfd_operator_cr: roles/nv_gpu/files/nfd/040_customresources.yml
 nfd_channel: "{% if openshift_release == '4.5' %}4.5{% else %}4.6{% endif %}"
 
+# test if a node with a NVIDIA GPU PCI card is available
+nfd_test_gpu_nodes: no
+# wait for a node with a NVIDIA GPU PCI card to appear
+nfd_wait_gpu_nodes: no
+
 # Manifest for installing NV GPU operator from operator Hub
 gpu_operator_packagemanifests: gpu-operator-certified
 gpu_operator_namespace: roles/nv_gpu/files/gpu/010_namespace.yml

--- a/toolbox/nfd/has_gpu_nodes.sh
+++ b/toolbox/nfd/has_gpu_nodes.sh
@@ -1,0 +1,11 @@
+#! /bin/bash -e
+
+THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+source ${THIS_DIR}/../_common.sh
+
+ANSIBLE_OPTS="${ANSIBLE_OPTS} -e install_nfd_operator_from_hub=no"
+ANSIBLE_OPTS="${ANSIBLE_OPTS} -e install_gpu_operator_from_hub=no"
+ANSIBLE_OPTS="${ANSIBLE_OPTS} -e nfd_test_gpu_nodes=yes"
+ANSIBLE_OPTS="${ANSIBLE_OPTS} -e user_mode=not-ci"
+
+exec ansible-playbook ${INVENTORY_ARG} ${ANSIBLE_OPTS} playbooks/deploy-gpu-operator-from-operatorhub.yml

--- a/toolbox/nfd/wait_gpu_nodes.sh
+++ b/toolbox/nfd/wait_gpu_nodes.sh
@@ -1,0 +1,12 @@
+#! /bin/bash -e
+
+THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+source ${THIS_DIR}/../_common.sh
+
+ANSIBLE_OPTS="${ANSIBLE_OPTS} -e install_nfd_operator_from_hub=no"
+ANSIBLE_OPTS="${ANSIBLE_OPTS} -e install_gpu_operator_from_hub=no"
+ANSIBLE_OPTS="${ANSIBLE_OPTS} -e nfd_test_gpu_nodes=yes"
+ANSIBLE_OPTS="${ANSIBLE_OPTS} -e nfd_wait_gpu_nodes=yes"
+ANSIBLE_OPTS="${ANSIBLE_OPTS} -e user_mode=not-ci"
+
+exec ansible-playbook ${INVENTORY_ARG} ${ANSIBLE_OPTS} playbooks/deploy-gpu-operator-from-operatorhub.yml


### PR DESCRIPTION
This PR improves the detection of GPU nodes in the cluster:

instead of relying on AWS Machines and types to detect the presence of GPU nodes, use NFD to ...
1. test if a GPU node is available (see NVIDIA GPU labels [there](https://github.com/NVIDIA/gpu-operator/blob/master/pkg/controller/clusterpolicy/state_manager.go#L26))
2. if not available, scale-up the cluster with AWS MachineSet
3. wait for the GPU node to show up

this PR implements steps 1 and 3.

Incidentally, the PR also removes the strong dependency on AWS infrastructure, which is now only required when no GPU node is available at the beginning of the execution.