### PR TITLE
Properly call gpu-operator/must-gather.sh and store its logs

### DIFF
--- a/build/root/usr/local/bin/ci_entrypoint_gpu-operator.sh
+++ b/build/root/usr/local/bin/ci_entrypoint_gpu-operator.sh
@@ -25,10 +25,20 @@ collect_must_gather() {
     echo "Running gpu-operator_gather ..."
     /usr/bin/gpu-operator_gather &> /dev/null
 
-    DEST="${ARTIFACT_DIR}/$(date +%H%M%S)__gpu-operator__must-gather"
-    echo "Running gpu-operator_gather ... copying results to $DEST..."
-    mkdir -p "$DEST"
-    cp -r /must-gather/* "$DEST"
+    export TOOLBOX_SCRIPT_NAME=toolbox/gpu-operator/must-gather.sh
+
+    COMMON_SH=$(
+        bash -c 'source toolbox/_common.sh;
+                 echo "8<--8<--8<--";
+                 # only evaluate these variables from _common.sh
+                 env | egrep "(^ARTIFACT_EXTRA_LOGS_DIR=)"'
+             )
+    ENV=$(echo "$COMMON_SH" | tac | sed '/8<--8<--8<--/Q' | tac) # keep only what's after the 8<--
+    eval $ENV
+
+    echo "Running gpu-operator_gather ... copying results to $ARTIFACT_EXTRA_LOGS_DIR"
+
+    cp -r /must-gather/* "$ARTIFACT_EXTRA_LOGS_DIR"
 
     echo "Running gpu-operator_gather ... finished."
 }

--- a/toolbox/gpu-operator/must-gather.sh
+++ b/toolbox/gpu-operator/must-gather.sh
@@ -6,14 +6,17 @@ if [[ "$0" == "/usr/bin/gpu-operator_gather" ]]; then
 
     TOP_DIR="$(dirname "$(readlink -f "$0")")/../../"
 else
+    THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
     # avoid sourcing _common.sh and messing up different env variables
     export TOOLBOX_SCRIPT_NAME=$0
 
     COMMON_SH=$(
-        bash -c 'source toolbox/_common.sh;
+        bash -c 'source '$THIS_DIR'/../_common.sh;
                  echo "8<--8<--8<--";
                  # only evaluate these variables from _common.sh
-                 env | egrep "(^ARTIFACT_EXTRA_LOGS_DIR=|^ARTIFACT_DIR=|^TOP_DIR=)"'
+                 echo TOP_DIR=$(pwd)
+                 env | egrep "(^ARTIFACT_EXTRA_LOGS_DIR=|^ARTIFACT_DIR=)"'
              )
     echo "$COMMON_SH" | sed '/8<--8<--8<--/Q'
     ENV=$(echo "$COMMON_SH" | tac | sed '/8<--8<--8<--/Q' | tac) # keep only what's after the 8<--


### PR DESCRIPTION
* 13d2409 - ci_entrypoint_gpu-operator.sh: get ARTIFACT_EXTRA_LOGS_DIR value from toolbox/_common.sh
* 4b271a6 - toolbox/gpu-operator/must-gather.sh: fix when called directly