### PR TITLE
fixes toolbox/gpu-operator/deploy_from_operatorhub.sh regression, it didnt accept more than one parameter

### DIFF
--- a/toolbox/gpu-operator/deploy_from_operatorhub.sh
+++ b/toolbox/gpu-operator/deploy_from_operatorhub.sh
@@ -37,8 +37,8 @@ if [[ "${1:-}" == "--help" || "${1:-}" == -h ]]; then
     exit 0
 fi
 
-if [ "$#" -gt 1 ]; then
-    echo "FATAL: expected 0 or 1 parameter ... (got '$@')"
+if [ "$#" -gt 2 ]; then
+    echo "FATAL: expected 2 parameters or less ... (got '$@')"
     usage
     exit 1
 elif [[ "${1:-}" == "$DEPLOY_FROM_BUNDLE_FLAG"* ]]; then


### PR DESCRIPTION
This fixes CI failures from lines like:
openshift/release@4a04e51/ci-operator/config/openshift-psap/ci-artifacts/openshift-psap-ci-artifacts-release-4.6.yaml#L90

Which pass 2 parameters (version and channel) to said script
