### PR TITLE
gpu_operator_run_gpu-burn: adjust hostname label on OCP >= 4.9

### DIFF
--- a/roles/check_deps/tasks/main.yml
+++ b/roles/check_deps/tasks/main.yml
@@ -12,6 +12,7 @@
     # see the 'fail' message below before modifying this command,
     # it verifies that the main dependencies are met.
     shell:
+      set -eo pipefail;
       oc version -o json
       | jq --raw-output '.openshiftVersion'
       | cut -b-3
@@ -30,3 +31,17 @@
 - name: 'Store openshift_release={{ ocp_version.stdout }}'
   set_fact:
     openshift_release: "{{ ocp_version.stdout }}"
+
+- name: Get openshift major and minor version
+  shell:
+    set -eo pipefail;
+    echo "{{ openshift_release }}" | tr '.' '\n'
+  register: ocp_major_minor_version
+
+- name: Store openshift major and minor version
+  set_fact:
+    openshift_release_major: "{{ ocp_major_minor_version.stdout[0] }}"
+    openshift_release_minor: "{{ ocp_major_minor_version.stdout[2] }}"
+
+- name: Store openshift major and minor version
+  debug: msg="openshift_release_major='{{ openshift_release_major }}', openshift_release_minor='{{ openshift_release_minor }}'"

--- a/roles/gpu_operator_run_gpu-burn/files/gpu_burn_pod.yml
+++ b/roles/gpu_operator_run_gpu-burn/files/gpu_burn_pod.yml
@@ -3,7 +3,7 @@ kind: Pod
 metadata:
   labels:
     app: gpu-burn
-  name: gpu-burn-{{ gpu_node_hostname }}
+  name: gpu-burn-{{ gpu_node_name }}
   namespace: default
 spec:
   restartPolicy: Never

--- a/roles/gpu_operator_run_gpu-burn/tasks/main.yml
+++ b/roles/gpu_operator_run_gpu-burn/tasks/main.yml
@@ -16,7 +16,6 @@
        -lnvidia.com/gpu.present=true
        -o custom-columns=NAME:metadata.name
        --no-headers
-    | cut -d. -f1
   register: gpu_burn_gpu_nodes
   failed_when: gpu_burn_gpu_nodes.stdout == ""
 
@@ -32,10 +31,17 @@
   with_items: "{{ gpu_burn_gpu_nodes.stdout_lines }}"
   shell: |
     set -eo pipefail;
-    GPU_NODE_HOSTNAME=$(echo '{{ item }}' );
+
+    if [[ "{{ openshift_release_major }}" == 4 && "{{ openshift_release_minor }}" -le 8 ]]; then
+      GPU_NODE_HOSTNAME=$(echo '{{ item }}' | cut -d. -f1);
+    else
+      GPU_NODE_HOSTNAME=$(echo '{{ item }}' );
+    fi
+
     echo "Hostname: $GPU_NODE_HOSTNAME";
     oc --ignore-not-found=true delete pod/gpu-burn-$GPU_NODE_HOSTNAME -n default
     cat "{{ gpu_burn_pod }}" \
+      | sed "s|{{ '{{' }} gpu_node_name {{ '}}' }}|{{ item }}|" \
       | sed "s|{{ '{{' }} gpu_node_hostname {{ '}}' }}|$GPU_NODE_HOSTNAME|" \
       | sed "s|{{ '{{' }} gpu_burn_time {{ '}}' }}|{{ gpu_burn_time }}|" \
       | oc apply -f-

--- a/roles/gpu_operator_wait_deployment/tasks/main.yml
+++ b/roles/gpu_operator_wait_deployment/tasks/main.yml
@@ -65,7 +65,7 @@
     register: has_gpu_feature_discovery_labels
     until:
     - has_gpu_feature_discovery_labels.stdout != ""
-    retries: 10
+    retries: 20
     delay: 30
 
   rescue:


### PR DESCRIPTION
With OCP 4.9, the `hostname` label changed from
```
"kubernetes.io/hostname": "ip-10-0-144-116",
```
to
```
"kubernetes.io/hostname": "ip-10-0-144-116.us-west-2.compute.internal",
```

GPU Burn relies on node label to be forcefully scheduled on all the
nodes with GPUs (to ensure that all the GPUs of all the nodes are
able to run CUDA workload).