### PR TITLE
Update gpu-operator image build for new Make target

### DIFF
--- a/roles/gpu_operator_bundle_from_commit/files/operator_bundle_image_builder_script.yml
+++ b/roles/gpu_operator_bundle_from_commit/files/operator_bundle_image_builder_script.yml
@@ -15,6 +15,12 @@ data:
     echo "OPERATOR_IMAGE_NAME=${OPERATOR_IMAGE_NAME}"
 
     CONTAINER_FILE=./bundle.Dockerfile
+    if [ ! -f ${CONTAINER_FILE} ]; then
+      # TODO: This branch allows for bundles to be built for the modified GPU operator make file.
+      # This was merged in https://github.com/NVIDIA/gpu-operator/commit/b0e99d9e6ac8738ee335f6e866242b1c9977ea09
+      # This can be set as the default once no older versions are built.
+      CONTAINER_FILE=./docker/bundle.Dockerfile
+    fi
     CONTEXT_LOCATION="."
 
     CSV_FILE=bundle/manifests/gpu-operator.clusterserviceversion.yaml

--- a/roles/gpu_operator_bundle_from_commit/files/operator_image_builder_script.yml
+++ b/roles/gpu_operator_bundle_from_commit/files/operator_image_builder_script.yml
@@ -20,15 +20,16 @@ data:
 
     git show --quiet
 
-    cat <<EOF > /usr/local/bin/docker
-    #! /bin/sh
-    exec podman --cgroup-manager=cgroupfs "\$@"
-    EOF
-    chmod u+x /usr/local/bin/docker
-
     CONTAINER_FILE=./Dockerfile
     if [ -f ${CONTAINER_FILE} ]; then
       # TODO: Remove this backwards compatible code once we stop testing versions that do not use the new Makefile
+
+      cat <<EOF > /usr/local/bin/docker
+      #! /bin/sh
+      exec podman --cgroup-manager=cgroupfs "\$@"
+      EOF
+      chmod u+x /usr/local/bin/docker
+
       if [ "${BUILDER_FROM_IMAGE}" ]; then
         # if provided, use custom 'FROM ... as builder' image
         sed "s|FROM golang:.* as builder|FROM ${BUILDER_FROM_IMAGE} as builder|" -i ${CONTAINER_FILE}
@@ -40,10 +41,13 @@ data:
     else
       # if provided, use custom 'FROM ... as builder' image by setting BUILDER_IMAGE variable
       # avoid docker.io quotas by setting CUDA_IMAGE
-      # This generates an images OUT_IMAGE (based on OPERATOR_IMAGE_NAME)
+      # The docker-image generates an image OUT_IMAGE (based on OPERATOR_IMAGE_NAME)
       make docker-image \
         REGISTRY="" \
-        OUT_IMAGE=${OPERATOR_IMAGE_NAME} CUDA_IMAGE=nvcr.io/nvidia/cuda ${BUILDER_FROM_IMAGE:+BUILDER_IMAGE=${BUILDER_FROM_IMAGE}}
+        DOCKER=podman \
+        OUT_IMAGE=${OPERATOR_IMAGE_NAME} \
+        CUDA_IMAGE=nvcr.io/nvidia/cuda \
+        ${BUILDER_FROM_IMAGE:+BUILDER_IMAGE=${BUILDER_FROM_IMAGE}}
     fi
 
     # push the image locally

--- a/roles/gpu_operator_bundle_from_commit/files/operator_image_builder_script.yml
+++ b/roles/gpu_operator_bundle_from_commit/files/operator_image_builder_script.yml
@@ -23,6 +23,7 @@ data:
     CONTAINER_FILE=./Dockerfile
     if [ -f ${CONTAINER_FILE} ]; then
       # TODO: Remove this backwards compatible code once we stop testing versions that do not use the new Makefile
+      # This was merged in https://github.com/NVIDIA/gpu-operator/commit/b0e99d9e6ac8738ee335f6e866242b1c9977ea09
 
       cat <<EOF > /usr/local/bin/docker
       #! /bin/sh

--- a/roles/gpu_operator_bundle_from_commit/files/operator_image_builder_script.yml
+++ b/roles/gpu_operator_bundle_from_commit/files/operator_image_builder_script.yml
@@ -26,13 +26,24 @@ data:
     EOF
     chmod u+x /usr/local/bin/docker
 
-    # if provided, use custom 'FROM ... as builder' image by setting BUILDER_IMAGE variable
-    # avoid docker.io quotas by setting CUDA_IMAGE
+    CONTAINER_FILE=./Dockerfile
+    if [ -f ${CONTAINER_FILE} ]; then
+      if [ "${BUILDER_FROM_IMAGE}" ]; then
+        # if provided, use custom 'FROM ... as builder' image
+        sed "s|FROM golang:.* as builder|FROM ${BUILDER_FROM_IMAGE} as builder|" -i ${CONTAINER_FILE}
+      fi
 
-    # This generates an images OUT_IMAGE (based on OPERATOR_IMAGE_NAME)
-    make docker-image \
-      REGISTRY="" \
-      OUT_IMAGE=${OPERATOR_IMAGE_NAME} CUDA_IMAGE=nvcr.io/nvidia/cuda ${BUILDER_FROM_IMAGE:+BUILDER_IMAGE=${BUILDER_FROM_IMAGE}}
+      # avoid docker.io quotas ...
+      sed -i 's|FROM nvidia/cuda:|FROM nvcr.io/nvidia/cuda:|' ${CONTAINER_FILE}
+      make docker-build IMG=${OPERATOR_IMAGE_NAME}
+    else
+      # if provided, use custom 'FROM ... as builder' image by setting BUILDER_IMAGE variable
+      # avoid docker.io quotas by setting CUDA_IMAGE
+      # This generates an images OUT_IMAGE (based on OPERATOR_IMAGE_NAME)
+      make docker-image \
+        REGISTRY="" \
+        OUT_IMAGE=${OPERATOR_IMAGE_NAME} CUDA_IMAGE=nvcr.io/nvidia/cuda ${BUILDER_FROM_IMAGE:+BUILDER_IMAGE=${BUILDER_FROM_IMAGE}}
+    fi
 
     # push the image locally
 

--- a/roles/gpu_operator_bundle_from_commit/files/operator_image_builder_script.yml
+++ b/roles/gpu_operator_bundle_from_commit/files/operator_image_builder_script.yml
@@ -28,6 +28,7 @@ data:
 
     CONTAINER_FILE=./Dockerfile
     if [ -f ${CONTAINER_FILE} ]; then
+      # TODO: Remove this backwards compatible code once we stop testing versions that do not use the new Makefile
       if [ "${BUILDER_FROM_IMAGE}" ]; then
         # if provided, use custom 'FROM ... as builder' image
         sed "s|FROM golang:.* as builder|FROM ${BUILDER_FROM_IMAGE} as builder|" -i ${CONTAINER_FILE}

--- a/roles/gpu_operator_bundle_from_commit/files/operator_image_builder_script.yml
+++ b/roles/gpu_operator_bundle_from_commit/files/operator_image_builder_script.yml
@@ -12,8 +12,6 @@ data:
 
     echo "OPERATOR_IMAGE_NAME=${OPERATOR_IMAGE_NAME}"
 
-    CONTAINER_FILE=./Dockerfile
-
     mkdir /work && cd /work
 
     git clone ${OPERATOR_GIT_REPO} gpu-operator -b ${OPERATOR_GIT_REF} --depth 1
@@ -22,21 +20,19 @@ data:
 
     git show --quiet
 
-    if [ "${BUILDER_FROM_IMAGE}" ]; then
-      # if provided, use custom 'FROM ... as builder' image
-      sed "s|FROM golang:.* as builder|FROM ${BUILDER_FROM_IMAGE} as builder|" -i ${CONTAINER_FILE}
-    fi
-
-    # avoid docker.io quotas ...
-    sed -i 's|FROM nvidia/cuda:|FROM nvcr.io/nvidia/cuda:|' ${CONTAINER_FILE}
-
     cat <<EOF > /usr/local/bin/docker
     #! /bin/sh
     exec podman --cgroup-manager=cgroupfs "\$@"
     EOF
     chmod u+x /usr/local/bin/docker
 
-    make docker-build IMG=${OPERATOR_IMAGE_NAME}
+    # if provided, use custom 'FROM ... as builder' image by setting BUILDER_IMAGE variable
+    # avoid docker.io quotas by setting CUDA_IMAGE
+
+    # This generates an images OUT_IMAGE (based on OPERATOR_IMAGE_NAME)
+    make docker-image \
+      REGISTRY="" \
+      OUT_IMAGE=${OPERATOR_IMAGE_NAME} CUDA_IMAGE=nvcr.io/nvidia/cuda ${BUILDER_FROM_IMAGE:+BUILDER_IMAGE=${BUILDER_FROM_IMAGE}}
 
     # push the image locally
 

--- a/roles/gpu_operator_bundle_from_commit/files/operator_image_builder_script.yml
+++ b/roles/gpu_operator_bundle_from_commit/files/operator_image_builder_script.yml
@@ -28,7 +28,7 @@ data:
       cat <<EOF > /usr/local/bin/docker
       #! /bin/sh
       exec podman --cgroup-manager=cgroupfs "\$@"
-      EOF
+    EOF
       chmod u+x /usr/local/bin/docker
 
       if [ "${BUILDER_FROM_IMAGE}" ]; then
@@ -44,7 +44,7 @@ data:
       # avoid docker.io quotas by setting CUDA_IMAGE
       # The docker-image generates an image OUT_IMAGE (based on OPERATOR_IMAGE_NAME)
       make docker-image \
-        REGISTRY="" \
+        VERSION=$(git rev-parse --short HEAD) \
         DOCKER=podman \
         OUT_IMAGE=${OPERATOR_IMAGE_NAME} \
         CUDA_IMAGE=nvcr.io/nvidia/cuda \


### PR DESCRIPTION
This change modifies the process of building a new GPU Operator image
from a particular commit to match the updated make process. This includes
support for specifying base images through make variables (docker build args)
and removes the need for executing sed commands on the docker files.

See https://gitlab.com/nvidia/kubernetes/gpu-operator/-/merge_requests/251

Signed-off-by: Evan Lezar <elezar@nvidia.com>