### PR TITLE
gpu_operator_deploy_from_operatorhub: Capture the state of the CatalogSource/certified-operators

### DIFF
--- a/roles/gpu_operator_deploy_from_operatorhub/tasks/main.yml
+++ b/roles/gpu_operator_deploy_from_operatorhub/tasks/main.yml
@@ -1,3 +1,10 @@
+- name: Capture the state of the CatalogSource/certified-operators (debug)
+  command:
+    oc get -oyaml CatalogSource/certified-operators
+       -n openshift-marketplace
+       -ojsonpath={.status.connectionState.lastObservedState}{"\n"}
+  failed_when: false
+
 - name: Ensure that the GPU Operator PackageManifest exists
   command: oc get packagemanifests/gpu-operator-certified -n openshift-marketplace
 


### PR DESCRIPTION

This error happens every once in a while:
 ```
<command> oc get packagemanifests/gpu-operator-certified -n openshift-marketplace
<stderr> Error from server (NotFound): packagemanifests.packages.operators.coreos.com "gpu-operator-certified" not found
```
I would like to see if the `CatalogSource/certified-operators` is not ready when it happens.
