### PR TITLE
Fix clusterpolicy.nvidia.com -> clusterpolicies.nvidia.com typo that caused CI failures

### DIFF
--- a/roles/gpu_operator_deploy_from_operatorhub/tasks/deploy_clusterpolicy.yml
+++ b/roles/gpu_operator_deploy_from_operatorhub/tasks/deploy_clusterpolicy.yml
@@ -31,7 +31,7 @@
 
 - block:
   - name: Wait for the GPU Operator ClusterPolicy CRD to appear
-    command: oc get crd clusterpolicy.nvidia.com
+    command: oc get crd clusterpolicies.nvidia.com
     register: has_clusterpolicy_cr
     until: has_clusterpolicy_cr.rc != 1
     retries: 20
@@ -68,7 +68,7 @@
   command: oc apply -f "{{ artifact_extra_logs_dir }}/gpu_operator_clusterpolicy.json"
 
 - name: Test if the ClusterPolicy has the 'validator' stanza
-  command: oc get clusterpolicy.nvidia.com -ojsonpath='{range .items[*]}{.spec.validator.version}{end}'
+  command: oc get clusterpolicies.nvidia.com -ojsonpath='{range .items[*]}{.spec.validator.version}{end}'
   register: gpu_operator_atleast_v170
   failed_when: false
 

--- a/roles/gpu_operator_deploy_from_operatorhub/tasks/deploy_clusterpolicy.yml
+++ b/roles/gpu_operator_deploy_from_operatorhub/tasks/deploy_clusterpolicy.yml
@@ -32,8 +32,8 @@
 - block:
   - name: Wait for the GPU Operator ClusterPolicy CRD to appear
     command: oc get crd clusterpolicies.nvidia.com
-    register: has_clusterpolicy_cr
-    until: has_clusterpolicy_cr.rc != 1
+    register: has_clusterpolicy_crd
+    until: has_clusterpolicy_crd.rc != 1
     retries: 20
     delay: 15
 

--- a/roles/gpu_operator_deploy_from_operatorhub/tasks/deploy_from_bundle.yml
+++ b/roles/gpu_operator_deploy_from_operatorhub/tasks/deploy_from_bundle.yml
@@ -48,6 +48,8 @@
          -ojsonpath={.spec.template.spec.containers[0].image}
          | grep {{ psap_quay_master_operator }}
     register: operator_deployment_image
+    until:
+    - operator_deployment_image.rc == 0
     retries: 15
     delay: 30
 


### PR DESCRIPTION
b510172de7d22ec83994d2b5dfc5286651205ccd - Fix clusterpolicy.nvidia.com -> clusterpolicies.nvidia.com typo that caused CI failures

25c1df404007437e37e1ce7f561cb093deab2412 - Fix broken waiting for CSV controller operator deployment image stanza update. It was racey so it wasn't noticed until now

a1c5c94d3d39bda4fad5245f85ffc7b432cccd98 - has_clusterpolicy_cr renamed to more precise has_clusterpolicy_crd