### PR TITLE
gpu_operator_set_repo-config: fix RHEL 8.4-beta repo-list

### DIFF
--- a/roles/gpu_operator_set_repo-config/tasks/main.yml
+++ b/roles/gpu_operator_set_repo-config/tasks/main.yml
@@ -33,7 +33,6 @@
         [rhel-8-beta-baseos-rpms]
         name = Red Hat Enterprise Linux 8 Beta BaseOS (RPMs)
         baseurl = https://mirror.openshift.com/enterprise/reposync/ci-deps/rhel-8-beta-baseos-rpms/
-        failovermethod = priority
         gpgcheck = 0
         sslclientcert = /etc/rhsm-host/ca/custom-repo-ca.pem
         sslclientkey = /etc/rhsm-host/ca/custom-repo-ca.pem
@@ -43,12 +42,55 @@
         [rhel-8-beta-appstream-rpms]
         name = Red Hat Enterprise Linux 8 Beta AppStream (RPMs)
         baseurl = https://mirror.openshift.com/enterprise/reposync/ci-deps/rhel-8-beta-appstream-rpms/
-        failovermethod = priority
         gpgcheck = 0
         sslclientcert = /etc/rhsm-host/ca/custom-repo-ca.pem
         sslclientkey = /etc/rhsm-host/ca/custom-repo-ca.pem
         sslverify = 0
         enabled = 1
+
+        [rhel-8-for-x86_64-baseos-eus-rpms]
+        name = rhel-8-for-x86_64-baseos-eus-rpms -- FAKE for GPU Operator
+        baseurl = https://mirror.openshift.com/enterprise/reposync/ci-deps/rhel-8-beta-appstream-rpms/
+        gpgcheck = 0
+        sslclientcert = /etc/rhsm-host/ca/custom-repo-ca.pem
+        sslclientkey = /etc/rhsm-host/ca/custom-repo-ca.pem
+        sslverify = 0
+        enabled = 1
+
+        [rhocp-4.8-for-rhel-8-x86_64-rpms]
+        name = rhocp-4.8-for-rhel-8-x86_64-rpms -- FAKE for GPU Operator
+        baseurl = https://mirror.openshift.com/enterprise/reposync/ci-deps/rhel-8-beta-appstream-rpms/
+        gpgcheck = 0
+        sslclientcert = /etc/rhsm-host/ca/custom-repo-ca.pem
+        sslclientkey = /etc/rhsm-host/ca/custom-repo-ca.pem
+        sslverify = 0
+        enabled = 1
+
+        [rhel-8-for-x86_64-appstream-rpms]
+        name = Red Hat Enterprise Linux 8 for x86_64 - AppStream (RPMs)
+        baseurl = https://cdn.redhat.com/content/dist/rhel8/8.3/x86_64/appstream/os
+        enabled = 1
+        gpgcheck = 1
+        gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+        sslverify = 1
+        sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+        sslclientkey = /etc/pki/entitlement-host/entitlement-key.pem
+        sslclientcert = /etc/pki/entitlement-host/entitlement.pem
+        metadata_expire = 86400
+        enabled_metadata = 1
+
+        [rhel-8-for-x86_64-baseos-rpms]
+        name = Red Hat Enterprise Linux 8 for x86_64 - BaseOS (RPMs)
+        baseurl = https://cdn.redhat.com/content/dist/rhel8/8.3/x86_64/baseos/os
+        enabled = 1
+        gpgcheck = 1
+        gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+        sslverify = 1
+        sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+        sslclientkey = /etc/pki/entitlement-host/entitlement-key.pem
+        sslclientcert = /etc/pki/entitlement-host/entitlement.pem
+        metadata_expire = 86400
+        enabled_metadata = 1
 
       dest: "{{ artifact_extra_logs_dir }}/gpu-operator.dnf.repo"
       mode: 0644


### PR DESCRIPTION
I faced 3 issues to get RHEL 8.4 beta repo-list to work as expected in
the GPU Operator driver-container:

a) the driver-container script tries to disable some repo, so if the
file is readonly, it fails (https://gitlab.com/nvidia/container-images/driver/-/issues/25)

b) it needs packages not available in the beta mirror, so these extra
repo must be available, eg (from install of `kernel-devel`):

```
perl-Encode              x86_64  4:2.97-3.el8                            rhel-8-beta-baseos-rpms           1.5 M
perl-Digest-MD5          x86_64  2.55-396.el8                            rhel-8-for-x86_64-appstream-rpms   37 k
openssl                  x86_64  1:1.1.1g-15.el8_3                       rhel-8-for-x86_64-baseos-rpms     707 k
```

c) the default repo cannot be fetched AFAIU, so they need to be masked
--> mount the file in `/etc/yum.repos.d` and force `rhelver=8.3` in the repo URL