### PR TITLE
Various improvements around the logging

### DIFF
--- a/build/root/usr/local/bin/ci_entrypoint_gpu-operator.sh
+++ b/build/root/usr/local/bin/ci_entrypoint_gpu-operator.sh
@@ -30,7 +30,7 @@ collect_must_gather() {
 }
 
 validate_gpu_operator_deployment() {
-    trap collect_must_gather ERR EXIT
+    trap collect_must_gather EXIT
 
     toolbox/gpu-operator/wait_deployment.sh
     toolbox/gpu-operator/run_gpu_burn.sh

--- a/build/root/usr/local/bin/ci_entrypoint_sro.sh
+++ b/build/root/usr/local/bin/ci_entrypoint_sro.sh
@@ -14,7 +14,7 @@ prepare_cluster_for_sro() {
 }
 
 validate_sro_deployment() {
-    trap toolbox/special-resource-operator/capture_deployment_state.sh ERR EXIT
+    trap toolbox/special-resource-operator/capture_deployment_state.sh EXIT
 
     toolbox/special-resource-operator/run_e2e_test.sh "${CI_IMAGE_SRO_COMMIT_CI_REPO}" "${CI_IMAGE_SRO_COMMIT_CI_REF}"
 }

--- a/config/ansible.cfg
+++ b/config/ansible.cfg
@@ -17,13 +17,14 @@ roles_path = roles/
 gathering = smart
 fact_caching = yaml
 fact_caching_timeout = 600
-callback_whitelist = json_to_logfile
+callback_whitelist = json_to_logfile, timer, profile_roles
 inventory_ignore_extensions = secrets.py, .pyc, .cfg, .crt, .ini
 # work around privilege escalation timeouts in ansible:
 timeout = 30
 
 stdout_callback = human_log
 callback_plugins = ../callback_plugins
+enable_task_debugger = False
 
 # Uncomment to use the provided example inventory
 inventory = inventory/hosts

--- a/roles/gpu_operator_capture_deployment_state/tasks/main.yml
+++ b/roles/gpu_operator_capture_deployment_state/tasks/main.yml
@@ -65,38 +65,18 @@
     done
   failed_when: false
 
-- name: Get the driver-container logs
-  shell:
-    set -o pipefail; set -e;
-    oc get pods -l app=nvidia-driver-daemonset -oname | grep .;
-    oc logs ds/nvidia-driver-daemonset
-       -n gpu-operator-resources
-       > {{ artifact_extra_logs_dir }}/gpu_operator_driver.log
-  failed_when: false
+- name: Get the name of the GPU Operator DaemonSets
+  command:
+    oc get DaemonSets -o name -n gpu-operator-resources
+  register: gpu_operator_daemonsets
 
-- name: Get the device-plugin logs
+- name: Get the logs of the GPU Operator DaemonSets
   shell:
-    set -o pipefail; set -e;
-    oc get pods -l app=nvidia-device-plugin-daemonset -oname | grep .;
-    oc logs ds/nvidia-device-plugin-daemonset
+    set -eo pipefail;
+    echo "Saving {{ item }} logs ...";
+    oc logs
        -n gpu-operator-resources
-       > {{ artifact_extra_logs_dir }}/gpu_operator_device-plugin.log
-  failed_when: false
-
-- name: Get the DCGM logs
-  shell:
-    set -o pipefail; set -e;
-    oc get pods -l app=nvidia-dcgm-exporter -oname | grep .;
-    oc logs ds/nvidia-dcgm-exporter
-       -n gpu-operator-resources
-       > {{ artifact_extra_logs_dir }}/gpu_operator_dcgm.log
-  failed_when: false
-
-- name: Capture the GFD logs (debug)
-  shell:
-    set -o pipefail; set -e;
-    oc get pods -l app=gpu-feature-discovery -oname | grep .;
-    oc logs ds/gpu-feature-discovery
-       -n gpu-operator-resources
-       > {{ artifact_extra_logs_dir }}/gpu_operator_gfd.log
-  failed_when: false
+       "{{ item }}"
+       --all-containers --prefix
+       > {{ artifact_extra_logs_dir }}/gpu_operator_$(echo "{{ item }}" | cut -d/ -f2).log
+  with_items: "{{ gpu_operator_daemonsets.stdout_lines }}"

--- a/toolbox/_common.sh
+++ b/toolbox/_common.sh
@@ -26,7 +26,10 @@ fi
 TOOLBOX_PATH="${0##*toolbox/}" # remove everything before 'toolbox/'
 TOOLBOX_PATH="${TOOLBOX_PATH%.*}" # remove file extension
 ARTIFACT_DIRNAME="${TOOLBOX_PATH//\//__}" # replace / by __
-ARTIFACT_EXTRA_LOGS_DIR="${ARTIFACT_DIR}/$(date +%H%M%S)__${ARTIFACT_DIRNAME}" # add ARTIFACT_DIR/date__
+
+mkdir -p "${ARTIFACT_DIR}"
+
+ARTIFACT_EXTRA_LOGS_DIR="${ARTIFACT_DIR}/$(printf '%03d' $(ls "${ARTIFACT_DIR}/" | grep __ | wc -l))__${ARTIFACT_DIRNAME}" # add ARTIFACT_DIR/date__
 export ARTIFACT_EXTRA_LOGS_DIR
 
 mkdir -p "${ARTIFACT_EXTRA_LOGS_DIR}"

--- a/toolbox/gpu-operator/diagnose.sh
+++ b/toolbox/gpu-operator/diagnose.sh
@@ -40,13 +40,15 @@ EOF
         return 0
     fi
 
-    cat <<EOF
+    if [[ $RUN_ALL != yes ]]; then
+        cat <<EOF
 
 Problem detected with '$@', capturing extra information...
 EOF
 
-    toolbox/cluster/capture_environment.sh > /dev/null || true
-    toolbox/gpu-operator/capture_deployment_state.sh > /dev/null || true
+        toolbox/cluster/capture_environment.sh > /dev/null || true
+        toolbox/gpu-operator/capture_deployment_state.sh > /dev/null || true
+    fi
 
     cat <<EOF
 
@@ -97,9 +99,13 @@ else
     echo "Found errors with the GPU Operator, skipping GPU-Burn testing."
 fi
 
-do_test "All the relevant output logs have been captured in ${ARTIFACT_DIR}" \
-        "(this step shouldn't fail)" \
-        toolbox/gpu-operator/capture_deployment_state.sh
+if [[ $RUN_ALL == yes ]]; then
+    echo "Capture the deployment state ..."
+    toolbox/gpu-operator/capture_deployment_state.sh > /dev/null || true
+    echo "Capture the cluster environment ..."
+    toolbox/cluster/capture_environment.sh > /dev/null || true
+    echo "Done with the state capture."
+fi
 
 if [[ "$has_errors" == 0 ]]; then
     cat <<EOF


### PR DESCRIPTION
* 7850818 - build/root/usr/local/bin/ci_entrypoint_*: trap only on EXIT

Otherwise, when trapping on ERR and EXIT, the trap gets executed twice
when an error occurs.

See the top of https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/periodic-ci-openshift-psap-ci-artifacts-release-4.8-gpu-operator-e2e-master/1395152369477488640/artifacts/gpu-operator-e2e-master/nightly/artifacts for an example.

---

* 18e0139 - toolbox/gpu-operator/diagnose.sh: run capture_deployment_state.sh and capture_environment.sh only once with --run-all

When test diagnose test was failing, `capture_deployment_state` was
running twice (once after the test failure, one at the end of the
diagnose.

See there for an example:
https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/periodic-ci-openshift-psap-ci-artifacts-release-4.8-gpu-operator-e2e-master/1395152369477488640/artifacts/gpu-operator-e2e-master/nightly/artifacts/004543__gpu-operator__must-gather/

---

* f3c987d - config/ansible.cfg: enable more logging plugins

- timer: This callback just adds total play duration to the play stats.
  https://docs.ansible.com/ansible/2.9/plugins/callback/timer.html

- profile_roles: This callback module provides profiling for ansible roles.
  https://docs.ansible.com/ansible/2.9/plugins/callback/profile_roles.html

Also `enable_task_debugger = False` to have it handy if we want to
enable it.

---

* 52825e7 - toolbox/_common.sh: change ARTIFACT_EXTRA_LOGS_DIR to use a seq of numbers instead of %H%M%S timestamp

This will enforce a correct ordering even if the test goes over midnight.

---

* 6a6d5a3 - gpu_operator_capture_deployment_state: save the logs of all the DaemonSets

Previous version wasn't working because the namespace wasn't specified ...

> set -o pipefail;
> set -e;
> oc get pods -l app=nvidia-driver-daemonset -oname | grep .;  # HERE
> oc logs ds/nvidia-driver-daemonset -n gpu-operator-resources > /must-gather/004516__gpu-operator__capture_deployment_state/gpu_operator_driver.log

https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/periodic-ci-openshift-psap-ci-artifacts-release-4.8-gpu-operator-e2e-master/1395152369477488640/artifacts/gpu-operator-e2e-master/nightly/artifacts/004543__gpu-operator__must-gather/004516__gpu-operator__capture_deployment_state/_ansible.log

---