### PR TITLE
fix entitlement file path

### DIFF
--- a/roles/entitlement_test_wait/files/entitlement-tester_entrypoint.yml
+++ b/roles/entitlement_test_wait/files/entitlement-tester_entrypoint.yml
@@ -20,7 +20,7 @@ data:
     echo
 
     echo "# md5sum of entitlement file (debug)"
-    if md5sum /etc/rhsm-host/rhsm.conf /etc/pki/entitlement-host/entitlement{,-key}.pem; then
+    if md5sum /etc/rhsm/rhsm.conf /etc/pki/entitlement/entitlement{,-key}.pem; then
       echo "# INFO: entitlement files found"
     else
       echo "#"


### PR DESCRIPTION
fix entitlement file path, according to https://github.com/openshift-psap/ci-artifacts/blob/master/roles/entitlement_deploy/files/mc_rhsm.yml#L17, https://github.com/openshift-psap/ci-artifacts/blob/master/roles/entitlement_deploy/files/mc_pem.yml#L17 and https://github.com/openshift-psap/ci-artifacts/blob/master/roles/entitlement_deploy/files/mc_pem.yml#L35


Signed-off-by: Feng Huang <fehuang@redhat.com>