### PR TITLE
entitlement_deploy: use ignition v3.0.0 for compatibility with OCP 4.5 and 4.6

### DIFF
--- a/roles/entitlement_deploy/files/mc_pem.yml
+++ b/roles/entitlement_deploy/files/mc_pem.yml
@@ -7,7 +7,7 @@ metadata:
 spec:
   config:
     ignition:
-      version: 3.2.0
+      version: 3.0.0
     storage:
       files:
       - contents:
@@ -25,7 +25,7 @@ metadata:
 spec:
   config:
     ignition:
-      version: 3.2.0
+      version: 3.0.0
     storage:
       files:
       - contents:

--- a/roles/entitlement_deploy/files/mc_rhsm.yml
+++ b/roles/entitlement_deploy/files/mc_rhsm.yml
@@ -7,7 +7,7 @@ metadata:
 spec:
   config:
     ignition:
-      version: 3.2.0
+      version: 3.0.0
     storage:
       files:
       - contents:


### PR DESCRIPTION
Testing is failing on OCP 4.5 and 4.6 since we switched to `--pem` key deployment (instead of deployment predefined MC resources from the secrets)