### PR TITLE
CI: detect flakes due to packagemanifest not found and cluster unreachable 

### DIFF
--- a/build/root/usr/local/bin/run
+++ b/build/root/usr/local/bin/run
@@ -29,9 +29,13 @@ ci_banner() {
 prechecks() {
     if [[ "${INSIDE_CI_IMAGE:-}" != "y" ]]; then
         echo "FATAL: this script shouldn't run outside of the CI image ..."
+        echo "INFO: 'export INSIDE_CI_IMAGE=y' to force"
         exit 1
     fi
-
+    if [ -z "${ARTIFACT_DIR:-}" ]; then
+        echo "ARTIFACT_DIR not set, cannot configured."
+        exit 1
+    fi
     if [[ -z "${KUBECONFIG}" ]]
     then
         echo "KUBECONFIG not set, cannot continue."

--- a/build/root/usr/local/bin/run
+++ b/build/root/usr/local/bin/run
@@ -61,10 +61,35 @@ prechecks() {
     fi
 }
 
+postchecks() {
+    set +e
+    set +x
+
+    reason=$1
+    shift
+
+    if [[ "$reason" == ERR ]]; then
+        touch $ARTIFACT_DIR/FAILURE
+
+        if ! oc version >/dev/null 2>&1; then
+            echo "Cluster unreachable" > $ARTIFACT_DIR/UNREACHABLE
+        fi
+    elif [[ "$reason" == EXIT ]]; then
+        if [ ! -e "$ARTIFACT_DIR/FAILURE" ]; then
+            echo "Test of '$@' succeeded."
+        else
+            echo "Test of '$@' failed."
+        fi
+    fi
+}
+
 ##############
 
 ci_banner "$@"
 prechecks
+
+trap "postchecks EXIT $*" EXIT
+trap "postchecks ERR" ERR
 
 #############
 

--- a/build/root/usr/local/bin/run
+++ b/build/root/usr/local/bin/run
@@ -68,40 +68,12 @@ prechecks
 
 #############
 
-if [ -z "${ARTIFACT_DIR:-}" ]; then
-    echo "No ARTIFACT_DIR configured."
-else
-    echo "Using '$ARTIFACT_DIR' to store the test artifacts"
-fi
-
-if [ $1 == "gpu-operator_test-master-branch" ]; then
-    target="gpu-operator"
-    action="test_master_branch"
-    shift 1
-elif [ $1 == "gpu-operator_test-operatorhub" ]; then
-    target="gpu-operator"
-    action="test_operatorhub"
-    shift 1
-elif [ $1 == "gpu-operator_test-helm" ]; then
-    target="gpu-operator"
-    action="test_helm"
-    shift 1
-elif [ $1 == "gpu-operator_undeploy-operatorhub" ]; then
-    target="gpu-operator"
-    action="undeploy_operatorhub"
-    shift 1
-elif [ $1 == "cluster-upgrade" ]; then
-    target="cluster"
-    action="upgrade"
-    shift 1
-else
-    script_name="$0"
-    target="$1"
-    action="$2"
-    shift 2
-fi
-
-set -x
+target="${1:-}"
+shift
+action="${1:-}"
+echo
+echo "Test target: '$target'; test action: '$action'"
+echo
 
 case ${target} in
     "cluster")

--- a/docs/ci/files.rst
+++ b/docs/ci/files.rst
@@ -1,0 +1,46 @@
+=============
+Special Files
+=============
+
+As part of the execution of the toolbox commands, some special files
+will be generated in the `$ARTIFACT_DIR` directory. They will be
+recognized by the code in `ci-dashboard
+<https://github.com/openshift-psap/ci-dashboard/>`_ repository and
+interpreted to enhance the dashboard display:
+
+- ``$ARTIFACT_DIR/<toolbox directory>/_ansible.log.json``: `JSON
+  <https://docs.ansible.com/ansible/latest/collections/ansible/posix/json_callback.html>`_
+  array of the ansible tasks executed as part of the toolbox
+  command. In particular, in this file, we parse the ``stats``
+  information of the last entry:
+
+.. code-block:: json
+
+    {
+      "log_level": "info",
+      "scope": "playbook",
+      "stats": {
+          "localhost": {
+              "changed": 4,
+              "failures": 0,
+              "ignored": 0,
+              "ok": 5,
+              "rescued": 0,
+              "skipped": 2,
+              "unreachable": 0
+          }
+      },
+      "status": "finished"
+    }
+
+
+- ``$ARTIFACT_DIR/FAILURE``: the presence this file after the CI
+  execution indicates that the testing failed.
+
+- ``$ARTIFACT_DIR/FLAKE``: the presence of this file after a toolbox
+  command fail indicates that a known flake occurred. The file
+  contains a brief description of the problem that happened.
+
+- ``$ARTIFACT_DIR/UNREACHABLE``: the presence this file after the CI
+  execution indicates that the testing failed and the cluster was
+  unreachable during our tear-down execution.

--- a/docs/ci/intro.rst
+++ b/docs/ci/intro.rst
@@ -1,0 +1,20 @@
+============
+Introduction
+============
+
+As part of Red Hat PSAP team, we run nightly a set of tests to
+validate the proper execution of the operators we are in charge of:
+
+- the `GPU Operator <https://openshift-psap.github.io/ci-dashboard/gpu-operator_daily-matrix.html>`_
+- the `Node Feature Discovery operator <https://openshift-psap.github.io/ci-dashboard/nfd_daily-matrix.html>`_
+- the `Node Tuning Operator <https://openshift-psap.github.io/ci-dashboard/nto_daily-matrix.html>`_
+- the `Special Resource Operator <https://openshift-psap.github.io/ci-dashboard/sro_daily-matrix.html>`_
+
+The execution of these nightly tests is controlled by the code in the
+`ci-artifacts <https://github.com/openshift-psap/ci-artifacts/>`_
+repository, and the test steps are driven by the `toolbox
+<https://openshift-psap.github.io/ci-artifacts/index.html#psap-toolbox>`_
+commands.
+
+The nightly test overview is generated with the help of the `ci-dashboard
+<https://github.com/openshift-psap/ci-dashboard/>`_ repository.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,6 +10,15 @@ Red Hat PSAP CI-Artifacts toolbox
    contrib
    changelog
 
+.. _psap_ci:
+
+.. toctree::
+   :maxdepth: 3
+   :caption: PSAP Operator CI
+
+   ci/intro
+   ci/files
+
 .. _psap_toolbox:
 
 .. toctree::

--- a/roles/check_deps/tasks/main.yml
+++ b/roles/check_deps/tasks/main.yml
@@ -1,4 +1,12 @@
 ---
+- name: Fail if artifact_dir is not defined
+  fail: msg="'artifact_dir' must be defined before running this role"
+  when: artifact_dir is undefined
+
+- name: Fail if artifact_extra_logs_dir is not defined
+  fail: msg="'artifact_extra_logs_dir' must be defined before running this role"
+  when: artifact_extra_logs_dir is undefined
+
 - block:
   - name: Fetch 'openshift_release' value and check dependencies
     # see the 'fail' message below before modifying this command,

--- a/roles/gpu_operator_deploy_from_operatorhub/tasks/deploy_from_catalog.yml
+++ b/roles/gpu_operator_deploy_from_operatorhub/tasks/deploy_from_catalog.yml
@@ -28,15 +28,24 @@
   - name: Ensure that the GPU Operator PackageManifest exists
     command: oc get packagemanifests/gpu-operator-certified -n openshift-marketplace
 
-- name: Save the GPU Operator PackageManifest (debug)
-  shell:
-    oc get packagemanifests/gpu-operator-certified -n openshift-marketplace -oyaml
-    > {{ artifact_extra_logs_dir }}/gpu_operator_packagemanifest.yml
+  - name: Save the GPU Operator PackageManifest (debug)
+    shell:
+      oc get packagemanifests/gpu-operator-certified -n openshift-marketplace -oyaml
+      > {{ artifact_extra_logs_dir }}/gpu_operator_packagemanifest.yml
 
-- name: Store the GPU Operator PackageManifest
-  shell:
-    oc get packagemanifests/gpu-operator-certified -n openshift-marketplace -ojson
-    > {{ artifact_extra_logs_dir }}/gpu_operator_packagemanifest.json
+  - name: Store the GPU Operator PackageManifest
+    shell:
+      oc get packagemanifests/gpu-operator-certified -n openshift-marketplace -ojson
+      > {{ artifact_extra_logs_dir }}/gpu_operator_packagemanifest.json
+
+  rescue:
+  - name: Mark the failure as flake
+    shell:
+      echo "Failed because of the GPU Operator packagemanifest not available"
+           > "{{ artifact_dir }}/FLAKE"
+
+  - name: Failing because of previous error
+    fail: msg="Failing because of the GPU Operator packagemanifest not available"
 
 - name: Store the CSV version
   when: gpu_operator_operatorhub_version | length > 0

--- a/roles/nfd_operator_deploy_from_operatorhub/tasks/main.yml
+++ b/roles/nfd_operator_deploy_from_operatorhub/tasks/main.yml
@@ -28,6 +28,15 @@
   - name: Ensure that the NFD Operator PackageManifest exists
     command: oc get packagemanifests/nfd -n openshift-marketplace
 
+  rescue:
+  - name: Mark the failure as flake
+    shell:
+      echo "Failed because of the NFD Operator packagemanifest not available"
+           > "{{ artifact_dir }}/FLAKE"
+
+  - name: Failing because of previous error
+    fail: msg="Failing because of the NFD Operator packagemanifest not available"
+
 - name: Save the NFD Operator PackageManifest (debug)
   shell:
     oc get packagemanifests/nfd -n openshift-marketplace -oyaml

--- a/toolbox/_common.sh
+++ b/toolbox/_common.sh
@@ -21,6 +21,7 @@ if [ -z "${ARTIFACT_DIR:-}" ]; then
 else
     echo "Using '$ARTIFACT_DIR' to store the test artifacts."
 fi
+ANSIBLE_OPTS="$ANSIBLE_OPTS -e artifact_dir=${ARTIFACT_DIR}"
 
 TOOLBOX_SCRIPT_NAME="${TOOLBOX_SCRIPT_NAME:-$0}"
 TOOLBOX_PATH="${TOOLBOX_SCRIPT_NAME##*toolbox/}" # remove everything before 'toolbox/'


### PR DESCRIPTION
* 83693b8 - CI: run: Remove old single-worded entrypoint definitions


---

* af9948c - CI: run: detect when cluster became unreachable during the testing


---

* 6c9b3d0 - toolbox: expose 'artifact_dir' as ansible variable

And ensure it is set in 'check_deps' role.

---

* 9a51d1a - gpu_operator_deploy_from_operatorhub: mark packagemanifests/gpu-operator-certified not found as flake


---

* 6d4b600 - nfd_operator_deploy_from_operatorhub: mark packagemanifests/nfd not found as flake


---

* dd01e42 - docs: introduce 'ci' section and document special files


---