### PR TITLE
gpu_operator_deploy_from_operatorhub: Capture the state of the CatalogSource/certified-operators

### DIFF
--- a/roles/gpu_operator_deploy_from_operatorhub/tasks/main.yml
+++ b/roles/gpu_operator_deploy_from_operatorhub/tasks/main.yml
@@ -2,7 +2,7 @@
   command:
     oc get -oyaml CatalogSource/certified-operators
        -n openshift-marketplace
-       -ojsonpath={.status.connectionState.lastObservedState}{"\n"}
+       '-ojsonpath={.status.connectionState.lastObservedState}{"\n"}'
   failed_when: false
 
 - name: Ensure that the GPU Operator PackageManifest exists


### PR DESCRIPTION
Fix ansible escaping of `"`