### PR TITLE
{nfd,gpu}_operator_deploy_from_operatorhub: sed/subscriptions/subscriptions.operators.coreos.com + minor updates 

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,7 +2,7 @@
 
 (Organized release by release)
 
-Changes since version 0.1.0 (June 2021)
+Changes since version 0.1 (June 2021)
 ---------------------------------------
 
 Toolbox
@@ -21,6 +21,19 @@ Retro-compatibility breaks
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 - Add nfd test_master_branch protocol `#179 https://github.com/openshift-psap/ci-artifacts/pull/179>`_
+
+Bug fixes
+~~~~~~~~~
+
+- Use ``subscriptions.operators.coreos.com`` instead of
+  ``subscriptions`` to avoid conflicts with Knative `subscriptions
+  <https://knative.dev/docs/eventing/channels/subscriptions>`_ `#207
+  <https://github.com/openshift-psap/ci-artifacts/pull/207>`_ `#208
+  <https://github.com/openshift-psap/ci-artifacts/pull/208>`_
+
+
+Features of version 0.1 (June 2021)
+-----------------------------------
 
   - ``toolbox/nfd/deploy_from_operatorhub.sh`` was moved to ``toolbox/nfd-operator/deploy_from_operatorhub.sh``
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -104,7 +104,8 @@ Coding guidelines
 
     - name: Inspect the Subscriptions status (debug)
       shell:
-        oc describe subscriptions/gpu-operator-certified -n openshift-operators
+        oc describe subscriptions.operators.coreos.com/gpu-operator-certified
+           -n openshift-operators
            > {{ artifact_extra_logs_dir }}/gpu_operator_Subscription.log
       failed_when: false
 

--- a/roles/cluster_set_scale/tasks/main.yml
+++ b/roles/cluster_set_scale/tasks/main.yml
@@ -91,8 +91,12 @@
       oc get 'machineset/{{ item }}' -n openshift-machine-api;
       echo GPU Machines;
       oc get machines -n openshift-machine-api -l 'machine.openshift.io/cluster-api-machineset={{ item }}';
-      echo GPU Machines description;
-      oc describe machines -n openshift-machine-api -l 'machine.openshift.io/cluster-api-machineset={{ item }}';
+    failed_when: false
+    loop: "{{ oc_get_machinesets.stdout_lines }}"
+
+  - name: Capture more information about the machineset failure
+    shell: |
+      oc describe machines -n openshift-machine-api -l 'machine.openshift.io/cluster-api-machineset={{ item }}' > {{ artifact_extra_logs_dir }}/machines_{{ item }}.desc
     failed_when: false
     loop: "{{ oc_get_machinesets.stdout_lines }}"
 

--- a/roles/cluster_upgrade_to_image/tasks/main.yml
+++ b/roles/cluster_upgrade_to_image/tasks/main.yml
@@ -58,11 +58,11 @@
 
 - name: Get ClusterVersion description
   shell:
-    oc describe ClusterVersion/version > {{ artifact_extra_logs_dir }}/ClusterVersion.descr
+    oc describe ClusterVersion/version > {{ artifact_extra_logs_dir }}/version_ClusterVersion.desc
 
 - name: Get ClusterVersion YAML
   shell:
-    oc get -oyaml ClusterVersion/version > {{ artifact_extra_logs_dir }}/ClusterVersion.yml
+    oc get -oyaml ClusterVersion/version > {{ artifact_extra_logs_dir }}/version_ClusterVersion.yml
 
 - name: Ensure that the upgrade succeeded
   fail: msg="Upgrade failed".

--- a/roles/entitlement_inspect/tasks/main.yml
+++ b/roles/entitlement_inspect/tasks/main.yml
@@ -17,7 +17,9 @@
   failed_when: false
 
 - name: Get the description of the worker MachineConfigPool
-  command: oc describe MachineConfigPool/worker
+  shell:
+    oc describe MachineConfigPool/worker
+       > {{ artifact_extra_logs_dir }}/worker_MachineConfigPool.desc
   failed_when: false
 
 - name: Get the state of the nodes

--- a/roles/gpu_operator_deploy_from_operatorhub/tasks/deploy_clusterpolicy.yml
+++ b/roles/gpu_operator_deploy_from_operatorhub/tasks/deploy_clusterpolicy.yml
@@ -29,24 +29,11 @@
     retries: 15
     delay: 30
 
-- name: Get the clusterpolicy of the GPU Operator from OperatorHub CSV
-  shell:
-    set -o pipefail;
-    oc get "{{ gpu_operator_csv_name_cmd.stdout }}"
-       -n openshift-operators
-       -ojson
-    | jq -r '.metadata.annotations."alm-examples"'
-    | jq .[0] > "{{ artifact_extra_logs_dir }}/gpu_operator_clusterpolicy.json"
-  register: operatorhub_clusterpolicy
-  until: operatorhub_clusterpolicy.rc == 0
-  retries: 20
-  delay: 15
-
 - block:
-  - name: Create the clusterPolicy CR for the GPU Operator
-    command: oc apply -f "{{ artifact_extra_logs_dir }}/gpu_operator_clusterpolicy.json"
-    register: test_clusterpolicy_cr
-    until: test_clusterpolicy_cr.rc != 1
+  - name: Wait for the GPU Operator ClusterPolicy CRD to appear
+    command: oc get crd clusterpolicy.nvidia.com
+    register: has_clusterpolicy_cr
+    until: has_clusterpolicy_cr.rc != 1
     retries: 20
     delay: 15
 
@@ -67,6 +54,18 @@
 
   - name: Failing because the ClusterPolicy CR cannot be created
     fail: msg="Failed because the ClusterPolicy CR cannot be created"
+
+- name: Get the clusterpolicy of the GPU Operator from OperatorHub CSV
+  shell:
+    set -o pipefail;
+    oc get "{{ gpu_operator_csv_name_cmd.stdout }}"
+       -n openshift-operators
+       -ojson
+    | jq -r '.metadata.annotations."alm-examples"'
+    | jq .[0] > "{{ artifact_extra_logs_dir }}/gpu_operator_clusterpolicy.json"
+
+- name: Create the clusterPolicy CR for the GPU Operator
+  command: oc apply -f "{{ artifact_extra_logs_dir }}/gpu_operator_clusterpolicy.json"
 
 - name: Test if the ClusterPolicy has the 'validator' stanza
   command: oc get clusterpolicy.nvidia.com -ojsonpath='{range .items[*]}{.spec.validator.version}{end}'

--- a/roles/gpu_operator_deploy_from_operatorhub/tasks/deploy_clusterpolicy.yml
+++ b/roles/gpu_operator_deploy_from_operatorhub/tasks/deploy_clusterpolicy.yml
@@ -53,8 +53,8 @@
   rescue:
   - name: Inspect the Subscriptions status (debug)
     shell:
-      (oc get subscriptions -n openshift-operators &&
-       oc describe subscriptions/gpu-operator-certified -n openshift-operators)
+      (oc get subscriptions.operators.coreos.com -n openshift-operators &&
+       oc describe subscriptions.operators.coreos.com/gpu-operator-certified -n openshift-operators)
        > {{ artifact_extra_logs_dir }}/gpu_operator_Subscription.log
     failed_when: false
 

--- a/roles/gpu_operator_deploy_from_operatorhub/tasks/deploy_from_bundle.yml
+++ b/roles/gpu_operator_deploy_from_operatorhub/tasks/deploy_from_bundle.yml
@@ -9,7 +9,7 @@
 
 - name: Delete the bundle subscription, if it exists
   command:
-    oc delete subscription
+    oc delete subscription.operators.coreos.com
       -l operators.coreos.com/{{ deploy_bundle_package_name }}.{{ deploy_bundle_namespace }}
       -n {{ deploy_bundle_namespace }}
       --ignore-not-found=true

--- a/roles/nfd_operator_deploy_from_operatorhub/tasks/main.yml
+++ b/roles/nfd_operator_deploy_from_operatorhub/tasks/main.yml
@@ -132,7 +132,9 @@
     failed_when: false
 
   - name: Describe the NFD subscription (debug)
-    command: oc describe subscriptions.operators.coreos.com/nfd -n openshift-nfd
+    shell:
+      oc describe subscriptions.operators.coreos.com/nfd -n openshift-nfd
+         > {{ artifact_extra_logs_dir }}/nfd_subscription.desc
     failed_when: false
 
   - name: List the ClusterServiceVersion status (debug)
@@ -140,7 +142,9 @@
     failed_when: false
 
   - name: Describe the ClusterServiceVersion status (debug)
-    command: oc describe ClusterServiceVersion -n openshift-nfd
+    shell:
+      oc describe ClusterServiceVersion -n openshift-nfd
+         > {{ artifact_extra_logs_dir }}/nfd_ClusterServiceVersion.desc
     failed_when: false
 
   - name: Failed when creating the NFD NodeFeatureDiscovery CR

--- a/roles/nfd_operator_deploy_from_operatorhub/tasks/main.yml
+++ b/roles/nfd_operator_deploy_from_operatorhub/tasks/main.yml
@@ -128,11 +128,11 @@
     delay: 15
   rescue:
   - name: List the NFD subscription (debug)
-    command: oc get subscriptions -n openshift-nfd
+    command: oc get subscriptions.operators.coreos.com -n openshift-nfd
     failed_when: false
 
   - name: Describe the NFD subscription (debug)
-    command: oc describe subscriptions/nfd -n openshift-nfd
+    command: oc describe subscriptions.operators.coreos.com/nfd -n openshift-nfd
     failed_when: false
 
   - name: List the ClusterServiceVersion status (debug)


### PR DESCRIPTION
* 66cce04 - {nfd,gpu}_operator_deploy_from_operatorhub: sed/subscriptions/subscriptions.operators.coreos.com

`subscription` object name may be used by the KNative (in addition to
OLM):
```
$ oc get crd -A | grep subscriptions

subscriptions.messaging.knative.dev   2021-06-07T14:57:28Z
subscriptions.operators.coreos.com    2021-06-06T16:45:30Z
```

```
$ oc explain subscriptions

KIND:     Subscription

VERSION:  messaging.knative.dev/v1
```

This breaks commands expecting OLM subscription resources like
```
oc get subscription/nfd
```

---

* 737f0c5 - gpu_operator_deploy_from_operatorhub: wait for CRD instead of waiting for CR creating


---

* 413b3ea - Always store 'oc describe' into an {{ artifact_extra_logs_dir }} file


---