### PR TITLE
nfd_deploy: use NFD version == OCP version (except for 4.8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,11 +137,12 @@ NFD
 ---
 
 - [x]  Deploy the NFD operator from OperatorHub:
+  - [x]  Control the install channel from the command-line
+
 ```
-toolbox/nfd/deploy_from_operatorhub.sh
+toolbox/nfd/deploy_from_operatorhub.sh [nfd_channel, eg: 4.7]
 toolbox/nfd/undeploy_from_operatorhub.sh
 ```
-  - [ ]  Control the channel to use from the command-line
 
 - [x] Test the NFD deployment
   - [x] test with the NFD if GPU nodes are available

--- a/roles/nfd_deploy/defaults/main/config.yml
+++ b/roles/nfd_deploy/defaults/main/config.yml
@@ -1,2 +1,2 @@
 ---
-nfd_channel: "{% if openshift_release == '4.5' %}4.5{% else %}4.6{% endif %}"
+nfd_channel: "{% if openshift_release == '4.8' %}4.7{% else %}{{ openshift_release }}{% endif %}"

--- a/roles/nfd_deploy/files/040_customresources.yml
+++ b/roles/nfd_deploy/files/040_customresources.yml
@@ -1,9 +1,0 @@
-# Operator version 4.6.0-202012161211.p0
-# Jan 18 2021
-apiVersion: nfd.openshift.io/v1alpha1
-kind: NodeFeatureDiscovery
-metadata:
-  name: nfd-master-server
-  namespace: openshift-nfd
-spec:
-  namespace: openshift-nfd

--- a/roles/nfd_deploy/tasks/main.yml
+++ b/roles/nfd_deploy/tasks/main.yml
@@ -1,3 +1,19 @@
+- name: Capture the state of the CatalogSource/certified-operators (debug)
+  command:
+    oc get -oyaml CatalogSource/certified-operators
+       -n openshift-marketplace
+       '-ojsonpath={.status.connectionState.lastObservedState}{"\n"}'
+  failed_when: false
+
+- name: Ensure that the NFD Operator PackageManifest exists
+  command: oc get packagemanifests/nfd -n openshift-marketplace
+
+- name: Save the NFD Operator PackageManifest (debug)
+  shell:
+    oc get packagemanifests/nfd -n openshift-marketplace -oyaml
+    > {{ artifact_extra_logs_dir }}/nfd_packagemanifest.yml
+  failed_when: false
+
 - name: Create the namespace for the NFD Operator
   command: oc apply -f "{{ nfd_operator_namespace }}"
 
@@ -12,10 +28,36 @@
   args:
     warn: false # don't warn about using sed here
 
+- name: "Wait for the NFD Operator OperatorHub ClusterServiceVersion"
+  command:
+    oc get ClusterServiceVersion
+       -oname
+       -n openshift-nfd
+  register: nfd_operator_csv_name
+  until: nfd_operator_csv_name.stdout != ""
+  retries: 40
+  delay: 30
+
+- name: Get the clusterpolicy of the NFD Operator from OperatorHub CSV
+  shell:
+    set -o pipefail;
+    oc get {{ nfd_operator_csv_name.stdout }}
+       -n openshift-nfd
+       -ojson
+    | jq -r '.metadata.annotations."alm-examples"'
+    | jq .[0]
+    | jq --arg  ns openshift-nfd '.metadata.namespace = $ns'
+    | jq --arg  ns openshift-nfd '.spec.namespace = $ns'
+    > {{ artifact_extra_logs_dir }}/nfd_cr.json
+  register: operatorhub_clusterpolicy
+  until: operatorhub_clusterpolicy.rc == 0
+  retries: 20
+  delay: 15
+
 - name: Create the NodeFeatureDiscovery CR for the NFD Operator
   block:
-    - name: Apply NodeFeatureDiscovery manifest
-      command: oc apply -f "{{ nfd_operator_cr }}"
+    - name: Create the NodeFeatureDiscovery CR
+      command: oc apply -f "{{ artifact_extra_logs_dir }}/nfd_cr.json"
       register: apply_nfd_cr
       until: apply_nfd_cr.rc != 1
       retries: 20

--- a/roles/nfd_deploy/vars/main/resources.yml
+++ b/roles/nfd_deploy/vars/main/resources.yml
@@ -3,4 +3,3 @@
 nfd_operator_namespace: roles/nfd_deploy/files/010_namespace.yml
 nfd_operator_operatorgroup: roles/nfd_deploy/files/020_operatorgroup.yml
 nfd_operator_operatorhub_sub: roles/nfd_deploy/files/030_operator_sub.yml
-nfd_operator_cr: roles/nfd_deploy/files/040_customresources.yml

--- a/roles/nfd_undeploy/tasks/main.yml
+++ b/roles/nfd_undeploy/tasks/main.yml
@@ -13,9 +13,6 @@
   when: operator_csv_name.rc == 0
   failed_when: false
 
-- name: Delete the NodeFeatureDiscovery CR of the NFD Operator
-  command: oc --ignore-not-found=true delete -f "{{ nfd_operator_cr }}"
-
 - name: Delete the CRD of the NFD Operator
   command: oc --ignore-not-found=true delete crd nodefeaturediscoveries.nfd.openshift.io
 

--- a/toolbox/nfd/deploy_from_operatorhub.sh
+++ b/toolbox/nfd/deploy_from_operatorhub.sh
@@ -3,4 +3,13 @@
 THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 source ${THIS_DIR}/../_common.sh
 
+if [ "$#" -gt 1 ]; then
+    echo "FATAL: expected 0 or 1 parameter ... (got '$@')"
+    echo "Usage: $0 [nfd_operatorhub_channel, eg: 4.7]"
+    exit 1
+elif [ "$#" -eq 1 ]; then
+    ANSIBLE_OPTS="${ANSIBLE_OPTS} -e nfd_channel=$1"
+    echo "Deploying the NFD Operator from OperatorHub using channel '$1'."
+fi
+
 exec ansible-playbook ${ANSIBLE_OPTS} playbooks/nfd_deploy.yml


### PR DESCRIPTION
This PR enables the deployment of the NFD operator from any channel (or the channel matching the current OCP version).

