### PR TITLE
toolbox: new script gpu-operator/must-gather.sh

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -23,6 +23,9 @@ RUN yum install -y \
 	rm -rf $HOME/.cache && \
 	rm -rf /var/cache/yum
 
+# For /usr/bin/gather
+RUN mkdir /must-gather && chmod 777 /must-gather
+
 # Set up Ansible
 RUN mkdir -p /etc/ansible \
     && echo "localhost ansible_connection=local" > /etc/ansible/hosts
@@ -40,6 +43,7 @@ ENV USER_NAME=psap-ci-runner \
     INSIDE_CI_IMAGE="y"
 
 COPY . ${HOME}/
+RUN ln -s ${HOME}/toolbox/gpu-operator/must-gather.sh /usr/bin/gather
 
 # Ensure directory permissions are properly set
 RUN mkdir -p ${HOME}/.ansible/tmp && chmod 777 ${HOME} -R

--- a/build/root/usr/local/bin/run
+++ b/build/root/usr/local/bin/run
@@ -143,15 +143,22 @@ prepare_cluster_for_gpu_operator() {
     fi
 }
 
+collect_must_gather() {
+    /usr/bin/gather
+    DEST="${ARTIFACT_DIR}/$(date +%H%M%S)__gpu-operator__must-gather"
+    mkdir -p "$DEST"
+    cp -r /must-gather/* "$DEST"
+}
+
 validate_gpu_operator_deployment() {
-    trap toolbox/gpu-operator/must-gather.sh ERR
+    trap collect_must_gather ERR
 
     toolbox/gpu-operator/wait_deployment.sh
     toolbox/gpu-operator/run_gpu_burn.sh
 
     trap - ERR
 
-    toolbox/gpu-operator/must-gather.sh
+    collect_must_gather
 }
 
 set -x

--- a/build/root/usr/local/bin/run
+++ b/build/root/usr/local/bin/run
@@ -144,11 +144,14 @@ prepare_cluster_for_gpu_operator() {
 }
 
 validate_gpu_operator_deployment() {
-    trap toolbox/gpu-operator/capture_deployment_state.sh ERR
+    trap toolbox/gpu-operator/must-gather.sh ERR
 
     toolbox/gpu-operator/wait_deployment.sh
     toolbox/gpu-operator/run_gpu_burn.sh
-    toolbox/gpu-operator/capture_deployment_state.sh
+
+    trap - ERR
+
+    toolbox/gpu-operator/must-gather.sh
 }
 
 set -x

--- a/roles/gpu_operator_deploy_from_operatorhub/tasks/main.yml
+++ b/roles/gpu_operator_deploy_from_operatorhub/tasks/main.yml
@@ -40,6 +40,9 @@
       gpu_operator_csv_name: "{{ gpu_operator_csv_name_cmd.stdout }}"
   when: gpu_operator_operatorhub_version != ''
 
+- name: Store the version of the GPU Operator that will be installed
+  shell: echo "{{ gpu_operator_csv_name }}" > {{ artifact_extra_logs_dir }}/gpu_operator_csv_name.txt
+
 - name: "Create the OperatorHub subscription for {{ gpu_operator_csv_name }}"
   debug: msg="{{ gpu_operator_csv_name }}"
 

--- a/toolbox/gpu-operator/must-gather.sh
+++ b/toolbox/gpu-operator/must-gather.sh
@@ -1,0 +1,78 @@
+#! /bin/bash -ex
+
+if [[ "$0" == "/usr/bin/gather" ]]; then
+    echo "Running as must-gather plugin image"
+    export ARTIFACT_DIR=/must-gather
+
+    THIS_DIR="$(dirname "$(readlink -f "$0")")"
+else
+    # avoid sourcing _common.sh and messing up different env variables
+    if [[ -z "${ARTIFACT_DIR:-}" ]]; then
+        export ARTIFACT_DIR="/tmp/ci-artifacts_$(date +%Y%m%d)"
+        echo "Using '$ARTIFACT_DIR' to store the test artifacts (default value for ARTIFACT_DIR)."
+    else
+        echo "Using '$ARTIFACT_DIR' to store the test artifacts."
+    fi
+
+    export ARTIFACT_DIR="$ARTIFACT_DIR/$(date +%H%M%S)__gpu-operator__must-gather"
+    THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+fi
+
+mkdir -p "$ARTIFACT_DIR"
+cd $THIS_DIR/../../
+
+MUST_GATHER_LOGS_DIR="$ARTIFACT_DIR"
+MUST_GATHER_INSPECT_DIR="$ARTIFACT_DIR/oc_adm_inspect"
+
+exec 1> >(tee $MUST_GATHER_LOGS_DIR/_must-gather.log)
+exec 2> >(tee $MUST_GATHER_LOGS_DIR/_must-gather.stderr.log >&2)
+
+# product
+cat <<EOF > $MUST_GATHER_LOGS_DIR/version
+ci-artifacts/toolbox/gpu-operator/must-gather
+$(git describe HEAD --long --always)
+EOF
+
+git show -s > $MUST_GATHER_LOGS_DIR/version.git_commit
+
+# Named resource list, eg. ns/openshift-config
+named_resources=()
+named_resources+=(ns/gpu-operator-resources)
+named_resources+=(ns/openshift-nfd)
+
+echo "# resources to inspect: ${named_resources[@]}"
+
+for named_res in "${named_resources[@]}"; do
+    # Run the Collection of Resources using inspect
+    oc adm inspect --dest-dir=$MUST_GATHER_INSPECT_DIR $named_res -n default || true
+done
+
+for res_type in InstallPlan ClusterServiceVersion; do
+    while read line; do
+        name=$res_type/$(echo "$line" | awk '{ print $2 }')
+        ns=$(echo "$line" | awk '{ print $1 }')
+        if [[ "$ns" != openshift-nfd && "$ns" != openshift-operators ]]; then
+            echo "# skip '$name -n $ns' (not interested in this namespace)"
+            continue
+        fi
+        echo "# $res_type to inspect: $name -n $ns"
+        oc adm inspect --dest-dir=$MUST_GATHER_INSPECT_DIR $name -n $ns || true
+    done <<< $(oc get --no-headers $res_type -A | egrep '(nfd|gpu-operator)')
+done
+
+for clusterpolicy_name in $(oc get clusterpolicy -oname || true); do
+    echo "# clusterpolicy to inspect: $clusterpolicy_name"
+    oc adm inspect --dest-dir=$MUST_GATHER_INSPECT_DIR $clusterpolicy_name || true
+done
+
+# ---
+
+toolbox/gpu-operator/diagnose.sh \
+    --run-all \
+    1> >(tee $MUST_GATHER_LOGS_DIR/diagnose.log) \
+    2> >(tee $MUST_GATHER_LOGS_DIR/diagnose.stderr.log >&2)
+
+# ---
+echo
+echo
+echo "All done! Results have been gathered in '$ARTIFACT_DIR'"


### PR DESCRIPTION
This PR creats a `must-gather` plugin image for the GPU Operator.

The first patch is focused on collecting all the relevant information.

The second patch is the `must-gather` entrypoint (see [here](https://github.com/openshift/enhancements/blob/master/enhancements/oc/must-gather.md) and [there](https://github.com/openshift/must-gather)) and image recipe.