### PR TITLE
Introduce a Github Action for checking ansible variable consistency

### DIFF
--- a/.github/workflows/check_consistency.yml
+++ b/.github/workflows/check_consistency.yml
@@ -1,0 +1,18 @@
+name: Check the consistency of the repository
+
+on:
+  pull_request:
+    branches: [master]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Check that all the variables point to existing files
+        run: toolbox/repo/validate_role_files.py
+
+      - name: Check that all the variables defined are actually used
+        run: toolbox/repo/validate_role_vars_used.py

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -30,6 +30,14 @@ Bug fixes
 - ``toolbox/local-ci/deploy.sh <ci command> <git repository> <git reference>`` was fixed `#179 <https://github.com/openshift-psap/ci-artifacts/pull/179>`_
 
 
+Other changes
+^^^^^^^^^^^^^
+
+- Introduce a Github Action for checking ansible variable consistency `#196 <https://github.com/openshift-psap/ci-artifacts/pull/196>`_
+
+  - ``toolbox/repo/validate_role_files.py`` is a new script to ensure that all the Ansible variables defining a filepath (``roles/``) do point to an existing file
+  - ``toolbox/repo/validate_role_vars_used.py`` is a new script to ensure that all the Ansible variables defined are actually used in their role (with an exception for symlinks)
+
 Changes since version May 7th, 2021
 -----------------------------------
 

--- a/README.rst
+++ b/README.rst
@@ -163,6 +163,9 @@ The functionalities of the toolbox commands are described in the
     │   └── wait_gpu_nodes.sh
     ├── nto
     │   └── run_e2e_test.sh
+    ├── repo
+    │   ├── validate_role_files.py
+    │   └── validate_role_vars_used.py
     └── special-resource-operator
         ├── capture_deployment_state.sh
         ├── deploy_from_commit.sh

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,6 +23,7 @@ Red Hat PSAP CI-Artifacts toolbox
    toolbox/nto
    toolbox/sro
    toolbox/local-ci
+   toolbox/repo
 
 
 Documentation generated on |today| from |release|.

--- a/docs/toolbox/repo.rst
+++ b/docs/toolbox/repo.rst
@@ -1,0 +1,23 @@
+======================
+Repository Maintenance
+======================
+
+Consistency checks
+==================
+
+* Ensure that all the Ansible variables defining a filepath
+  (``roles/``) do point to an existing file
+
+
+.. code-block:: shell
+
+    toolbox/repo/validate_role_files.py
+
+
+* Ensure that all the Ansible variables defined are actually used in
+  their role (with an exception for symlinks)
+
+
+.. code-block:: shell
+
+    toolbox/repo/validate_role_vars_used.py

--- a/roles/entitlement_test_in_cluster/defaults/main/config.yml
+++ b/roles/entitlement_test_in_cluster/defaults/main/config.yml
@@ -1,6 +1,3 @@
 ---
 # path to the PEM key to test locally
 entitlement_pem:
-
-# container image to use for testing the entitlement
-entitlement_test_image: registry.access.redhat.com/ubi8:latest

--- a/roles/gpu_operator_deploy_from_operatorhub/vars/main/resources.yml
+++ b/roles/gpu_operator_deploy_from_operatorhub/vars/main/resources.yml
@@ -1,6 +1,3 @@
 ---
-# Manifest for installing the GPU operator from OperatorHub
-gpu_operator_packagemanifests: gpu-operator-certified
-
 gpu_operator_namespace: roles/gpu_operator_deploy_from_operatorhub/files/010_namespace.yml
 gpu_operator_operatorhub_sub: roles/gpu_operator_deploy_from_operatorhub/templates/020_operator_sub.yml.j2

--- a/roles/nfd_operator_deploy_custom_commit/vars/main/resources.yml
+++ b/roles/nfd_operator_deploy_custom_commit/vars/main/resources.yml
@@ -1,8 +1,6 @@
 ---
 # Custom label to apply to the node where we'll load fuse
 tuned_module_fuse_label: tuned.module.fuse
-# NFD Deploy Script
-nfd_install_script: roles/nfd_operator_deploy_custom_commit/scripts/deploy_operator.sh
 # Manifest for installing the nfd operator from a custom commit
 tuned_module_fuse: roles/nfd_operator_deploy_custom_commit/files/tuned_module_fuse.yml
 nfd_operator_ci_utils: roles/nfd_operator_deploy_custom_commit/files/operator_ci_utils.yml

--- a/roles/sro_deploy_custom_commit/vars/main/resources.yml
+++ b/roles/sro_deploy_custom_commit/vars/main/resources.yml
@@ -1,2 +1,1 @@
 ---
-sro_install_script: roles/sro_deploy_custom_commit/scripts/deploy_operator.sh

--- a/roles/sro_undeploy_custom_commit/vars/main/resources.yml
+++ b/roles/sro_undeploy_custom_commit/vars/main/resources.yml
@@ -1,2 +1,1 @@
 ---
-sro_install_script: roles/sro_deploy_custom_commit/scripts/deploy_operator.sh

--- a/toolbox/repo/validate_role_files.py
+++ b/toolbox/repo/validate_role_files.py
@@ -1,0 +1,80 @@
+#! /usr/bin/env python
+
+# This script ensures that all the Ansible variables defining a
+# filepath (`roles/`) do point to an existing file.
+
+import glob, os, sys
+import yaml
+import pathlib
+
+THIS_DIR = pathlib.Path(__file__).absolute().parent
+TOP_DIR = THIS_DIR.parent.parent
+# go to top directory
+os.chdir(TOP_DIR)
+
+ROLES_VARS_GLOB = "roles/*/vars/*/*"
+FILE_PREFIX = "roles/"
+
+def validate_role_vars_files(filename, yaml_doc):
+    errors = 0
+
+    for key, value in yaml_doc.items():
+        try:
+
+            if not value.startswith(FILE_PREFIX):
+                print(f"{key}: {value} --> not starting with '{FILE_PREFIX}', ignoring.")
+                continue
+        except AttributeError: # value.startswith
+            print(f"{key}: --> no a string, ignoring.")
+            continue
+
+        if not pathlib.Path(value).exists():
+            errors += 1
+
+            print(f"ERROR: {key}: {value} --> not found")
+            continue
+
+        # file found, nothing to do
+
+    return errors
+
+def traverse_role_vars():
+    errors = 0
+    for filename in TOP_DIR.glob(ROLES_VARS_GLOB):
+        print()
+        print("###", filename.relative_to(TOP_DIR))
+        with open(filename) as f:
+            try:
+                yaml_doc = yaml.safe_load(f)
+            except yaml.YAMLError as e:
+                print(f"--> invalid YAML file ({e})")
+                continue
+
+        if yaml_doc is None:
+            print(f"--> empty file")
+            continue
+
+        file_errors = validate_role_vars_files(filename, yaml_doc)
+        errors += file_errors
+
+        print(f"--> found {file_errors} error{'s' if file_errors > 1 else ''} in {filename.relative_to(TOP_DIR)}")
+
+    return errors
+
+def main():
+    if "-h" in sys.argv or "--help" in sys.argv:
+        print("""\
+This script ensures that all the Ansible variables defining a
+filepath (`roles/`) do point to an existing file.""")
+        return 0
+
+    print(f"INFO: Searching for missing files in '{ROLES_VARS_GLOB}'")
+    errors = traverse_role_vars()
+
+    print()
+    print(f"{'ERROR' if errors else 'INFO'}: found {errors} missing file{'s' if errors > 1 else ''}")
+
+    return 1 if errors else 0
+
+if __name__ == "__main__":
+    exit(main())

--- a/toolbox/repo/validate_role_vars_used.py
+++ b/toolbox/repo/validate_role_vars_used.py
@@ -1,0 +1,98 @@
+#! /usr/bin/env python
+
+# This script ensures that all the Ansible variables defined are
+# actually used in their role (with an exception for symlinks)
+
+import glob, os, sys
+import yaml
+import subprocess
+import pathlib
+import itertools
+import shlex
+
+THIS_DIR = pathlib.Path(__file__).absolute().parent
+TOP_DIR = THIS_DIR.parent.parent
+# go to top directory
+os.chdir(TOP_DIR)
+
+ROLES_VARS_GLOB = "roles/*/vars/*/*"
+ROLES_DEFAULTS_GLOB = "roles/*/defaults/*/*"
+
+def validate_role_vars_used(filename, yaml_doc):
+    errors = 0
+
+    # filename.parts[len(TOP_DIR.parts)] is 'roles'
+    role_name = filename.parts[len(TOP_DIR.parts)+1]
+    for key in yaml_doc:
+        grep_command = ["grep", key,
+                        str(pathlib.Path("roles") / role_name),
+                        "--recursive",
+                        ]
+        proc = subprocess.run(grep_command, capture_output=True)
+
+        if proc.returncode != 0:
+            print("DEBUG:", shlex.join(grep_command))
+            # grep should always find 'key' inside 'filename',
+            # I couldn't find how to exclude one specific file with
+            # grep options....
+            print(proc.stderr)
+            print("ERROR: grep shouldn't have failed ...")
+            proc.check_returncode() # raises a subprocess.CalledProcessError
+
+        count = len(proc.stdout.decode('utf-8').splitlines())
+        count -= 1 # exclude 'key' found inside 'filename'
+        if count == 0:
+            print(f"ERROR: '{key}' not used in role '{role_name}'")
+            errors += 1
+            continue
+
+        # key is used, nothing to do
+
+    return errors
+
+def traverse_role_vars_defaults():
+    errors = 0
+    for filename in itertools.chain(TOP_DIR.glob(ROLES_VARS_GLOB), TOP_DIR.glob(ROLES_DEFAULTS_GLOB)):
+        print()
+
+        print("###", filename.relative_to(TOP_DIR))
+
+        if filename.is_symlink():
+            print(f"--> is a symlink, don't check.")
+            continue
+
+        with open(filename) as f:
+            try:
+                yaml_doc = yaml.safe_load(f)
+            except yaml.YAMLError as e:
+                print(f"--> invalid YAML file ({e})")
+                continue
+
+        if yaml_doc is None:
+            print(f"--> empty file")
+            continue
+
+        file_errors = validate_role_vars_used(filename, yaml_doc)
+        errors += file_errors
+
+        print(f"--> found {file_errors} error{'s' if file_errors > 1 else ''} in {filename.relative_to(TOP_DIR)}")
+
+    return errors
+
+def main():
+    if "-h" in sys.argv or "--help" in sys.argv:
+        print("""\
+This script ensures that all the Ansible variables defined are
+actually used in their role (with an exception for symlinks)""")
+        return 0
+
+    print(f"INFO: Searching for used variables in '{ROLES_VARS_GLOB}'")
+    errors = traverse_role_vars_defaults()
+
+    print()
+    print(f"{'ERROR' if errors else 'INFO'}: found {errors} unused variable{'s' if errors > 1 else ''}")
+
+    return 1 if errors else 0
+
+if __name__ == "__main__":
+    exit(main())


### PR DESCRIPTION
This PR creates a new `pull_request` GitHub Action to validate:
1. that all the variables defining a filepath (`roles/`) do point to an existing file
2. that all the variables defined are actually used in their role (with an exception for symlinks, shared between `undeploy` -> `deploy`).

This should prevent the problem solved by https://github.com/openshift-psap/ci-artifacts/pull/195 to happen again.

The PR also fixed problems found by the checks (only unused variables).