### PR TITLE
roles/nv_gpu/tasks/install_nv.yml: get debug logs when InstallPlan lookup fails

### DIFF
--- a/roles/nv_gpu/tasks/install_nv.yml
+++ b/roles/nv_gpu/tasks/install_nv.yml
@@ -58,35 +58,43 @@
     until: gpu_operator_installplan_name.stdout != ""
     retries: 20
     delay: 30
+
+  - name: "Approve the GPU Operator OperatorHub InstallPlan"
+    command:
+      oc patch InstallPlan/{{ gpu_operator_installplan_name.stdout }}
+         -n openshift-operators
+         --type merge
+         --patch '{"spec":{"approved":true}}'
+
+  - name: "Wait for the GPU Operator OperatorHub ClusterServiceVersion"
+    command:
+      oc get ClusterServiceVersion/{{ gpu_operator_csv_name }}
+         -oname
+         -n openshift-operators
+    register: gpu_operator_wait_csv
+    until: gpu_operator_wait_csv.stdout != ""
+    retries: 40
+    delay: 30
+
   rescue:
   - name: Capture the Catalog Operator logs (debug)
-    shell:
-      oc logs deployment.apps/catalog-operator
-         -n openshift-operator-lifecycle-manager
-      | grep gpu-operator-certified
-      | cut -b29- | uniq
+    command: oc logs deployment.apps/catalog-operator -n openshift-operator-lifecycle-manager
+    register: catalog_operator_logs
+    when: artifact_extra_logs_dir | default('', true) | trim != ''
     ignore_errors: true
+    no_log: true
 
-  - name: Fail because the InstallPlan was not created
-    fail:
-      msg: Failed because the InstallPlan was not created
+  - copy:
+      dest: "{{ artifact_extra_logs_dir }}/catalog_operator.logs"
+      content: "{{ catalog_operator_logs.stdout }}"
+    when: artifact_extra_logs_dir | default('', true) | trim != ''
 
-- name: "Approve the GPU Operator OperatorHub InstallPlan"
-  command:
-    oc patch InstallPlan/{{ gpu_operator_installplan_name.stdout }}
-       -n openshift-operators
-       --type merge
-       --patch '{"spec":{"approved":true}}'
+  - debug:
+      msg: "The logs of Catalog-operator have been saved in {{ artifact_extra_logs_dir }}/catalog_operator.logs"
+    when: artifact_extra_logs_dir | default('', true) | trim != ''
 
-- name: "Wait for the GPU Operator OperatorHub ClusterServiceVersion"
-  command:
-    oc get  ClusterServiceVersion/{{ gpu_operator_csv_name }}
-      -oname
-      -n openshift-operators
-  register: gpu_operator_wait_csv
-  until: gpu_operator_wait_csv.stdout != ""
-  retries: 20
-  delay: 30
+  - fail:
+      msg: Failed because the GPU Operator could not be install from the Catalog Operator
 
 - name: Create a temporary file for the GPU Operator clusterpolicy
   ansible.builtin.tempfile:

--- a/roles/nv_gpu/tasks/install_nv.yml
+++ b/roles/nv_gpu/tasks/install_nv.yml
@@ -46,17 +46,30 @@
   args:
     warn: false # don't warn about using sed here
 
-- name: "Find the GPU Operator OperatorHub InstallPlan"
-  # TODO: use 'oc get installplan -loperators.coreos.com/gpu-operator-certified.openshift-operators'
-  # when we get rid of OCP 4.5 support
-  command:
-    oc get Subscription/gpu-operator-certified
-       -n openshift-operators
-       -ojsonpath={@.status.installPlanRef.name}
-  register: gpu_operator_installplan_name
-  until: gpu_operator_installplan_name.stdout != ""
-  retries: 150
-  delay: 30
+- block:
+  - name: Find the GPU Operator OperatorHub InstallPlan
+    # TODO: use 'oc get installplan -loperators.coreos.com/gpu-operator-certified.openshift-operators'
+    # when we get rid of OCP 4.5 support
+    command:
+      oc get Subscription/gpu-operator-certified
+         -n openshift-operators
+         -ojsonpath={@.status.installPlanRef.name}
+    register: gpu_operator_installplan_name
+    until: gpu_operator_installplan_name.stdout != ""
+    retries: 20
+    delay: 30
+  rescue:
+  - name: Capture the Catalog Operator logs (debug)
+    shell:
+      oc logs deployment.apps/catalog-operator
+         -n openshift-operator-lifecycle-manager
+      | grep gpu-operator-certified
+      | cut -b29- | uniq
+    ignore_errors: true
+
+  - name: Fail because the InstallPlan was not created
+    fail:
+      msg: Failed because the InstallPlan was not created
 
 - name: "Approve the GPU Operator OperatorHub InstallPlan"
   command:


### PR DESCRIPTION
Example of what we can find in the catalog operator logs:


> 1 queueinformer_operator.go:290] sync "openshift-operators" failed: constraints not satisfiable: no operators found matching the 
subscription criteria for gpu-operator-certified, a subscription to package gpu-operator-certified exists in the namespace

> 1 event.go:282] Event(v1.ObjectReference{Kind:"Namespace", Namespace:"", Name:"openshift-operators", UID:"f03ec97c-fdd7-4815-9bb8-ef14f588042d", APIVersion:"v1", ResourceVersion:"57004", FieldPath:""}): type: 'Warning' reason: 'ResolutionFailed' constraints not satisfiable: no operators found matching the subscription criteria for gpu-operator-certified, a subscription to package gpu-operator-certified exists in the namespace
```