### PR TITLE
build/Dockerfile: move helm to the right directory

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -33,7 +33,7 @@ RUN curl ${OCP_CLI_URL} | tar xfz - -C /usr/local/bin oc
 # Install dependencies: `helm`
 ARG HELM_VERSION=v3.5.1
 ARG HELM_URL=https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz
-RUN curl ${HELM_URL} | tar xfz - -C /usr/local/bin linux-amd64/helm
+RUN curl ${HELM_URL} | tar xfz - -C /usr/local/bin --strip-components 1 linux-amd64/helm
 
 
 # Install dependencies: `operator-sdk`


### PR DESCRIPTION
Helm was incorrectly downloaded at this path `/usr/local/bin/linux-amd64/helm`.
I'm not sure how to get `tar` to extract directly to the right directory ...