### PR TITLE
Fix 1.4.0 and small refactoring steps

### DIFF
--- a/build/root/usr/local/bin/run
+++ b/build/root/usr/local/bin/run
@@ -153,8 +153,6 @@ validate_gpu_operator_deployment() {
 
 set -x
 case ${1:-} in
-    "gpu-commit-ci")
-        ;&
     "gpu-operator_test-master-branch")
         CI_IMAGE_GPU_COMMIT_CI_REPO="${2:-https://github.com/NVIDIA/gpu-operator.git}"
         CI_IMAGE_GPU_COMMIT_CI_REF="${3:-master}"
@@ -170,8 +168,6 @@ case ${1:-} in
         validate_gpu_operator_deployment
 	exit 0
         ;;
-    "gpu-ci")
-        ;&
     "gpu-operator_test-operatorhub")
         OPERATOR_VERSION="${2:-}"
         prepare_cluster_for_gpu_operator
@@ -179,8 +175,6 @@ case ${1:-} in
         validate_gpu_operator_deployment
 	exit 0
         ;;
-    "gpu-helm-ci")
-        ;&
     "gpu-operator_test-helm")
         if [ -z "${2:-}" ]; then
             echo "FATAL: $0 $1 should receive the operator version as parameter."
@@ -194,9 +188,6 @@ case ${1:-} in
         validate_gpu_operator_deployment
         exit 0
         ;;
-
-    "gpu-ci-undeploy")
-        ;&
     "gpu-operator_undeploy-operatorhub")
         toolbox/gpu-operator/undeploy_from_operatorhub.sh
         exit 0

--- a/build/root/usr/local/bin/run
+++ b/build/root/usr/local/bin/run
@@ -129,7 +129,7 @@ else
 fi
 
 prepare_cluster_for_gpu_operator() {
-    toolbox/capture_environment.sh
+    toolbox/cluster/capture_environment.sh
 
     entitle
 

--- a/roles/gpu_operator_wait_deployment/tasks/main.yml
+++ b/roles/gpu_operator_wait_deployment/tasks/main.yml
@@ -25,10 +25,11 @@
 
 - name: Ensure that nvidia-device-plugin-validation Pod has ran successfully
   command:
-    oc get pods --field-selector=status.phase=Succeeded
-                -n gpu-operator-resources
-                -oname
-                --no-headers
+    oc get pods
+      --field-selector=metadata.name=nvidia-device-plugin-validation
+      --field-selector=status.phase=Succeeded
+      -n gpu-operator-resources
+      -oname --no-headers
   register: has_deviceplugin_validation_pod
   until:
   - has_deviceplugin_validation_pod.stdout == "pod/nvidia-device-plugin-validation"

--- a/toolbox/_common.sh
+++ b/toolbox/_common.sh
@@ -36,7 +36,7 @@ ANSIBLE_OPTS="$ANSIBLE_OPTS -e artifact_extra_logs_dir=${ARTIFACT_EXTRA_LOGS_DIR
 ### Ansible logs  directory
 
 if [ -z "${ANSIBLE_LOG_PATH:-}" ]; then
-    export ANSIBLE_LOG_PATH="${ARTIFACT_EXTRA_LOGS_DIR}/_ansible_logs"
+    export ANSIBLE_LOG_PATH="${ARTIFACT_EXTRA_LOGS_DIR}/_ansible.log"
 fi
 echo "Using '${ANSIBLE_LOG_PATH}' to store ansible logs."
 mkdir -p "$(dirname "${ANSIBLE_LOG_PATH}")"

--- a/toolbox/cluster/capture_environment.sh
+++ b/toolbox/cluster/capture_environment.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
 THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-source ${THIS_DIR}/_common.sh
+source ${THIS_DIR}/../_common.sh
 
 exec ansible-playbook ${ANSIBLE_OPTS} playbooks/capture_environment.yml

--- a/toolbox/gpu-operator/diagnose.sh
+++ b/toolbox/gpu-operator/diagnose.sh
@@ -42,7 +42,7 @@ EOF
 Problem detected with '$@', capturing extra information...
 EOF
 
-    toolbox/capture_environment.sh > /dev/null || true
+    toolbox/cluster/capture_environment.sh > /dev/null || true
     toolbox/gpu-operator/capture_deployment_state.sh > /dev/null || true
 
     cat <<EOF


### PR DESCRIPTION
* d627317 - gpu_operator_wait_deployment: fix to properly wait for 1.4.0 deployment

Test of 1.4.0 was failing because multiple Pod showed up, while we
expected only one:

```
<command> oc get pods --field-selector=status.phase=Succeeded -n gpu-operator-resources -oname --no-headers
==> FAILED attempt #15/15
<stdout> pod/nvidia-device-plugin-validation
<stdout> pod/nvidia-driver-validation
```

---

* e2417ba - toolbox: change ansible log file to '_ansible.log'


---

* d67c7ea - toolbox: move capture_environment.sh to cluster/capture_environment.sh

---

* ccd9cec - build/root/usr/local/bin/run: remove old flags