### PR TITLE
entitlement_test_wait_deployment: check PEM expiration date and warn if it expires in less that 48h.

### DIFF
--- a/roles/entitlement_test_wait_deployment/files/entitlement-tester_entrypoint.yml
+++ b/roles/entitlement_test_wait_deployment/files/entitlement-tester_entrypoint.yml
@@ -73,6 +73,15 @@ data:
       fi
     done
 
+    # inspect the PEM certificate "notAfter" date
+    yum install -yq openssl
+
+    EXPIRATION_WARNING_DELAY_HR=48
+    openssl x509 -enddate -noout -in /etc/pki/entitlement-host/entitlement.pem # prints the `notAfter` date
+    if ! openssl x509 -checkend $(($EXPIRATION_WARNING_DELAY_HR * 60 * 60)) -noout -in /etc/pki/entitlement-host/entitlement.pem; then
+      echo "WARNING: PEM certificate expires in less than ${EXPIRATION_WARNING_DELAY_HR} hours ..."
+    fi
+
     echo
     echo "# ensure that RH repositories can be accessed"
 


### PR DESCRIPTION
A follow-up task could be to do this check before deploying the key, and writing a warning into `$ARTIFACT_DIR/WARNING` if it is expiring soon. `ci-dashboard` could also display the content of this file ...