### PR TITLE
gpu_operator_wait_deployment: wait longer for Prometheus to pick up the DCGM metrics

### DIFF
--- a/roles/gpu_operator_wait_deployment/tasks/main.yml
+++ b/roles/gpu_operator_wait_deployment/tasks/main.yml
@@ -99,8 +99,8 @@
       | grep dcgm
     register: dcgm_exporter_prom
     until: dcgm_exporter_prom.rc == 0
-    retries: 5
-    delay: 20
+    retries: 20
+    delay: 30
     ignore_errors: true
 
   rescue:

--- a/roles/gpu_operator_wait_deployment/tasks/main.yml
+++ b/roles/gpu_operator_wait_deployment/tasks/main.yml
@@ -93,15 +93,15 @@
 
   - name: Wait for Prometheus to pick up the DCGM endpoint
     shell:
+      set -o pipefail;
       oc get secret prometheus-k8s -n openshift-monitoring -ojson | jq -r '.data["prometheus.yaml.gz"]'
       | base64 -d
       | gunzip
       | grep dcgm
     register: dcgm_exporter_prom
     until: dcgm_exporter_prom.rc == 0
-    retries: 20
+    retries: 30
     delay: 30
-    ignore_errors: true
 
   rescue:
   - name: Capture the DCGM logs (debug)
@@ -111,4 +111,4 @@
     failed_when: false
 
   - name: The DCGM does not correctly expose the GPU metrics
-    fail: msg="The DCGM does not correctly expose the GPU metrics"
+    fail: msg="The DCGM does not correctly expose the GPU metrics to Prometheus"


### PR DESCRIPTION
I noticed that Prometheus test is failing but currently ignored (`ignore_errors: true`)
```
2021-05-05 23:58:16,931 p=3874 u=psap-ci-runner n=ansible | TASK: gpu_operator_wait_deployment : Wait for Prometheus to pick up the DCGM endpoint
2021-05-05 23:58:16,932 p=3874 u=psap-ci-runner n=ansible | msg: non-zero return code
2021-05-05 23:58:16,932 p=3874 u=psap-ci-runner n=ansible | 
2021-05-05 23:58:16,932 p=3874 u=psap-ci-runner n=ansible | <command> oc get secret prometheus-k8s -n openshift-monitoring -ojson | jq -r '.data["prometheus.yaml.gz"]' | base64 -d | gunzip | grep dcgm
2021-05-05 23:58:16,932 p=3874 u=psap-ci-runner n=ansible | 
2021-05-05 23:58:16,932 p=3874 u=psap-ci-runner n=ansible | 
2021-05-05 23:58:16,932 p=3874 u=psap-ci-runner n=ansible | ==> FAILED attempt #1/5
2021-05-05 23:58:16,932 p=3874 u=psap-ci-runner n=ansible | 
2021-05-05 23:58:37,376 p=3874 u=psap-ci-runner n=ansible | ==> FAILED attempt #2/5
2021-05-05 23:58:37,376 p=3874 u=psap-ci-runner n=ansible | 
2021-05-05 23:58:57,808 p=3874 u=psap-ci-runner n=ansible | ==> FAILED attempt #3/5
2021-05-05 23:58:57,808 p=3874 u=psap-ci-runner n=ansible | 
2021-05-05 23:59:18,255 p=3874 u=psap-ci-runner n=ansible | ==> FAILED attempt #4/5
2021-05-05 23:59:18,255 p=3874 u=psap-ci-runner n=ansible | 
2021-05-05 23:59:38,684 p=3874 u=psap-ci-runner n=ansible | ==> FAILED attempt #5/5
2021-05-05 23:59:38,684 p=3874 u=psap-ci-runner n=ansible | 
2021-05-05 23:59:59,163 p=3874 u=psap-ci-runner n=ansible | ---
2021-05-05 23:59:59,163 p=3874 u=psap-ci-runner n=ansible | 
2021-05-05 23:59:59,163 p=3874 u=psap-ci-runner n=ansible | 
2021-05-05 23:59:59,164 p=3874 u=psap-ci-runner n=ansible | ---
2021-05-05 23:59:59,164 p=3874 u=psap-ci-runner n=ansible | roles/gpu_operator_wait_deployment/tasks/main.yml:94
2021-05-05 23:59:59,164 p=3874 u=psap-ci-runner n=ansible | TASK: gpu_operator_wait_deployment : Wait for Prometheus to pick up the DCGM endpoint
2021-05-05 23:59:59,164 p=3874 u=psap-ci-runner n=ansible | ----- FAILED ----
2021-05-05 23:59:59,164 p=3874 u=psap-ci-runner n=ansible | ==> FAILED | ignore_errors=True
2021-05-05 23:59:59,164 p=3874 u=psap-ci-runner n=ansible | msg: non-zero return code
2021-05-05 23:59:59,164 p=3874 u=psap-ci-runner n=ansible | 
2021-05-05 23:59:59,164 p=3874 u=psap-ci-runner n=ansible | <command> oc get secret prometheus-k8s -n openshift-monitoring -ojson | jq -r '.data["prometheus.yaml.gz"]' | base64 -d | gunzip | grep dcgm
2021-05-05 23:59:59,164 p=3874 u=psap-ci-runner n=ansible | 
2021-05-05 23:59:59,164 p=3874 u=psap-ci-runner n=ansible | ----- FAILED ----
```

if it continues failing we need to investigate what's going wrong