### PR TITLE
gpu_operator_run_gpu-burn: improve and store pod description

### DIFF
--- a/roles/gpu_operator_run_gpu-burn/tasks/main.yml
+++ b/roles/gpu_operator_run_gpu-burn/tasks/main.yml
@@ -43,36 +43,27 @@
 - name: "Let the GPU burn Pods run {{ gpu_burn_time }}seconds"
   command: "sleep {{ gpu_burn_time }}"
 
-- name: Wait for GPU burn Pods to complete
-  with_items: "{{ gpu_burn_gpu_nodes.stdout_lines }}"
-  command:
-    oc get pod/gpu-burn-{{ item }}
-       -n default
-       -o custom-columns=:.status.phase
-       --no-headers
-  register: gpu_burn_gpu_wait
-  until: gpu_burn_gpu_wait.stdout == "Succeeded" or gpu_burn_gpu_wait.stdout == "Error" or gpu_burn_gpu_wait.stdout == "Failed"
-  retries: 10
-  delay: 30
-
 - name: Ensure that the GPU burn ran successfully
   block:
-  - name: Ensure that the GPU burn Pods to complete successfully
+  - name: Wait for GPU burn Pods to complete
     with_items: "{{ gpu_burn_gpu_nodes.stdout_lines }}"
     command:
       oc get pod/gpu-burn-{{ item }}
          -n default
          -o custom-columns=:.status.phase
          --no-headers
-    register: gpu_burn_gpu_test
-    failed_when: gpu_burn_gpu_test.stdout != "Succeeded"
+    register: gpu_burn_wait
+    until: gpu_burn_wait.stdout == "Succeeded" or gpu_burn_wait.stdout == "Error" or gpu_burn_wait.stdout == "Failed"
+    failed_when: gpu_burn_wait.stdout != "Succeeded"
+    retries: 10
+    delay: 30
 
   - name: Ensure that no GPU was faulty
     with_items: "{{ gpu_burn_gpu_nodes.stdout_lines }}"
     shell:
       oc logs pod/gpu-burn-{{ item }} -n default | grep FAULTY
-    register: gpu_burn_gpu_test_faulty
-    failed_when: gpu_burn_gpu_test_faulty.rc == 0
+    register: gpu_burn_test_faulty
+    failed_when: gpu_burn_test_faulty.rc == 0
 
   always:
   - name: Save the logs of the GPU burn Pods
@@ -80,11 +71,15 @@
     with_items: "{{ gpu_burn_gpu_nodes.stdout_lines }}"
     failed_when: false
 
+  - name: Save the description of the GPU burn Pods
+    shell: oc describe pod/gpu-burn-{{ item }} -n default > {{ artifact_extra_logs_dir }}/gpu_burn.{{ item }}.description.txt
+    with_items: "{{ gpu_burn_gpu_nodes.stdout_lines }}"
+    failed_when: false
+
   - name: Save the full logs of the GPU burn Pods
     shell: oc logs pod/gpu-burn-{{ item }} -n default > {{ artifact_extra_logs_dir }}/gpu_burn.{{ item }}.log
     with_items: "{{ gpu_burn_gpu_nodes.stdout_lines }}"
     failed_when: false
-
 
   - name: Cleanup the GPU burn Pods
     command: oc --ignore-not-found=true delete pod/gpu-burn-{{ item }} -n default


### PR DESCRIPTION
This role failed in a recent [test](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/openshift-psap_ci-artifacts/120/pull-ci-openshift-psap-ci-artifacts-master-gpu-operator-e2e/1390217302070267904/artifacts/gpu-operator-e2e/presubmit-operatorhub/artifacts/090951__gpu-operator__run_gpu_burn/_ansible.log) because the Pod was in `Pending` state at the end of the retry counter, 
but not enough information were captured to understand what happened.

```
2021-05-06 09:20:06,352 p=5502 u=psap-ci-runner n=ansible | roles/gpu_operator_run_gpu-burn/tasks/main.yml:46
2021-05-06 09:20:06,352 p=5502 u=psap-ci-runner n=ansible | TASK: gpu_operator_run_gpu-burn : Wait for GPU burn Pods to complete
2021-05-06 09:20:06,352 p=5502 u=psap-ci-runner n=ansible | ----- FAILED ----
2021-05-06 09:20:06,353 p=5502 u=psap-ci-runner n=ansible | msg: All items completed
2021-05-06 09:20:06,353 p=5502 u=psap-ci-runner n=ansible | 
2021-05-06 09:20:06,353 p=5502 u=psap-ci-runner n=ansible | LOOP #0: item = ip-10-0-152-212
2021-05-06 09:20:06,353 p=5502 u=psap-ci-runner n=ansible | 
2021-05-06 09:20:06,353 p=5502 u=psap-ci-runner n=ansible | <command> oc get pod/gpu-burn-ip-10-0-152-212 -n default -o custom-columns=:.status.phase --no-headers
2021-05-06 09:20:06,353 p=5502 u=psap-ci-runner n=ansible | 
2021-05-06 09:20:06,353 p=5502 u=psap-ci-runner n=ansible | <stdout> Pending
2021-05-06 09:20:06,353 p=5502 u=psap-ci-runner n=ansible | ----- FAILED ----

```

This PR captures the `description` of GPU Burn pods, and merges the wait&check tasks.