### PR TITLE
cluster_upgrade_to_image: new role

### DIFF
--- a/build/root/usr/local/bin/run
+++ b/build/root/usr/local/bin/run
@@ -192,6 +192,14 @@ case ${1:-} in
         toolbox/gpu-operator/undeploy_from_operatorhub.sh
         exit 0
 	;;
+    "cluster-upgrade")
+        if [ -z "${CLUSTER_UPGRADE_TARGET_IMAGE:-}" ]; then
+            echo "FATAL: CLUSTER_UPGRADE_TARGET_IMAGE must be provided to upgrade the cluster"
+            exit 1
+        fi
+        toolbox/cluster/upgrade_to_image.sh "$CLUSTER_UPGRADE_TARGET_IMAGE"
+        exit 0
+        ;;
     -*)
         echo "Unknown option: ${1:-}"
         exit 1

--- a/playbooks/cluster_upgrade_to_image.yml
+++ b/playbooks/cluster_upgrade_to_image.yml
@@ -1,0 +1,7 @@
+---
+- name: (force) upgrade the cluster to a given version
+  hosts: localhost
+  connection: local
+  gather_facts: true
+  roles:
+  - cluster_upgrade_to_image

--- a/roles/cluster_upgrade_to_image/defaults/main/config.yml
+++ b/roles/cluster_upgrade_to_image/defaults/main/config.yml
@@ -1,0 +1,2 @@
+# the image to which the cluster will be upgraded
+cluster_upgrade_image: ""

--- a/roles/cluster_upgrade_to_image/meta/main.yml
+++ b/roles/cluster_upgrade_to_image/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - role: check_deps

--- a/roles/cluster_upgrade_to_image/tasks/main.yml
+++ b/roles/cluster_upgrade_to_image/tasks/main.yml
@@ -1,0 +1,72 @@
+---
+- name: Check that cluster_upgrade_image  is defined
+  fail: msg="Bailing out. This play requires 'cluster_upgrade_image' to be defined"
+  when: cluster_upgrade_image is undefined
+
+- name: Get the current version of the cluster
+  command: oc get clusterversion
+
+- name: Store old OpenShift version identifier
+  shell:
+    set -o pipefail;
+    oc version -o json
+       | jq --raw-output '.openshiftVersion'
+       > {{ artifact_extra_logs_dir }}/ocp.before.version
+  register: ocp_full_version
+
+- name: Store old OpenShift YAML version
+  shell:
+    oc version -oyaml
+       > {{ artifact_extra_logs_dir }}/ocp_version.before.yml
+
+- name: Trigger the cluster upgrade
+  command:
+    oc adm upgrade '--to-image={{ cluster_upgrade_image }}'
+      --allow-explicit-upgrade
+      --force=true
+      --allow-upgrade-with-warnings
+
+- name: Wait a bit for the upgrade to start
+  command: sleep 30
+
+- name: Wait for the end of the upgrade
+  command:
+    oc get ClusterVersion/version -o jsonpath='{.status.history[0].state}{"\n"}'
+  register: cluster_version
+  until:
+  - cluster_version.rc == 0
+  - cluster_version.stdout
+  - cluster_version.stdout != "Partial"
+  retries: 90
+  delay: 60
+
+- name: Get ClusterVersion status
+  command: oc get ClusterVersion/version
+
+- name: Store new OpenShift version identifier
+  shell:
+    set -o pipefail;
+    oc version -o json
+       | jq --raw-output '.openshiftVersion'
+       > {{ artifact_extra_logs_dir }}/ocp.after.version
+  register: ocp_full_version
+
+- name: Store new OpenShift YAML version
+  shell:
+    oc version -oyaml
+       > {{ artifact_extra_logs_dir }}/ocp_version.after.yml
+
+- name: Get ClusterVersion description
+  shell:
+    oc describe ClusterVersion/version > {{ artifact_extra_logs_dir }}/ClusterVersion.descr
+
+- name: Get ClusterVersion YAML
+  shell:
+    oc get -oyaml ClusterVersion/version > {{ artifact_extra_logs_dir }}/ClusterVersion.yml
+
+- name: Ensure that the upgrade succeeded
+  fail: msg="Upgrade failed".
+  when: cluster_version.stdout != "Completed"
+
+- name: Cluster upgrade finished
+  debug: msg="Upgrade succeeded"

--- a/toolbox/cluster/upgrade_to_image.sh
+++ b/toolbox/cluster/upgrade_to_image.sh
@@ -1,0 +1,13 @@
+#! /bin/bash -e
+
+THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+source ${THIS_DIR}/../_common.sh
+
+if [ -z "${1-}" ]; then
+    echo "FATAL: An image must be provided to upgrade the cluster..."
+    exit 1
+fi
+
+ANSIBLE_OPTS="${ANSIBLE_OPTS} -e cluster_upgrade_image=${1}"
+
+exec ansible-playbook ${ANSIBLE_OPTS} playbooks/cluster_upgrade_to_image.yml


### PR DESCRIPTION
This PR adds a new role for triggering an upgrade of OpenShift to a given image.
At the moment, no check is performed against the target image, and the upgrade is forced.

An upgrade hook is added to the CI entrypoint: `run cluster-upgrade`, which expects to receive the target image with `CLUSTER_UPGRADE_TARGET_IMAGE` environment variable.

The CI configuration is being updated with this PR https://github.com/openshift/release/pull/17498
It will remain as a presubmit hook until the GPU Operator supports cluster upgrade without uninstalling the operator.