### PR TITLE
Extend (and fix) waiting times

### DIFF
--- a/roles/entitlement/tasks/test_wait.yml
+++ b/roles/entitlement/tasks/test_wait.yml
@@ -25,6 +25,10 @@
           echo "Waiting for Pod completion ... (#${i})";
           sleep 10;
           i=$(($i+1));
+          if [[ "$i" == "12" ]]; then
+            echo "Pod took too long to terminate, aborting..."
+            exit 1;
+          fi;
       done;
       $CMD;
       $CMD | egrep 'Succeeded';

--- a/roles/entitlement/tasks/test_wait.yml
+++ b/roles/entitlement/tasks/test_wait.yml
@@ -4,14 +4,9 @@
     entitlement_retries: 1
   when: entitlement_test_wait != 'yes'
 
-- name: Specify the number of retries to perform to wait for the entitlement
+- name: "Set the number of retry loop to {{ nb_entitlement_wait_retries }} if waiting is requested"
   set_fact:
-    nb_entitlement_retries: 10
-  when: entitlement_test_wait == 'yes'
-
-- name: "Set the number of retry loop to {{ nb_entitlement_retries }} if waiting is requested"
-  set_fact:
-    entitlement_retries: "{{ nb_entitlement_retries }}"
+    entitlement_retries: "{{ nb_entitlement_wait_retries }}"
   when: entitlement_test_wait == 'yes'
 
 - block:

--- a/roles/entitlement/vars/main.yml
+++ b/roles/entitlement/vars/main.yml
@@ -24,3 +24,6 @@ entitlement_mc_rhsm: 'roles/entitlement/files/mc_rhsm.yml'
 entitlement_mc_pem: 'roles/entitlement/files/mc_pem.yml'
 entitlement_py_apply: 'roles/entitlement/files/apply_template.py'
 entitlement_test_pod: 'roles/entitlement/files/test_pod.yml'
+
+# the number of retries to perform when waiting for the entitlement
+nb_entitlement_wait_retries: 20

--- a/roles/nv_gpu/tasks/install_nv.yml
+++ b/roles/nv_gpu/tasks/install_nv.yml
@@ -54,7 +54,7 @@
       -n openshift-operators
   register: gpu_operator_installplan_name
   until: gpu_operator_installplan_name.stdout != ""
-  retries: 10
+  retries: 30
   delay: 15
 
 - name: "Approve the GPU Operator OperatorHub InstallPlan"


### PR DESCRIPTION
* 2a91812 - roles/nv_gpu/tasks/install_nv.yml: extend the # of retries for the InstallPlan to show up


---

* 2a89a88 - roles/entitlement: retry 20 times when waiting


---

* b0bf982 - roles/entitlement/tasks/test_wait.yml: stop waiting for Pod completion after 120s


---