### PR TITLE
Backport: {nfd,gpu}_operator_deploy_from_operatorhub: sed/subscriptions/subscriptions.operators.coreos.com

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,19 @@
 
 (Organized release by release)
 
+Features of version 0.1.1 (July 2021)
+-------------------------------------
+
+Bug fixes
+~~~~~~~~~
+
+- Use ``subscriptions.operators.coreos.com`` instead of
+  ``subscriptions`` to avoid conflicts with Knative `subscriptions
+  <https://knative.dev/docs/eventing/channels/subscriptions>`_ `#207
+  <https://github.com/openshift-psap/ci-artifacts/pull/207>`_ `#208
+  <https://github.com/openshift-psap/ci-artifacts/pull/208>`_
+
+
 Features of version 0.1 (June 2021)
 -----------------------------------
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -104,7 +104,8 @@ Coding guidelines
 
     - name: Inspect the Subscriptions status (debug)
       shell:
-        oc describe subscriptions/gpu-operator-certified -n openshift-operators
+        oc describe subscriptions.operators.coreos.com/gpu-operator-certified
+           -n openshift-operators
            > {{ artifact_extra_logs_dir }}/gpu_operator_Subscription.log
       failed_when: false
 

--- a/roles/gpu_operator_deploy_from_operatorhub/tasks/deploy_clusterpolicy.yml
+++ b/roles/gpu_operator_deploy_from_operatorhub/tasks/deploy_clusterpolicy.yml
@@ -53,8 +53,8 @@
   rescue:
   - name: Inspect the Subscriptions status (debug)
     shell:
-      (oc get subscriptions -n openshift-operators &&
-       oc describe subscriptions/gpu-operator-certified -n openshift-operators)
+      (oc get subscriptions.operators.coreos.com -n openshift-operators &&
+       oc describe subscriptions.operators.coreos.com/gpu-operator-certified -n openshift-operators)
        > {{ artifact_extra_logs_dir }}/gpu_operator_Subscription.log
     failed_when: false
 

--- a/roles/gpu_operator_deploy_from_operatorhub/tasks/deploy_from_bundle.yml
+++ b/roles/gpu_operator_deploy_from_operatorhub/tasks/deploy_from_bundle.yml
@@ -9,7 +9,7 @@
 
 - name: Delete the bundle subscription, if it exists
   command:
-    oc delete subscription
+    oc delete subscription.operators.coreos.com
       -l operators.coreos.com/{{ deploy_bundle_package_name }}.{{ deploy_bundle_namespace }}
       -n {{ deploy_bundle_namespace }}
       --ignore-not-found=true

--- a/roles/nfd_deploy/tasks/main.yml
+++ b/roles/nfd_deploy/tasks/main.yml
@@ -119,11 +119,11 @@
     delay: 15
   rescue:
   - name: List the NFD subscription (debug)
-    command: oc get subscriptions -n openshift-nfd
+    command: oc get subscriptions.operators.coreos.com -n openshift-nfd
     failed_when: false
 
   - name: Describe the NFD subscription (debug)
-    command: oc describe subscriptions/nfd -n openshift-nfd
+    command: oc describe subscriptions.operators.coreos.com/nfd -n openshift-nfd
     failed_when: false
 
   - name: List the ClusterServiceVersion status (debug)


### PR DESCRIPTION
Backport of https://github.com/openshift-psap/ci-artifacts/pull/207 fix to `stable-v0.1` branch.