### PR TITLE
roles/nv_gpu/tasks/install_nv.yml: rewrite 'Find the GPU Operator OperatorHub InstallPlan'

### DIFF
--- a/roles/nv_gpu/tasks/install_nv.yml
+++ b/roles/nv_gpu/tasks/install_nv.yml
@@ -47,11 +47,12 @@
     warn: false # don't warn about using sed here
 
 - name: "Find the GPU Operator OperatorHub InstallPlan"
+  # TODO: use 'oc get installplan -loperators.coreos.com/gpu-operator-certified.openshift-operators'
+  # when we get rid of OCP 4.5 support
   command:
-    oc get installplan
-      -oname
-      -loperators.coreos.com/gpu-operator-certified.openshift-operators
-      -n openshift-operators
+    oc get Subscription/gpu-operator-certified
+       -n openshift-operators
+       -ojsonpath={@.status.installPlanRef.name}
   register: gpu_operator_installplan_name
   until: gpu_operator_installplan_name.stdout != ""
   retries: 150
@@ -59,7 +60,7 @@
 
 - name: "Approve the GPU Operator OperatorHub InstallPlan"
   command:
-    oc patch {{ gpu_operator_installplan_name.stdout }}
+    oc patch InstallPlan/{{ gpu_operator_installplan_name.stdout }}
        -n openshift-operators
        --type merge
        --patch '{"spec":{"approved":true}}'

--- a/roles/nv_gpu/tasks/install_nv.yml
+++ b/roles/nv_gpu/tasks/install_nv.yml
@@ -70,8 +70,8 @@
     oc get  ClusterServiceVersion/{{ gpu_operator_csv_name }}
       -oname
       -n openshift-operators
-  register: gpu_operator_installplan_name
-  until: gpu_operator_installplan_name.stdout != ""
+  register: gpu_operator_wait_csv
+  until: gpu_operator_wait_csv.stdout != ""
   retries: 20
   delay: 30
 


### PR DESCRIPTION
The old way (using `-loperators.coreos.com/gpu-operator-certified.openshift-operators`)
wasn't supported in OCP 4.5, causing the retry loop to fail.