### PR TITLE
nfd_deploy: add hook for OCP 4.5 for finding the CSV

### DIFF
--- a/roles/nfd_deploy/tasks/main.yml
+++ b/roles/nfd_deploy/tasks/main.yml
@@ -50,21 +50,42 @@
 
 - name: Wait for the NFD Operator OperatorHub ClusterServiceVersion
   block:
-  - name: Wait for the NFD Operator OperatorHub ClusterServiceVersion
-    command:
-      oc get ClusterServiceVersion
-         -l operators.coreos.com/nfd.openshift-nfd
-         -oname
-         -n openshift-nfd
-    register: nfd_operator_csv_name
-    until: nfd_operator_csv_name.stdout != ""
-    retries: 40
-    delay: 30
+  - name: Use different methods for OCP 4.5 vs more recent
+    block:
+    - name: Use 'rescue' block for OCP 4.5
+      when: openshift_release == "4.5"
+      fail: msg="Label operators.coreos.com/nfd.openshift-nfd not available in OCP 4.5"
+
+    - name: Wait for the NFD Operator OperatorHub ClusterServiceVersion (except v4.5)
+      command:
+        oc get ClusterServiceVersion
+           -l operators.coreos.com/nfd.openshift-nfd
+           -oname
+           -n openshift-nfd
+      register: nfd_operator_csv_name
+      until: nfd_operator_csv_name.stdout != ""
+      retries: 40
+      delay: 30
+
+    rescue:
+    - name: Wait for the NFD Operator OperatorHub ClusterServiceVersion (only v4.5)
+      when: openshift_release == "4.5"
+      shell:
+        set -o pipefail;
+        oc get ClusterServiceVersion
+           -oname
+           -n openshift-nfd
+           | grep /nfd
+      register: nfd_operator_csv_name
+      until: nfd_operator_csv_name.stdout != ""
+      retries: 40
+      delay: 30
+
   rescue:
-  - name: List the ClusterServiceVersion in the openshift-nfd namespace
+  - name: List the ClusterServiceVersion in the openshift-nfd namespace (debug)
     command: oc get ClusterServiceVersion -n openshift-nfd
 
-  - name: Store the YAML of the ClusterServiceVersion in the openshift-nfd namespace
+  - name: Store the YAML of the ClusterServiceVersion in the openshift-nfd namespace (debug)
     shell:
       oc get ClusterServiceVersion -n openshift-nfd -oyaml
          > {{ artifact_extra_logs_dir }}/openshift-nfd_ClusterServiceVersions.yml


### PR DESCRIPTION
This doesn't work:
```
roles/nfd_deploy/tasks/main.yml:53
TASK: nfd_deploy : Wait for the NFD Operator OperatorHub ClusterServiceVersion

<command> oc get ClusterServiceVersion -l operators.coreos.com/nfd.openshift-nfd -oname -n openshift-nfd
```

while this debug task worked right after:
```
roles/nfd_deploy/tasks/main.yml:64
TASK: nfd_deploy : List the ClusterServiceVersion in the openshift-nfd namespace

<command> oc get ClusterServiceVersion -n openshift-nfd

<stdout> NAME                        DISPLAY                  VERSION   REPLACES   PHASE
<stdout> nfd.4.5.0-202104130540.p0   Node Feature Discovery   4.5.0                Succeeded
```

https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/periodic-ci-openshift-psap-ci-artifacts-release-4.5-gpu-operator-e2e-140/1390079064026386432/artifacts/gpu-operator-e2e-140/nightly/artifacts/234947__nfd__deploy_from_operatorhub/_ansible.log