### PR TITLE
Fix various bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# OpenShift-PSAP Ci Artifacs
+# OpenShift-PSAP CI Artifacs
 
 This repository contains [Ansible](https://www.ansible.com/) roles and
-playbooks for [OpenShift](https://www.openshift.com/) PSAP Ci.
+playbooks for [OpenShift](https://www.openshift.com/) PSAP CI.
 
-> Performance & Latency Sensitive Application Platform 
+> Performance & Latency Sensitive Application Platform
 
 ---
 
@@ -12,31 +12,137 @@ playbooks for [OpenShift](https://www.openshift.com/) PSAP Ci.
 Requirements: (localhost)
 
 - Ansible >= 2.9.5
-- OpenShift Client (oc)
-- kubeconfig file defined at KUBECONFIG
+- OpenShift Client (`oc`)
+- A kubeconfig config file defined at `KUBECONFIG`
 
-## Ci playbook for the NFD  operator
+# CI testing of the GPU Operator
 
-Ci run for NFD, deploys NFD from git, and check the health of the operator
+The main goal of this repository is to perform nightly testing of the
+GPU Operator. This consists in multiple pieces:
 
-TODO: deploy from OperatorHub
+1. a container image [definition](build/Dockerfile);
+2. an [entrypoint script](for the container image) that will run in
+the container image;
+3. a set of
+[config files](https://github.com/openshift/release/tree/master/ci-operator/config/openshift-psap/ci-artifacts)
+and associated
+[jobs](https://github.com/openshift/release/tree/master/ci-operator/jobs/openshift-psap/ci-artifacts)
+for PROW CI engine.
 
-```bash
-ansible-playbook -i inventory/hosts playbooks/openshift-ci.yml
+See
+[there](https://prow.ci.openshift.org/?type=periodic&job=periodic-ci-openshift-psap-ci-artifacts-*)
+for the nightly CI results.
+
+As an example, the nightly tests currently run commands such as:
+
+```
+run gpu-ci             # test the GPU Operator from OperatorHub installation
+run gpu-commit-ci      # test the GPU Operator from its `master` branch
+run gpu-helm-ci 1.4.0  # test the GPU Operator from Helm installation
 ```
 
-## Ci playbook for the GPU operator
+These commands will in-turn trigger `toolbox` commands, in order to
+prepare the cluster, install the relevant operators and validate the
+successful usage of the GPUs.
 
-Ci run for the GPU operator
+The `toolbox` commands are described in the section below.
 
-[Optional] In case of not having a GPU ready OpenShift node, run this playbook first
+## PSAP toolbox
 
-```bash
-ansible-playbook -i inventory/hosts playbooks/gpu-burst.yml
+See the progress and discussions about the toolbox development in
+[this issue](https://github.com/openshift-psap/ci-artifacts/issues/34).
+
+GPU Operator
+------------
+
+- [x] Deploy from OperatorHub
+    - [ ] allow deploying an older version https://github.com/openshift-psap/ci-artifacts/issues/76
+```
+toolbox/gpu-operator/deploy_from_operatorhub.sh
+toolbox/gpu-operator/undeploy_from_operatorhub.sh
 ```
 
-With an openShift GPU ready node, we can then run
+- [x] Deploy from helm
+```
+toolbox/gpu-operator/list_version_from_helm.sh
+toolbox/gpu-operator/deploy_with_helm.sh <helm-version>
+toolbox/gpu-operator/undeploy_with_helm.sh
+```
 
-```bash
-ansible-playbook -i inventory/hosts playbooks/nvidia-gpu-operator-ci.yml
+- [x]  Deploy from a custom commit.
+```
+toolbox/gpu-operator/deploy_from_commit.sh <git repository> <git reference> [gpu_operator_image_tag_uid]
+Example:
+toolbox/gpu-operator/deploy_from_commit.sh https://github.com/NVIDIA/gpu-operator.git master
+```
+
+- [x] Run the GPU Operator deployment validation tests
+```
+toolbox/gpu-operator/run_ci_checks.sh
+```
+
+- [ ] Run GPU Burst to validate that the GPUs can run workloads
+
+- [ ] Capture GPU operator possible issues (entitlement, NFD labelling, operator deployment, state of resources in gpu-operator-resources, ...)
+  - already partly done inside the CI, but we should improve the toolbox aspect
+
+
+NFD
+---
+
+- [ ]  Deploy the NFD operator from OperatorHub:
+```
+toolbox/nfd/deploy_from_operatorhub.sh
+toolbox/nfd/undeploy_from_operatorhub.sh
+```
+  - [ ]  Control the channel to use from the command-line
+
+- [ ] Test the NFD deployment #78
+  - [ ] test with the NFD if GPU nodes are available
+  - [ ] wait with the NFD for GPU nodes to become available  #78
+```
+toolbox/nfd/has_gpu_nodes.sh
+toolbox/nfd/wait_gpu_nodes.sh
+```
+
+
+Cluster
+-------
+
+- [x] Add a GPU node on AWS
+```
+./toolbox/scaleup_cluster.sh
+```
+   - [x] Specify a machine type in the command-line, and skip scale-up if a node with the given machine-type is already present
+```
+./toolbox/scaleup_cluster.sh <machine-type>
+```
+
+- [x] Entitle the cluster, by passing a PEM file, checking if they should be concatenated or not, etc. And do nothing is the cluster is already entitled
+```
+toolbox/entitlement/deploy.sh --pem /path/to/pem
+toolbox/entitlement/deploy.sh --machine-configs /path/to/machineconfigs
+toolbox/entitlement/undeploy.sh
+toolbox/entitlement/test.sh
+toolbox/entitlement/wait.sh
+```
+  - [x] Capture all the clues required to understand entitlement issues
+
+```
+toolbox/entitlement/inspect.sh
+```
+
+- [ ] Deployment of an entitled cluster
+  - already coded, but we need to integrate [this repo](https://gitlab.com/kpouget_psap/deploy-cluster) within the toolbox
+  - deploy a cluster with 1 master node
+
+CI
+---
+
+- [x] Build the image used for the Prow CI testing, and run a given command in the Pod
+```
+Usage:   toolbox/local-ci/deploy.sh <ci command> <git repository> <git reference> [gpu_operator_image_tag_uid]
+Example: toolbox/local-ci/deploy.sh 'run gpu-ci' https://github.com/openshift-psap/ci-artifacts.git master
+
+toolbox/local-ci/cleanup.sh
 ```

--- a/build/root/usr/local/bin/run
+++ b/build/root/usr/local/bin/run
@@ -71,7 +71,7 @@ prechecks() {
 
 entitle() {
     echo "Testing if the cluster is already entitled ..."
-    if toolbox/entitlement/test.sh; then
+    if toolbox/entitlement/test.sh --no-inspect; then
         echo "Cluster already entitled, skipping entitlement."
         return
     fi

--- a/callback_plugins/human_log.py
+++ b/callback_plugins/human_log.py
@@ -86,11 +86,10 @@ class CallbackModule(default_CallbackModule):
         self.__display_result(result, color)
 
     def _print_task_banner(self, task):
-        self._display.display("---")
         self._display.display("")
         self._display.display(f"{task.get_path()}")
-
-        pass
+        self._display.display("---")
+        self._display.display("")
 
     def v2_runner_retry(self, result):
         color = C.COLOR_VERBOSE

--- a/playbooks/gpu-burst.yml
+++ b/playbooks/gpu-burst.yml
@@ -1,7 +1,0 @@
----
-- name: Scaling up an OCP GPU ready node
-  hosts: localhost
-  connection: local
-  gather_facts: true
-  roles:
-    - openshift_node

--- a/roles/entitlement/tasks/inspect.yml
+++ b/roles/entitlement/tasks/inspect.yml
@@ -16,5 +16,5 @@
   ignore_errors: true
 
 - name: Get the state of the nodes
-  command: oc nodes
+  command: oc get nodes
   ignore_errors: true

--- a/roles/entitlement/tasks/main.yml
+++ b/roles/entitlement/tasks/main.yml
@@ -6,6 +6,7 @@
     when: entitlement_test == 'yes'
   rescue:
   - include_tasks: roles/entitlement/tasks/inspect.yml
+    when: entitlement_inspect != 'never'
   - name: Failing because of a previous error
     fail:
       msg: Failed because of a previous error

--- a/roles/entitlement/tasks/test_wait.yml
+++ b/roles/entitlement/tasks/test_wait.yml
@@ -1,7 +1,7 @@
 ---
-- name: Set the number of retry loop to 1 if waiting not requested
+- name: Set the number of retry loop to 0 if waiting not requested
   set_fact:
-    entitlement_retries: 1
+    entitlement_retries: 0
   when: entitlement_test_wait != 'yes'
 
 - name: "Set the number of retry loop to {{ nb_entitlement_wait_retries }} if waiting is requested"

--- a/roles/entitlement/vars/main.yml
+++ b/roles/entitlement/vars/main.yml
@@ -16,7 +16,7 @@ entitlement_test: 'yes'
 entitlement_test_wait: 'yes'
 
 # gather information about entitlement deployment
-# (done anyway in case of test failure)
+# (done anyway in case of test failure, except if set to 'never')
 entitlement_inspect: 'no'
 
 # template files for the MachineConfig resources

--- a/roles/nv_gpu/tasks/ci_checks.yml
+++ b/roles/nv_gpu/tasks/ci_checks.yml
@@ -9,6 +9,18 @@
   retries: 10
   delay: 10
 
+- name: Ensure that NFD is running
+  command: oc get nodes -lfeature.node.kubernetes.io/system-os_release.ID=rhcos
+
+- name: Ensure that NFD found nodes with GPU labels
+  # label list should be in sync with:
+  # https://github.com/NVIDIA/gpu-operator/blob/master/pkg/controller/clusterpolicy/state_manager.go#L26
+  shell:
+    (   oc get nodes -oname --ignore-not-found=false -l feature.node.kubernetes.io/pci-10de.present
+     || oc get nodes -oname --ignore-not-found=false -l feature.node.kubernetes.io/pci-0302_10de.present
+     || oc get nodes -oname --ignore-not-found=false -l feature.node.kubernetes.io/pci-0300_10de.present
+    ) | grep .
+
 - name: check that nvidia-device-plugin-validation Pod has ran successfully
   shell:
     oc get pods --field-selector=status.phase=Succeeded

--- a/roles/nv_gpu/vars/main.yml
+++ b/roles/nv_gpu/vars/main.yml
@@ -7,9 +7,9 @@ nfd_operator_cr: roles/nv_gpu/files/nfd/040_customresources.yml
 nfd_channel: "{% if openshift_release == '4.5' %}4.5{% else %}4.6{% endif %}"
 
 # test if a node with a NVIDIA GPU PCI card is available
-nfd_test_gpu_nodes: no
+nfd_test_gpu_nodes: false
 # wait for a node with a NVIDIA GPU PCI card to appear
-nfd_wait_gpu_nodes: no
+nfd_wait_gpu_nodes: false
 
 # Manifest for installing NV GPU operator from operator Hub
 gpu_operator_packagemanifests: gpu-operator-certified

--- a/roles/nv_gpu_install_from_commit/tasks/deploy.yml
+++ b/roles/nv_gpu_install_from_commit/tasks/deploy.yml
@@ -7,5 +7,16 @@
     oc delete --ignore-not-found=true SecurityContextConstraints restricted-readonly;
     oc delete --ignore-not-found=true Namespace/gpu-operator-resources;
 
-- name: deploy the custom version of the GPU operator
-  command: bash "{{ gpu_operator_helm_install }}" deploy_from_commit "{{ gpu_operator_git_repo }}" "{{ gpu_operator_git_ref }}" "{{ gpu_operator_image_tag }}"
+- block:
+  - name: deploy the custom version of the GPU operator
+    command: bash "{{ gpu_operator_helm_install }}" deploy_from_commit "{{ gpu_operator_git_repo }}" "{{ gpu_operator_git_ref }}" "{{ gpu_operator_image_tag }}"
+
+  rescue:
+  - name: get the state of the GPU operator pod (debug)
+    command: oc get pods -n gpu-operator-ci
+  - name: get the logs of the GPU operator pod (debug)
+    command:
+      oc logs -n gpu-operator-ci deployment.apps/gpu-operator
+  - name: fail because of a previous error
+    fail:
+      msg: failing because of a previous error

--- a/toolbox/entitlement/test.sh
+++ b/toolbox/entitlement/test.sh
@@ -7,4 +7,9 @@ ANSIBLE_OPTS="${ANSIBLE_OPTS} -e entitlement_deploy=no"
 ANSIBLE_OPTS="${ANSIBLE_OPTS} -e entitlement_test=yes"
 ANSIBLE_OPTS="${ANSIBLE_OPTS} -e entitlement_test_wait=no"
 
+if [[ "$1" == "--no-inspect" ]]; then
+    ANSIBLE_OPTS="${ANSIBLE_OPTS} -e entitlement_inspect=never"
+    echo "INFO: Inspect on failure disabled."
+fi
+
 exec ansible-playbook ${INVENTORY_ARG} ${ANSIBLE_OPTS} playbooks/entitlement.yml


### PR DESCRIPTION
* 10d6e0c - roles/entitlement/tasks/inspect.yml: Get the state of the nodes: correctly call 'oc get nodes'


---

* a73721f - callback_plugins/human_log.py: correctly group 'task.get_path()' with its task logs


---

* ae0128e - roles/entitlement/tasks/test_wait.yml: retry '0' times when not waiting


---

* 0e1c453 - toolbox/entitlement/test.sh: add '--no-inspect' flag

This flag allows muting the inspection tasks (eg, when we expect the
test to confirm that the entitlement is not deployed)

---

* dc2d530 - roles/nv_gpu/tasks/ci_checks.yml: check that NFD is live and GPU nodes are available


---

* 5fd73f8 - callback_plugins/human_log.py: improve readability

The task output now looks like this:

```
---

---
roles/nv_gpu/tasks/ci_checks.yml:4
TASK: nv_gpu : CRD check - Ci mode

<command> oc get crds/clusterpolicies.nvidia.com

<stdout> NAME                         CREATED AT
<stdout> clusterpolicies.nvidia.com   2021-03-08T09:27:30Z

Monday 08 March 2021  10:48:52 +0100 (0:00:01.961)       0:00:04.545 **********
```

or when it fails:
```
---

---
roles/nv_gpu/tasks/ci_checks.yml:15
TASK: nv_gpu : Ensure that NFD found nodes with GPU labels
----- FAILED ----
msg: non-zero return code

<command> (   oc get nodes -oname --ignore-not-found=false -l feature.node.kubernetes.io/pci-10de.present || oc get nodes -oname --ignore-not-found=false -l feature.node.kubernetes.io/pci-0302_10de.present || oc get nodes -oname --ignore-not-found=false -l feature.node.kubernetes.io/pci-0300_10de.present ) | grep .

----- FAILED ----

Monday 08 March 2021  10:51:38 +0100 (0:00:00.812)       0:00:05.870 **********
```

---

* d292f49 - roles/nv_gpu_install_from_commit/tasks/deploy.yml: catch more information when the deploy fails


---

* 9dcf66e - playbooks/gpu-burst.yml: remove unused file


---

* 9d4c48e - README.md: rewrite with a focus on the toolbox


---

* 9622f22 - roles/nv_gpu/vars/main.yml: make yamllint happy
