### PR TITLE
Prepare artifact directory in toolbox/_common.sh

### DIFF
--- a/build/root/usr/local/bin/run
+++ b/build/root/usr/local/bin/run
@@ -161,6 +161,12 @@ prepare_ansible
 
 #############
 
+if [ -z "${ARTIFACT_DIR:-}" ]; then
+    echo "No ARTIFACT_DIR configured."
+else
+    echo "ARTIFACT_DIR=$ARTIFACT_DIR"
+fi
+
 prepare_cluster_for_gpu_operator() {
     entitle
 

--- a/build/root/usr/local/bin/run
+++ b/build/root/usr/local/bin/run
@@ -223,11 +223,6 @@ case ${1:-} in
     "gpu-ci-undeploy")
         toolbox/gpu-operator/undeploy_from_operatorhub.sh
 	;;
-
-    "psap-ci")
-	exec ansible-playbook ${ANSIBLE_OPTS} playbooks/openshift-psap-ci.yml
-	;;
-
     -*)
         echo "Unknown option: ${1:-}"
         exit 1

--- a/build/root/usr/local/bin/run
+++ b/build/root/usr/local/bin/run
@@ -115,56 +115,17 @@ entitle() {
     fi
 }
 
-prepare_ansible() {
-    if [ -z "${ARTIFACT_DIR:-}" ]; then
-        export ARTIFACT_DIR="/tmp/ci-artifacts/$(date +%Y%m%d_%H%M)"
-        echo "No ARTIFACT_DIR configured, using $ARTIFACT_DIR"
-    fi
-    echo "Using ${ARTIFACT_DIR} for storing artifact files."
-
-    ARTIFACT_EXTRA_LOGS_DIR="${ARTIFACT_DIR}/${1:-}/extra_logs"
-
-    mkdir -p "${ARTIFACT_EXTRA_LOGS_DIR}"
-    echo "Using ${ARTIFACT_EXTRA_LOGS_DIR} for storing extra log files."
-
-    if [ -z "${ANSIBLE_LOG_PATH:-}" ]; then
-        export ANSIBLE_LOG_PATH="${ARTIFACT_DIR}/ansible/logs"
-    fi
-    echo "Using ${ANSIBLE_LOG_PATH} for storing ansible logs."
-
-    mkdir -p "$(dirname "${ANSIBLE_LOG_PATH}")"
-
-    if [ -z "${ANSIBLE_CACHE_PLUGIN_CONNECTION:-}" ]; then
-        export ANSIBLE_CACHE_PLUGIN_CONNECTION="${ARTIFACT_DIR}/ansible/facts"
-    fi
-    echo "Using ${ANSIBLE_CACHE_PLUGIN_CONNECTION} for storing ansible facts."
-
-    mkdir -p "${ANSIBLE_CACHE_PLUGIN_CONNECTION}"
-    # ---
-
-    ANSIBLE_OPTS=${ANSIBLE_OPTS:--v}
-    ANSIBLE_OPTS="${ANSIBLE_OPTS} \
-                  ${EXTRA_ANSIBLE_OPTS:-} \
-                  -e artifact_extra_logs_dir=${ARTIFACT_EXTRA_LOGS_DIR}"
-
-    export ANSIBLE_OPTS
-    export EXTRA_ANSIBLE_OPTS=
-
-    echo "ANSIBLE_OPTS='$ANSIBLE_OPTS'"
-}
-
 ##############
 
 prechecks
 ci_banner
-prepare_ansible
 
 #############
 
 if [ -z "${ARTIFACT_DIR:-}" ]; then
     echo "No ARTIFACT_DIR configured."
 else
-    echo "ARTIFACT_DIR=$ARTIFACT_DIR"
+    echo "Using '$ARTIFACT_DIR' to store the test artifacts"
 fi
 
 prepare_cluster_for_gpu_operator() {

--- a/toolbox/_common.sh
+++ b/toolbox/_common.sh
@@ -7,11 +7,47 @@ set -o nounset
 
 ANSIBLE_OPTS="${ANSIBLE_OPTS:--vv}"
 
+### OpenShift version
+
 if [ ! -z "${OCP_VERSION:-}" ]; then
     ANSIBLE_OPTS="$ANSIBLE_OPTS -e openshift_release=$OCP_VERSION"
 fi
 
-export ANSIBLE_CACHE_PLUGIN_CONNECTION="${ANSIBLE_CACHE_PLUGIN_CONNECTION:-/tmp/ansible/facts}"
-echo "Using ${ANSIBLE_CACHE_PLUGIN_CONNECTION} for storing ansible facts."
+### Artifacts directory
+
+if [ -z "${ARTIFACT_DIR:-}" ]; then
+    export ARTIFACT_DIR="/tmp/ci-artifacts_$(date +%Y%m%d)"
+    echo "No ARTIFACT_DIR configured, using $ARTIFACT_DIR to store the test artifacts"
+else
+    echo "Using '$ARTIFACT_DIR' to store the test artifacts"
+fi
+
+
+TOOLBOX_PATH="${0##*toolbox/}"
+ARTIFACT_DIRNAME="${TOOLBOX_PATH/\//__}"
+ARTIFACT_EXTRA_LOGS_DIR="${ARTIFACT_DIR}/$(date +%H%M%S)_${ARTIFACT_DIRNAME}"
+export ARTIFACT_EXTRA_LOGS_DIR
+
+mkdir -p "${ARTIFACT_EXTRA_LOGS_DIR}"
+echo "Using '${ARTIFACT_EXTRA_LOGS_DIR}' to store extra log files."
+ANSIBLE_OPTS="$ANSIBLE_OPTS -e artifact_extra_logs_dir=${ARTIFACT_EXTRA_LOGS_DIR}"
+
+### Ansible logs  directory
+
+if [ -z "${ANSIBLE_LOG_PATH:-}" ]; then
+    export ANSIBLE_LOG_PATH="${ARTIFACT_EXTRA_LOGS_DIR}/ansible_logs"
+fi
+echo "Using '${ANSIBLE_LOG_PATH}' to store ansible logs."
+mkdir -p "$(dirname "${ANSIBLE_LOG_PATH}")"
+
+# Ansible caching directory
+
+if [ -z "${ANSIBLE_CACHE_PLUGIN_CONNECTION:-}" ]; then
+    export ANSIBLE_CACHE_PLUGIN_CONNECTION="${ARTIFACT_EXTRA_LOGS_DIR}/ansible_facts"
+fi
+echo "Using '${ANSIBLE_CACHE_PLUGIN_CONNECTION}' to store ansible facts."
+mkdir -p "${ANSIBLE_CACHE_PLUGIN_CONNECTION}"
+
+###
 
 cd $TOP_DIR


### PR DESCRIPTION
Prepare artifact directory in `toolbox/_common.sh`, and create one directory (with a hour/minute timestamp) per toolbox operation, so that we can better understand what logs belong to which toolbox task.