### PR TITLE
toolbox: gpu_operator: deploy_from_operatorhub: fix channel/version mismatch

### DIFF
--- a/toolbox/gpu_operator.py
+++ b/toolbox/gpu_operator.py
@@ -81,7 +81,7 @@ class GPUOperator:
                 print("Channel may only be specified if --version is specified")
                 sys.exit(1)
 
-            opts["gpu_operator_operatorhub_channel"] = version
+            opts["gpu_operator_operatorhub_channel"] = channel
             print(
                 f"Deploying the GPU Operator from OperatorHub using channel '{channel}'."
             )


### PR DESCRIPTION
```
apiVersion: operators.coreos.com/v1alpha1
kind: Subscription
metadata:
  name: gpu-operator-certified
  namespace: openshift-operators
spec:
  channel: "1.5.2" <-- wrong channel (this is the version)
```
https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/openshift_release/20625/rehearse-20625-periodic-ci-openshift-psap-ci-artifacts-release-4.6-gpu-operator-e2e-152/1420294373391732736/artifacts/gpu-operator-e2e-152/nightly/artifacts/009__gpu_operator__deploy_from_operatorhub/gpu_operator_sub.yml