### PR TITLE
gpu_operator_wait_deployment: update to support new (>= v1.7.0) GPU Operator validator

### DIFF
--- a/roles/gpu_operator_wait_deployment/tasks/main.yml
+++ b/roles/gpu_operator_wait_deployment/tasks/main.yml
@@ -23,17 +23,41 @@
   retries: 10
   delay: 10
 
-- name: Ensure that nvidia-device-plugin-validation Pod has ran successfully
-  command:
-    oc get pods
-      --field-selector=metadata.name=nvidia-device-plugin-validation,status.phase=Succeeded
-      -n gpu-operator-resources
-      -oname --no-headers
-  register: has_deviceplugin_validation_pod
-  until:
-  - has_deviceplugin_validation_pod.stdout == "pod/nvidia-device-plugin-validation"
-  retries: 15
-  delay: 60
+- name: Test if the ClusterPolicy has the 'validator' stanza
+  command: oc get {{ has_clusterpolicy.stdout }} -ojsonpath={.spec.validator.version}
+  register: clusterpolicy_has_validator
+  failed_when: false
+
+- name: Wait for the GPU Operator (>= v1.7.0) to run its internal validation steps
+  when: clusterpolicy_has_validator.stdout
+  block:
+  - name: Ensure that nvidia-operator-validator DS is ready
+    command:
+      oc get ds/nvidia-operator-validator
+         -n gpu-operator-resources
+         -oyaml
+         -ojsonpath={.status.numberUnavailable}
+    register: operator_validator_numberUnavailable
+    until:
+    - operator_validator_numberUnavailable.rc == 0
+    - not operator_validator_numberUnavailable.stdout
+    retries: 15
+    delay: 60
+
+- name: Wait for the GPU Operator (< v1.7.0) to run its internal validation steps
+  when: not clusterpolicy_has_validator.stdout
+  block:
+  - name: Ensure that nvidia-device-plugin-validation Pod has ran successfully
+    command:
+      oc get pods
+        --field-selector=metadata.name=nvidia-device-plugin-validation,status.phase=Succeeded
+        -n gpu-operator-resources
+        -oname --no-headers
+    register: has_deviceplugin_validation_pod
+    until:
+    - has_deviceplugin_validation_pod.stdout == "pod/nvidia-device-plugin-validation"
+    retries: 15
+    delay: 60
 
 - block:
   - name: Wait for the gpu-feature-discovery Pod to label the nodes


### PR DESCRIPTION
When [PR 217](https://gitlab.com/nvidia/kubernetes/gpu-operator/-/merge_requests/217) will be merged in the GPU Operator, the master branch testing will fail as they are changing the way the operator internally validates its deployment.

This PR allows the testing of the old Pod-based validation and new DS-based validation, by checking if the `ClusterPolicy` has the `.spec.validator.version` stanza or not.

I tested this PR locally and it works as expected when everything is correctly deployed,
and it's also part of https://github.com/openshift-psap/ci-artifacts/pull/151 where I'm working with NVIDIA to getting the PR to work properly on OpenShift.

--

This PR can be merged independently of NVIDIA's, as it must work properly before (testing of versions < 1.7.0) and after the merge (testing of master+upcoming versions)

