### PR TITLE
Support entitlement on no-workers clusters

### DIFF
--- a/roles/entitlement_deploy/files/apply_template.py
+++ b/roles/entitlement_deploy/files/apply_template.py
@@ -1,19 +1,33 @@
-#! /usr/bin/python3
+#!/usr/bin/env python3
 
-import fileinput
 import base64
 import sys
 
-template = sys.argv[1]
-keyname = sys.argv[2]
-filename = sys.argv[3]
-print(f"Replacing '{keyname}' with the content of '{filename}'", file=sys.stderr)
 
-with open(filename, "rb") as f:
-    file_b64 = base64.b64encode(f.read()).decode()
+def main():
+    keyname = sys.argv[1]
+    value = sys.argv[2]
 
-found = False
-for line in fileinput.input(files=[template]):
-    if keyname in line: found = True
-    print(line.replace(keyname, file_b64), end="")
-exit(0 if found else 1)
+    if value.startswith("@"):
+        filename = value[1:]  # Skip @
+        print(
+            f"Replacing '{keyname}' with the base64 of the content of '{filename}'",
+            file=sys.stderr,
+        )
+
+        with open(filename, "rb") as f:
+            value = base64.b64encode(f.read()).decode()
+    else:
+        print(f"Replacing '{keyname}' with '{value}'", file=sys.stderr)
+
+    found = False
+    for line in sys.stdin:
+        if keyname in line:
+            found = True
+        print(line.replace(keyname, value), end="")
+
+    exit(0 if found else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/roles/entitlement_deploy/files/mc_pem.yml
+++ b/roles/entitlement_deploy/files/mc_pem.yml
@@ -2,7 +2,7 @@ apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig
 metadata:
   labels:
-    machineconfiguration.openshift.io/role: worker
+    machineconfiguration.openshift.io/role: MACHINE_CONFIG_ROLE
   name: 50-entitlement-pem
 spec:
   config:
@@ -20,7 +20,7 @@ apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig
 metadata:
   labels:
-    machineconfiguration.openshift.io/role: worker
+    machineconfiguration.openshift.io/role: MACHINE_CONFIG_ROLE
   name: 50-entitlement-key-pem
 spec:
   config:

--- a/roles/entitlement_deploy/files/mc_rhsm.yml
+++ b/roles/entitlement_deploy/files/mc_rhsm.yml
@@ -2,7 +2,7 @@ apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig
 metadata:
   labels:
-    machineconfiguration.openshift.io/role: worker
+    machineconfiguration.openshift.io/role: MACHINE_CONFIG_ROLE
   name: 50-rhsm-conf
 spec:
   config:

--- a/roles/entitlement_deploy/files/mc_rhsm_ca.yml
+++ b/roles/entitlement_deploy/files/mc_rhsm_ca.yml
@@ -2,7 +2,7 @@ apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig
 metadata:
   labels:
-    machineconfiguration.openshift.io/role: worker
+    machineconfiguration.openshift.io/role: MACHINE_CONFIG_ROLE
   name: 50-rhsm-repo-ca
 spec:
   config:

--- a/roles/entitlement_deploy/tasks/main.yml
+++ b/roles/entitlement_deploy/tasks/main.yml
@@ -14,18 +14,34 @@
 - name: Compute the md5sum of the entitlement files (debug)
   command: md5sum '{{ entitlement_rhsm }}' '{{ entitlement_pem }}'
 
+- name: Get cluster control plane topology
+  command: oc get scheduler -ojsonpath="{.items[0].spec.mastersSchedulable}\n"
+  register: masters_are_also_workers
+
+- name: Set master as machine config target role in single node clusters
+  when: masters_are_also_workers.stdout == "true"
+  set_fact:
+      machine_config_role: master
+
+- name: Set worker as machine config target role in non-single-node clusters
+  when: not masters_are_also_workers.stdout == "false"
+  set_fact:
+      machine_config_role: worker
+
 - name: "Deploy RHSM from file '{{ entitlement_rhsm }}'"
   shell:
     set -o pipefail;
-    python3 "{{ entitlement_py_apply }}"
-            "{{ entitlement_mc_rhsm }}" BASE64_ENCODED_RHSM_FILE "{{ entitlement_rhsm }}"
+    cat "{{ entitlement_mc_rhsm }}" 
+    | python3 "{{ entitlement_py_apply }}" BASE64_ENCODED_RHSM_FILE @"{{ entitlement_rhsm }}" 
+    | python3 "{{ entitlement_py_apply }}" MACHINE_CONFIG_ROLE "{{ machine_config_role }}"
     | oc apply -f-
 
 - name: "Deploy the pem and key-pem from file '{{ entitlement_pem }}'"
   shell:
     set -o pipefail;
-    python3 "{{ entitlement_py_apply }}"
-            "{{ entitlement_mc_pem }}" BASE64_ENCODED_PEM_FILE "{{ entitlement_pem }}"
+    cat "{{ entitlement_mc_pem }}" 
+    | python3 "{{ entitlement_py_apply }}" BASE64_ENCODED_PEM_FILE @"{{ entitlement_pem }}"
+    | python3 "{{ entitlement_py_apply }}" MACHINE_CONFIG_ROLE "{{ machine_config_role }}"
     | oc apply -f-
 
 - name: "Deploy the repo CA from file '{{ entitlement_mc_rhsm_ca }}' if requested"
@@ -36,7 +52,8 @@
   - name: "Deploy the repo CA from file '{{ entitlement_mc_rhsm_ca }}'"
     shell:
       set -o pipefail;
-      python3 "{{ entitlement_py_apply }}"
-              "{{ entitlement_mc_rhsm_ca }}" BASE64_ENCODED_RHSM_CA_FILE "{{ entitlement_repo_ca }}"
+      cat "{{ entitlement_mc_rhsm_ca }}" 
+      | python3 "{{ entitlement_py_apply }}" BASE64_ENCODED_RHSM_CA_FILE @"{{ entitlement_repo_ca }}"
+      | python3 "{{ entitlement_py_apply }}" MACHINE_CONFIG_ROLE "{{ machine_config_role }}"
       | oc apply -f-
   when: entitlement_repo_ca | default('', true) | trim != ''

--- a/roles/entitlement_inspect/tasks/main.yml
+++ b/roles/entitlement_inspect/tasks/main.yml
@@ -22,6 +22,11 @@
        > {{ artifact_extra_logs_dir }}/worker_MachineConfigPool.desc
   failed_when: false
 
+- name: Get the description of the master MachineConfigPool
+  shell: oc describe MachineConfigPool/master
+       > {{ artifact_extra_logs_dir }}/master_MachineConfigPool.desc
+  failed_when: false
+
 - name: Get the state of the nodes
   command: oc get nodes
   failed_when: false


### PR DESCRIPTION
On no-worker clusters, we want to target the masters with our machine
configs rather than the workers, because there are no workers.

We check that by looking at the Scheduler CR `.spec.mastersSchedulable`
stanza
