### PR TITLE
toolbox: add toolbox/gpu-operator/run_gpu_burn.sh script

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,10 @@ toolbox/gpu-operator/deploy_from_commit.sh https://github.com/NVIDIA/gpu-operato
 toolbox/gpu-operator/run_ci_checks.sh
 ```
 
-- [ ] Run GPU Burst to validate that the GPUs can run workloads
+- [x] Run GPU Burst to validate that all the GPUs of all the nodes can run workloads
+```
+toolbox/gpu-operator/run_gpu_burn.sh [gpu-burn runtime, in seconds]
+```
 
 - [ ] Capture GPU operator possible issues (entitlement, NFD labelling, operator deployment, state of resources in gpu-operator-resources, ...)
   - already partly done inside the CI, but we should improve the toolbox aspect

--- a/build/root/usr/local/bin/run
+++ b/build/root/usr/local/bin/run
@@ -143,6 +143,7 @@ case ${1:-} in
                                                    "${CI_IMAGE_GPU_COMMIT_CI_REF}" \
                                                    "${CI_IMAGE_GPU_COMMIT_CI_IMAGE_UID}"
         toolbox/gpu-operator/run_ci_checks.sh
+        toolbox/gpu-operator/run_gpu_burn.sh
 
 	exit 0
         ;;
@@ -156,6 +157,7 @@ case ${1:-} in
         prepare_cluster_for_gpu_operator
         toolbox/gpu-operator/deploy_from_operatorhub.sh ${OPERATOR_VERSION}
         toolbox/gpu-operator/run_ci_checks.sh
+        toolbox/gpu-operator/run_gpu_burn.sh
 
 	exit 0
         ;;
@@ -171,6 +173,7 @@ case ${1:-} in
         toolbox/gpu-operator/list_version_from_helm.sh
         toolbox/gpu-operator/deploy_with_helm.sh ${OPERATOR_VERSION}
         toolbox/gpu-operator/run_ci_checks.sh
+        toolbox/gpu-operator/run_gpu_burn.sh
 
         exit 0
         ;;

--- a/playbooks/gpu-burn.yml
+++ b/playbooks/gpu-burn.yml
@@ -1,0 +1,8 @@
+---
+# Run GPU Burn to validate the GPU deployment
+- name: Run GPU burn
+  hosts: localhost
+  connection: local
+  gather_facts: true
+  roles:
+    - role: gpu_burn

--- a/roles/gpu_burn/files/gpu_burn_cm_entrypoint.yml
+++ b/roles/gpu_burn/files/gpu_burn_cm_entrypoint.yml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: gpu-burn-entrypoint
+  namespace: default
+data:
+  entrypoint.sh: |-
+    #!/bin/bash
+
+    NUM_GPUS=$(nvidia-smi -L | wc -l)
+    if [ $NUM_GPUS -eq 0 ]; then
+      echo "ERROR: No GPUs found"
+      exit 1
+    fi
+
+    echo "Running on ${NUM_GPUS} GPUs:"
+    nvidia-smi -L
+    echo ""
+    time /usr/local/bin/gpu-burn $GPU_BURN_TIME

--- a/roles/gpu_burn/files/gpu_burn_pod.yml
+++ b/roles/gpu_burn/files/gpu_burn_pod.yml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: gpu-burn
+  name: gpu-burn-{{ gpu_node_hostname }}
+  namespace: default
+spec:
+  restartPolicy: Never
+  containers:
+  - image: quay.io/openshift-psap/gpu-burn
+    imagePullPolicy: Always
+    name: gpu-burn-ctr
+    command:
+    - /bin/entrypoint.sh
+    volumeMounts:
+    - name: entrypoint
+      mountPath: /bin/entrypoint.sh
+      readOnly: true
+      subPath: entrypoint.sh
+    env:
+    - name: GPU_BURN_TIME
+      value: "{{ gpu_burn_time }}"
+  volumes:
+    - name: entrypoint
+      configMap:
+        defaultMode: 0700
+        name: gpu-burn-entrypoint
+  nodeSelector:
+    nvidia.com/gpu.present: "true"
+    kubernetes.io/hostname: "{{ gpu_node_hostname }}"

--- a/roles/gpu_burn/tasks/main.yml
+++ b/roles/gpu_burn/tasks/main.yml
@@ -1,0 +1,87 @@
+---
+- name: Ensure that NFD found nodes with GPU labels
+  # label list should be in sync with:
+  # https://github.com/NVIDIA/gpu-operator/blob/master/pkg/controller/clusterpolicy/state_manager.go#L26
+  shell:
+    (   oc get nodes -oname --ignore-not-found=false -l feature.node.kubernetes.io/pci-10de.present
+     || oc get nodes -oname --ignore-not-found=false -l feature.node.kubernetes.io/pci-0302_10de.present
+     || oc get nodes -oname --ignore-not-found=false -l feature.node.kubernetes.io/pci-0300_10de.present
+    ) | grep .
+
+- name: Get the list of nodes with GPUs
+  shell:
+    oc get nodes
+       -lnvidia.com/gpu.present=true
+       -o custom-columns=NAME:metadata.name
+       --no-headers
+    | cut -d. -f1
+  register: gpu_burn_gpu_nodes
+  failed_when: gpu_burn_gpu_nodes.stdout == ""
+
+- name: Create the entrypoint ConfigMap
+  command: oc apply -f "{{ gpu_burn_cm_entrypoint }}"
+
+- name: Create GPU burn Pods
+  with_items: "{{ gpu_burn_gpu_nodes.stdout_lines }}"
+  shell: |
+    set -eo pipefail;
+    GPU_NODE_HOSTNAME=$(echo '{{ item }}' );
+    echo "Hostname: $GPU_NODE_HOSTNAME";
+    oc delete pod/gpu-burn-$GPU_NODE_HOSTNAME -n default --ignore-not-found=true
+    cat "{{ gpu_burn_pod }}" \
+      | sed "s|{{ '{{' }} gpu_node_hostname {{ '}}' }}|$GPU_NODE_HOSTNAME|" \
+      | sed "s|{{ '{{' }} gpu_burn_time {{ '}}' }}|{{ gpu_burn_time }}|" \
+      | oc apply -f-
+
+- name: "Let the GPU burn Pods run {{ gpu_burn_time }}seconds"
+  command: "sleep {{ gpu_burn_time }}"
+
+- name: Wait for GPU burn Pods to complete
+  with_items: "{{ gpu_burn_gpu_nodes.stdout_lines }}"
+  command:
+    oc get pod/gpu-burn-{{ item }}
+       -n default
+       -o custom-columns=:.status.phase
+       --no-headers
+  register: gpu_burn_gpu_wait
+  until: gpu_burn_gpu_wait.stdout == "Succeeded" or gpu_burn_gpu_wait.stdout == "Error" or gpu_burn_gpu_wait.stdout == "Failed"
+  retries: 10
+  delay: 30
+
+- block:
+  - name: Ensure that the GPU burn Pods to complete successfully
+    with_items: "{{ gpu_burn_gpu_nodes.stdout_lines }}"
+    command:
+      oc get pod/gpu-burn-{{ item }}
+         -n default
+         -o custom-columns=:.status.phase
+         --no-headers
+    register: gpu_burn_gpu_test
+    failed_when: gpu_burn_gpu_test.stdout != "Succeeded"
+
+  - name: Ensure that no GPU was faulty
+    with_items: "{{ gpu_burn_gpu_nodes.stdout_lines }}"
+    shell:
+      oc logs pod/gpu-burn-{{ item }} -n default | grep FAULTY
+    register: gpu_burn_gpu_test_faulty
+    failed_when: gpu_burn_gpu_test_faulty.rc == 0
+
+  always:
+  - name: Save the logs of the GPU burn Pods
+    shell: oc logs pod/gpu-burn-{{ item }} -n default | grep -o "[^$(printf '\r')]*$"
+    with_items: "{{ gpu_burn_gpu_nodes.stdout_lines }}"
+    ignore_errors: true
+
+  - name: Save the full logs of the GPU burn Pods
+    shell: oc logs pod/gpu-burn-{{ item }} -n default > {{ artifact_extra_logs_dir }}/gpu_burn.{{ item }}.logs
+    with_items: "{{ gpu_burn_gpu_nodes.stdout_lines }}"
+    ignore_errors: true
+    when: artifact_extra_logs_dir | default('', true) | trim != ''
+
+  - name: Cleanup the GPU burn Pods
+    command: oc delete pod/gpu-burn-{{ item }} -n default
+    with_items: "{{ gpu_burn_gpu_nodes.stdout_lines }}"
+    ignore_errors: true
+
+  - name: Delete the entrypoint ConfigMap
+    command: oc delete -f "{{ gpu_burn_cm_entrypoint }}"

--- a/roles/gpu_burn/vars/main.yml
+++ b/roles/gpu_burn/vars/main.yml
@@ -1,0 +1,5 @@
+gpu_burn_cm_entrypoint: roles/gpu_burn/files/gpu_burn_cm_entrypoint.yml
+gpu_burn_pod: roles/gpu_burn/files/gpu_burn_pod.yml
+
+# time argument for GPU burn, in seconds
+gpu_burn_time: 300

--- a/toolbox/gpu-operator/run_gpu_burn.sh
+++ b/toolbox/gpu-operator/run_gpu_burn.sh
@@ -1,0 +1,16 @@
+#! /bin/bash -e
+
+THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+source ${THIS_DIR}/../_common.sh
+
+
+if [ "$#" -gt 1 ]; then
+    echo "FATAL: expected 0 or 1 parameter ... (got $#: '$@')"
+    echo "Usage: $0 [gpu-burn runtime]"
+    exit 1
+elif [ "$#" -eq 1 ]; then
+    ANSIBLE_OPTS="${ANSIBLE_OPTS} -e gpu_burn_time=$1"
+    echo "Running GPU Burn for ${1} seconds."
+fi
+
+exec ansible-playbook ${INVENTORY_ARG} ${ANSIBLE_OPTS} playbooks/gpu-burn.yml


### PR DESCRIPTION
* 4dd82ec - callback_plugins/human_log.py: correctly group 'task.get_path()' with its task logs


---

* 16dd890 - callback_plugins/human_log.py: improve readability

The task output now looks like this:

```
---

---
roles/nv_gpu/tasks/ci_checks.yml:4
TASK: nv_gpu : CRD check - Ci mode

<command> oc get crds/clusterpolicies.nvidia.com

<stdout> NAME                         CREATED AT
<stdout> clusterpolicies.nvidia.com   2021-03-08T09:27:30Z

Monday 08 March 2021  10:48:52 +0100 (0:00:01.961)       0:00:04.545 **********
```

or when it fails:
```
---

---
roles/nv_gpu/tasks/ci_checks.yml:15
TASK: nv_gpu : Ensure that NFD found nodes with GPU labels
----- FAILED ----
msg: non-zero return code

<command> (   oc get nodes -oname --ignore-not-found=false -l feature.node.kubernetes.io/pci-10de.present || oc get nodes -oname --ignore-not-found=false -l feature.node.kubernetes.io/pci-0302_10de.present || oc get nodes -oname --ignore-not-found=false -l feature.node.kubernetes.io/pci-0300_10de.present ) | grep .

----- FAILED ----

Monday 08 March 2021  10:51:38 +0100 (0:00:00.812)       0:00:05.870 **********
```

---

* 54c9a62 - callback_plugins/human_log.py: improve to handle ansible 'with_items' loops


---

* 8a0d4f5 - toolbox: add toolbox/gpu-operator/run_gpu_burn.sh script

---

* 8bfc7a0 - build/root/usr/local/bin/run: call gpu-burn in the CI tests
