### PR TITLE
gpu_operator_deploy_from_operatorhub: add support for setting the channel

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -57,6 +57,9 @@ Other changes
 
     - ``toolbox/gpu-operator/set_repo-config.sh <path/to/repo.list> [<dest-dir>]``
 
+- gpu_operator_deploy_from_operatorhub: add support for setting the channel `# <https://github.com/openshift-psap/ci-artifacts/pull/173>`
+
+    - ``toolbox/gpu-operator/deploy_from_operatorhub.sh [<version> [<channel>]]``
 
 CI Image and Testing
 ~~~~~~~~~~~~~~~~~~~~

--- a/docs/toolbox/gpu_operator.rst
+++ b/docs/toolbox/gpu_operator.rst
@@ -9,9 +9,37 @@ Deployment
 
 .. code-block:: shell
 
-    toolbox/gpu-operator/deploy_from_operatorhub.sh [<version>]
+    toolbox/gpu-operator/deploy_from_operatorhub.sh [<version>] [<channel>]
     toolbox/gpu-operator/undeploy_from_operatorhub.sh
 
+**Examples:**
+
+- ``./toolbox/gpu-operator/deploy_from_operatorhub.sh``
+
+  - Installs the latest version available
+
+- ``./toolbox/gpu-operator/deploy_from_operatorhub.sh 1.7.0 v1.7``
+
+  - Installs ``v1.7.0`` from the ``v1.7`` channel
+
+- ``./toolbox/gpu-operator/deploy_from_operatorhub.sh 1.6.2 stable``
+
+  - Installs ``v1.6.2`` from the ``stable`` channel
+
+**Note about the GPU Operator channel:**
+
+- Before ``v1.7.0``, the GPU Operator was using a unique channel name
+  (``stable``). Within this channel, OperatorHub would automatically
+  upgrade the operator to the latest available version. This was an
+  issue as the operator doesn't support (yet) being upgraded (remove
+  and reinstall is the official way). OperatorHub allows specifying
+  the upgrade as ``Manual``, but this isn't the default behavior.
+- Starting with ``v1.7.0``, the channel is set to ``v1.7``, so that
+  OperatorHub won't trigger an automatic upgrade.
+- See the `OpenShift Subscriptions and channel documentation`_ for
+  further information.
+
+.. _OpenShift Subscriptions and channel documentation: https://docs.openshift.com/container-platform/4.7/operators/understanding/olm/olm-understanding-olm.html#olm-subscription_olm-understanding-olm
 
 * List the versions available from OperatorHub
 

--- a/roles/gpu_operator_deploy_from_operatorhub/defaults/main/config.yml
+++ b/roles/gpu_operator_deploy_from_operatorhub/defaults/main/config.yml
@@ -1,3 +1,6 @@
 ---
 # Empty to use the latest version, or set to force a given version
 gpu_operator_operatorhub_version: ""
+
+# Channel to use in OperatorHub deployment subscription
+gpu_operator_operatorhub_channel: ""

--- a/roles/gpu_operator_deploy_from_operatorhub/tasks/deploy_from_catalog.yml
+++ b/roles/gpu_operator_deploy_from_operatorhub/tasks/deploy_from_catalog.yml
@@ -32,29 +32,65 @@
   shell:
     oc get packagemanifests/gpu-operator-certified -n openshift-marketplace -oyaml
     > {{ artifact_extra_logs_dir }}/gpu_operator_packagemanifest.yml
-  failed_when: false
 
-- block:
-  - name: Get the version of the GPU Operator on OperatorHub
-    shell:
-      set -o pipefail;
-      oc get packagemanifests/gpu-operator-certified -n openshift-marketplace -ojson
-      | jq -r .status.channels[0].currentCSV
+- name: Store the GPU Operator PackageManifest
+  shell:
+    oc get packagemanifests/gpu-operator-certified -n openshift-marketplace -ojson
+    > {{ artifact_extra_logs_dir }}/gpu_operator_packagemanifest.json
+
+- name: Store the CSV version
+  when: gpu_operator_operatorhub_version | length > 0
+  set_fact:
+    gpu_operator_csv_name: "gpu-operator-certified.v{{ gpu_operator_operatorhub_version }}"
+
+- name: "Fetch the channel name for the requested version ({{ gpu_operator_operatorhub_version }})"
+  when: gpu_operator_operatorhub_version != "" and not gpu_operator_operatorhub_channel
+  block:
+
+  - name: Fetch the channel name for the requested CSV
+    command:
+      jq -r
+         '.status.channels[] | select(.currentCSV=="{{ gpu_operator_csv_name }}") | .name'
+         "{{ artifact_extra_logs_dir }}/gpu_operator_packagemanifest.json"
+    register: gpu_operator_channel_cmd
+
+  - name: Fail if the channel of the CSV could not be found
+    fail: msg="Could not find the channel for the requested GPU Operator version '{{ gpu_operator_operatorhub_version }}'"
+    when: not gpu_operator_channel_cmd.stdout
+
+  - name: Store the channel name
+    set_fact:
+      gpu_operator_operatorhub_channel: "{{ gpu_operator_channel_cmd.stdout }}"
+
+- name: Fetch the default channel name
+  when: not gpu_operator_operatorhub_channel
+  block:
+  - name: Get the default channel of the GPU Operator on OperatorHub
+    command:
+      jq -r .status.defaultChannel {{ artifact_extra_logs_dir }}/gpu_operator_packagemanifest.json
+    register: gpu_operator_channel_cmd
+
+  - name: Store the channel name
+    set_fact:
+      gpu_operator_operatorhub_channel: "{{ gpu_operator_channel_cmd.stdout }}"
+
+- name: Fetch the GPU Operator version and store its CSV name
+  when: not gpu_operator_operatorhub_version
+  block:
+  - name: "Get the version of the GPU Operator on OperatorHub on channel {{ gpu_operator_operatorhub_channel }}"
+    command:
+      jq -r
+         '.status.channels[] | select(.name == "{{ gpu_operator_operatorhub_channel }}") | .currentCSV'
+         {{ artifact_extra_logs_dir }}/gpu_operator_packagemanifest.json
     register: gpu_operator_csv_name_cmd
+
+  - name: Fail if current CSV not found for the channel
+    fail: msg="Could not find the current CSV for the GPU Operator Channel '{{ gpu_operator_operatorhub_channel }}'"
+    when: not gpu_operator_csv_name_cmd.stdout
 
   - name: Store the CSV version
     set_fact:
       gpu_operator_csv_name: "{{ gpu_operator_csv_name_cmd.stdout }}"
-  when: gpu_operator_operatorhub_version == ''
-
-- block:
-  - name: Get the version of the GPU Operator on OperatorHub
-    command: echo "gpu-operator-certified.v{{ gpu_operator_operatorhub_version }}"
-    register: gpu_operator_csv_name_cmd
-  - name: Store the CSV version
-    set_fact:
-      gpu_operator_csv_name: "{{ gpu_operator_csv_name_cmd.stdout }}"
-  when: gpu_operator_operatorhub_version != ''
 
 - name: Store the version of the GPU Operator that will be installed
   shell: echo "{{ gpu_operator_csv_name }}" > {{ artifact_extra_logs_dir }}/gpu_operator_csv_name.txt
@@ -62,14 +98,18 @@
 - name: "Create the OperatorHub subscription for {{ gpu_operator_csv_name }}"
   debug: msg="{{ gpu_operator_csv_name }}"
 
+- name: Store the CSV version
+  set_fact:
+    startingCSV: "{{ gpu_operator_csv_name }}"
+
 - name: "Create the OperatorHub subscription for {{ gpu_operator_csv_name }}"
-  shell:
-    set -o pipefail;
-    cat {{ gpu_operator_operatorhub_sub }}
-    | sed 's|{{ '{{' }} startingCSV {{ '}}' }}|{{ gpu_operator_csv_name }}|'
-    | oc apply -f-
-  args:
-    warn: false # don't warn about using sed here
+  template:
+    src: "{{ gpu_operator_operatorhub_sub }}"
+    dest: "{{ artifact_extra_logs_dir }}/gpu_operator_sub.yml"
+    mode: 0400
+
+- name: Instantiate the OperatorHub subscription
+  command: oc create -f "{{ artifact_extra_logs_dir }}/gpu_operator_sub.yml"
 
 - block:
   - name: Find the GPU Operator OperatorHub InstallPlan

--- a/roles/gpu_operator_deploy_from_operatorhub/templates/020_operator_sub.yml.j2
+++ b/roles/gpu_operator_deploy_from_operatorhub/templates/020_operator_sub.yml.j2
@@ -4,7 +4,7 @@ metadata:
   name: gpu-operator-certified
   namespace: openshift-operators
 spec:
-  channel: stable
+  channel: "{{ gpu_operator_operatorhub_channel }}"
   installPlanApproval: Manual
   name: gpu-operator-certified
   source: certified-operators

--- a/roles/gpu_operator_deploy_from_operatorhub/vars/main/resources.yml
+++ b/roles/gpu_operator_deploy_from_operatorhub/vars/main/resources.yml
@@ -3,4 +3,4 @@
 gpu_operator_packagemanifests: gpu-operator-certified
 
 gpu_operator_namespace: roles/gpu_operator_deploy_from_operatorhub/files/010_namespace.yml
-gpu_operator_operatorhub_sub: roles/gpu_operator_deploy_from_operatorhub/files/020_operator_sub.yml
+gpu_operator_operatorhub_sub: roles/gpu_operator_deploy_from_operatorhub/templates/020_operator_sub.yml.j2

--- a/roles/gpu_operator_deploy_from_operatorhub/vars/main/resources.yml
+++ b/roles/gpu_operator_deploy_from_operatorhub/vars/main/resources.yml
@@ -4,4 +4,3 @@ gpu_operator_packagemanifests: gpu-operator-certified
 
 gpu_operator_namespace: roles/gpu_operator_deploy_from_operatorhub/files/010_namespace.yml
 gpu_operator_operatorhub_sub: roles/gpu_operator_deploy_from_operatorhub/files/020_operator_sub.yml
-gpu_operator_install_plan: roles/gpu_operator_deploy_from_operatorhub/files/030_install_plan.yml

--- a/toolbox/gpu-operator/deploy_from_operatorhub.sh
+++ b/toolbox/gpu-operator/deploy_from_operatorhub.sh
@@ -7,8 +7,12 @@ DEPLOY_FROM_BUNDLE_FLAG="--from-bundle=master"
 
 usage() {
     cat <<EOF
-Usage: $0 [FLAG]
 Deploys the GPU Operator from OperatorHub / OLM
+
+Usage:
+    $0
+    $0 <version> [<channel>]
+    $0 $DEPLOY_FROM_BUNDLE_FLAG
 
 Flags:
   -h, --help           Display this help message
@@ -20,6 +24,8 @@ Flags:
 
   <version>            Deploy a given version from OperatorHub
                        See toolbox/gpu-operator/list_version_from_operator_hub.sh for the version available
+
+  <channel>            Channel to use when deploying from OperatorHub. Default: stable
 EOF
 }
 
@@ -28,19 +34,29 @@ if [[ "${1:-}" == "--help" || "${1:-}" == -h ]]; then
     exit 0
 fi
 
-if [ "$#" -gt 1 ]; then
-    echo "FATAL: expected 0 or 1 parameter ... (got '$@')"
-    usage
-    exit 1
-elif [[ "${1:-}" == "$DEPLOY_FROM_BUNDLE_FLAG" ]]; then
+if [[ "${1:-}" == "$DEPLOY_FROM_BUNDLE_FLAG" ]]; then
     echo "Deploying the GPU Operator from OperatorHub using its master bundle."
     ANSIBLE_OPTS="${ANSIBLE_OPTS} -e gpu_operator_deploy_from=bundle"
 
-elif [[ "$#" == 1 ]]; then
+    if [ "$#" -gt 1 ]; then
+        shift
+        echo "FATAL: $DEPLOY_FROM_BUNDLE_FLAG expects no additional parameter (got '$@')"
+        usage
+        exit 1
+    fi
+elif [[ "$#" == 0 ]]; then
+    echo "Deploying the GPU Operator from OperatorHub using the latest version available."
+elif [[ "$#" == 1 || "$#" == 2 ]]; then
     ANSIBLE_OPTS="${ANSIBLE_OPTS} -e gpu_operator_operatorhub_version=$1"
     echo "Deploying the GPU Operator from OperatorHub using version '$1'."
+    if [[ "$#" == 2 ]]; then
+        ANSIBLE_OPTS="${ANSIBLE_OPTS} -e gpu_operator_operatorhub_channel=$2"
+        echo "Deploying the GPU Operator from OperatorHub using channel '$2'."
+    fi
 else
-    echo "Deploying the GPU Operator from OperatorHub using the latest version available."
+    echo "FATAL: unexpected number of paramters (got '$@')"
+    usage
+    exit 1
 fi
 
 exec ansible-playbook ${ANSIBLE_OPTS} playbooks/gpu_operator_deploy_from_operatorhub.yml


### PR DESCRIPTION
Until `v1.6.2`, the GPU Operator was only using the `stable` channel, so this information was hard-coded in the `Subscription` resource. With `v1.7.0`, NVIDIA chose to use one channel per (major) release, so we need to allow it customization.