### PR TITLE
CI: fix ci_entrypoint_gpu-operator test_operatorhub()

### DIFF
--- a/build/root/usr/local/bin/ci_entrypoint_gpu-operator.sh
+++ b/build/root/usr/local/bin/ci_entrypoint_gpu-operator.sh
@@ -87,11 +87,11 @@ test_commit() {
 
 test_operatorhub() {
     if [ "${1:-}" ]; then
-        OPERATOR_VERSION="--version={$1}"
+        OPERATOR_VERSION="--version=$1"
     fi
     shift || true
     if [ "${1:-}" ]; then
-        OPERATOR_CHANNEL="--channel={$1}"
+        OPERATOR_CHANNEL="--channel=$1"
     fi
 
     prepare_cluster_for_gpu_operator


### PR DESCRIPTION
Without this fix, the code produces:
```
+ '[' 1.4.0 ']'
+ OPERATOR_VERSION='--version={1.4.0}'
+ shift
+ '[' stable ']'
+ OPERATOR_CHANNEL='--channel={stable}'
```
https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/periodic-ci-openshift-psap-ci-artifacts-release-4.5-gpu-operator-e2e-140/1420157171710038016/artifacts/gpu-operator-e2e-140/nightly/build-log.txt