### PR TITLE
[ci-mirror] Some small mirror fixes

### DIFF
--- a/subprojects/ci-mirror/mirrors/dataset/sync.sh
+++ b/subprojects/ci-mirror/mirrors/dataset/sync.sh
@@ -11,8 +11,8 @@ echo "Downloading COCO to ${PWD}"
 
 CURL_FLAGS=("--fail-early" "--fail")
 
-ANNOTATIONS="http://images.cocodataset.org/annotations/"
-DATASETS="http://images.cocodataset.org/zips/"
+ANNOTATIONS="http://images.cocodataset.org/annotations"
+DATASETS="http://images.cocodataset.org/zips"
 
 for url in $ANNOTATIONS $DATASETS; do
     if [[ $url == $ANNOTATIONS ]]; then

--- a/subprojects/ci-mirror/openshift/template.yaml
+++ b/subprojects/ci-mirror/openshift/template.yaml
@@ -67,7 +67,7 @@ objects:
   - apiVersion: security.openshift.io/v1
     kind: SecurityContextConstraints
     metadata:
-      name: ${NAME}
+      name: ${NAMESPACE}-${NAME}
     priority: null
     readOnlyRootFilesystem: false
     requiredDropCapabilities: null


### PR DESCRIPTION
- The SCC is cluster-scoped so the name should contain the mirror namespace to avoid clash
- URL contained // twice