### PR TITLE
{nfd,gpu}_operator_deploy_from_operatorhub: better wait for packagemanifest to be available

### DIFF
--- a/roles/gpu_operator_deploy_from_operatorhub/tasks/deploy_from_catalog.yml
+++ b/roles/gpu_operator_deploy_from_operatorhub/tasks/deploy_from_catalog.yml
@@ -7,26 +7,13 @@
          '-ojsonpath={.status.connectionState.lastObservedState}{"\n"}'
     failed_when: false
 
-  - name: Ensure that the GPU Operator PackageManifest exists
-    command: oc get packagemanifests/gpu-operator-certified -n openshift-marketplace
-    failed_when: false
-    register: gpu_operator_package_available
-
-  - name: Wait for the GPU Operator to be available or its catalog to be fully populated
-    when: gpu_operator_package_available.rc != 0
-    shell:
+  - name: Wait for the GPU Operator to be available
+    command:
       oc get packagemanifests/gpu-operator-certified -n openshift-marketplace
-         ||
-      test $(oc get -oyaml CatalogSource/certified-operators
-                -n openshift-marketplace
-                '-ojsonpath={.status.connectionState.lastObservedState}{"\n"}') == "READY"
     register: gpu_operator_package_wait
     until: gpu_operator_package_wait.rc == 0
     retries: 15
     delay: 30
-
-  - name: Ensure that the GPU Operator PackageManifest exists
-    command: oc get packagemanifests/gpu-operator-certified -n openshift-marketplace
 
   - name: Save the GPU Operator PackageManifest (debug)
     shell:

--- a/roles/nfd_operator_deploy_from_operatorhub/tasks/main.yml
+++ b/roles/nfd_operator_deploy_from_operatorhub/tasks/main.yml
@@ -7,26 +7,13 @@
          '-ojsonpath={.status.connectionState.lastObservedState}{"\n"}'
     failed_when: false
 
-  - name: Ensure that the NFD Operator PackageManifest exists
-    command: oc get packagemanifests/nfd -n openshift-marketplace
-    failed_when: false
-    register: nfd_package_available
-
-  - name: Wait for the NFD to be available or its catalog to be fully populated
-    when: nfd_package_available.rc != 0
-    shell:
+  - name: Wait for the NFD to be available
+    command:
       oc get packagemanifests/nfd -n openshift-marketplace
-         ||
-      test $(oc get -oyaml CatalogSource/redhat-operators
-                -n openshift-marketplace
-                '-ojsonpath={.status.connectionState.lastObservedState}{"\n"}') == "READY"
     register: nfd_package_wait
     until: nfd_package_wait.rc == 0
     retries: 15
     delay: 30
-
-  - name: Ensure that the NFD Operator PackageManifest exists
-    command: oc get packagemanifests/nfd -n openshift-marketplace
 
   rescue:
   - name: Mark the failure as flake


### PR DESCRIPTION
Cluster Pools (cf this https://github.com/openshift/release/pull/20601) fail because of this error:
```
2021-07-27 09:18:54,314 p=2875 u=psap-ci-runner n=ansible | roles/nfd_operator_deploy_from_operatorhub/tasks/main.yml:10
2021-07-27 09:18:54,314 p=2875 u=psap-ci-runner n=ansible | TASK: nfd_operator_deploy_from_operatorhub : Ensure that the NFD Operator PackageManifest exists
2021-07-27 09:18:54,314 p=2875 u=psap-ci-runner n=ansible | msg: non-zero return code
2021-07-27 09:18:54,314 p=2875 u=psap-ci-runner n=ansible | 
2021-07-27 09:18:54,315 p=2875 u=psap-ci-runner n=ansible | <command> oc get packagemanifests/nfd -n openshift-marketplace
2021-07-27 09:18:54,315 p=2875 u=psap-ci-runner n=ansible | 
2021-07-27 09:18:54,315 p=2875 u=psap-ci-runner n=ansible | <stderr> error: the server doesn't have a resource type "packagemanifests"
2021-07-27 09:18:54,324 p=2875 u=psap-ci-runner n=ansible | 
2021-07-27 09:18:54,324 p=2875 u=psap-ci-runner n=ansible | Tuesday 27 July 2021  09:18:54 +0000 (0:00:00.531)       0:00:01.602 ********** 
2021-07-27 09:18:54,959 p=2875 u=psap-ci-runner n=ansible | ---
```
(the resource `type` is not available). That's not expected and not something we hit before. 
This PR makes sure we wait for the package manifest to be available.

---

The previous code was "waiting" (as opposed to checking) for the catalogue operator to be Ready or the package to be available (assuming that when the operator is ready, everything else shouldn't move anymore)

now, the code simply waits for the package to be available, oblivious to other implementation considerations