### PR TITLE
WIP Test upgrades using canary images

### DIFF
--- a/build/root/usr/local/bin/ci_entrypoint_custom.sh
+++ b/build/root/usr/local/bin/ci_entrypoint_custom.sh
@@ -1,0 +1,14 @@
+#! /usr/bin/env bash
+
+set -o pipefail
+set -o errexit
+set -o nounset
+
+# This file intentionally left blank.
+
+# This file will run when you comment "/test custom" on your PR.
+# Feel free to modify this file to run whatever you want in order to test your PR
+# Please restore the file to this original state once you're done
+
+set -x
+run gpu-operator test_upgrade_commit

--- a/playbooks/build-canary.yml
+++ b/playbooks/build-canary.yml
@@ -1,0 +1,7 @@
+---
+- name: Build an operand image canary on the local cluster
+  hosts: localhost
+  connection: local
+  gather_facts: true
+  roles:
+    - role: build-canary

--- a/roles/build-canary/defaults/main/config.yml
+++ b/roles/build-canary/defaults/main/config.yml
@@ -1,0 +1,12 @@
+---
+# The namespace to place the BuildConfig and ImageStream resources in. This should be the same namespaces as the pods
+# that pull the built operand image. 
+build_operand_canary_namespace: ""
+
+# The name that will be given to the ImageStream, BuildConfig and Build resources. This is also the name of the
+# operand image that will be built and pushed to the {{ build_operand_canary_namespace }} repository in the internal
+# cluster registry
+build_operand_canary_imagestream_name: ""
+
+# The image tag of the operand image in the internal registry
+build_operand_canary_tag: ""

--- a/roles/build-canary/meta/main.yml
+++ b/roles/build-canary/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - role: check_deps

--- a/roles/build-canary/tasks/main.yml
+++ b/roles/build-canary/tasks/main.yml
@@ -1,0 +1,140 @@
+---
+- name: Make sure imagestream name is set
+  when: not build_operand_canary_imagestream_name
+  fail: msg="Failed because build_operand_canary_imagestream_name has to be set"
+
+- name: Make sure build_operand_canary_tag is set
+  when: not build_operand_canary_tag
+  fail: msg="Failed because build_operand_canary_tag has to be set"
+
+- name: Create the namespace manifest
+  template:
+    src: "{{ build_operand_canary_namespace_deployment }}"
+    dest: "{{ artifact_extra_logs_dir }}/{{ build_operand_canary_imagestream_name }}_namespace.yml"
+
+- name: Apply the namespace manifest
+  command:
+    oc apply -f "{{ artifact_extra_logs_dir }}/{{ build_operand_canary_imagestream_name }}_namespace.yml"
+
+- name: Create the imagestream manifest
+  template:
+    src: "{{ build_operand_canary_imagestream }}"
+    dest: "{{ artifact_extra_logs_dir }}/{{ build_operand_canary_imagestream_name }}_imagestream.yml"
+
+- name: Apply the namespace manifest
+  command:
+    oc apply -f "{{ artifact_extra_logs_dir }}/{{ build_operand_canary_imagestream_name }}_imagestream.yml"
+
+- name: Search if the CI image exists
+  command: oc get imagestreamtag \
+              -n "{{ build_operand_canary_namespace }}" \
+              "{{ build_operand_canary_imagestream_name }}:{{ build_operand_canary_tag }}" \
+              -oname --ignore-not-found
+  register: has_ci_image
+
+- name: Build the CI image
+  when: has_ci_image.stdout == ""
+  block:
+  - name: Wait for the GPU Operator OperatorHub ClusterServiceVersion name
+    command:
+      oc get ClusterServiceVersion
+         -l operators.coreos.com/gpu-operator-certified.openshift-operators
+         -oname
+         -n openshift-operators
+    register: gpu_operator_csv_name_cmd
+    until: gpu_operator_csv_name_cmd.stdout != ""
+    retries: 15
+    delay: 30
+
+  - name: Get the clusterpolicy of the GPU Operator from OperatorHub CSV
+    shell:
+      set -o pipefail;
+      oc get "{{ gpu_operator_csv_name_cmd.stdout }}"
+         -n openshift-operators
+         -ojson
+      | jq -r '.metadata.annotations."alm-examples"'
+      | jq .[0] > "{{ artifact_extra_logs_dir }}/gpu_operator_clusterpolicy.json"
+
+  - name: input_clusterpolicy
+    set_fact: 
+      input_clusterpolicy: "{{ artifact_extra_logs_dir }}/gpu_operator_clusterpolicy.json"
+
+  - name: Get the repo/image:version for all the operands
+    block:
+    - command: jq -r '.spec.dcgmExporter.version' {{ input_clusterpolicy }}
+      register: dcgm_exporter_operand_tag
+    - command: jq -r '.spec.dcgmExporter.repository' {{ input_clusterpolicy }}
+      register: dcgm_exporter_operand_repo
+    - command: jq -r '.spec.dcgmExporter.image' {{ input_clusterpolicy }}
+      register: dcgm_exporter_operand_image
+    - command: jq -r '.spec.dcgm.version' {{ input_clusterpolicy }}
+      register: dcgm_operand_tag
+    - command: jq -r '.spec.dcgm.repository' {{ input_clusterpolicy }}
+      register: dcgm_operand_repo
+    - command: jq -r '.spec.dcgm.image' {{ input_clusterpolicy }}
+      register: dcgm_operand_image
+    - command: jq -r '.spec.devicePlugin.version' {{ input_clusterpolicy }}
+      register: device_plugin_operand_tag
+    - command: jq -r '.spec.devicePlugin.repository' {{ input_clusterpolicy }}
+      register: device_plugin_operand_repo
+    - command: jq -r '.spec.devicePlugin.image' {{ input_clusterpolicy }}
+      register: device_plugin_operand_image
+    - command: jq -r '.spec.driver.manager.version' {{ input_clusterpolicy }}
+      register: driver_manager_operand_tag
+    - command: jq -r '.spec.driver.manager.repository' {{ input_clusterpolicy }}
+      register: driver_manager_operand_repo
+    - command: jq -r '.spec.driver.manager.image' {{ input_clusterpolicy }}
+      register: driver_manager_operand_image
+    - command: jq -r '.spec.driver.version' {{ input_clusterpolicy }}
+      register: driver_operand_tag
+    - command: jq -r '.spec.driver.repository' {{ input_clusterpolicy }}
+      register: driver_operand_repo
+    - command: jq -r '.spec.driver.image' {{ input_clusterpolicy }}
+      register: driver_operand_image
+    - command: jq -r '.spec.gfd.version' {{ input_clusterpolicy }}
+      register: gfd_operand_tag
+    - command: jq -r '.spec.gfd.repository' {{ input_clusterpolicy }}
+      register: gfd_operand_repo
+    - command: jq -r '.spec.gfd.image' {{ input_clusterpolicy }}
+      register: gfd_operand_image
+    - command: jq -r '.spec.validator.version' {{ input_clusterpolicy }}
+      register: validator_operand_tag
+    - command: jq -r '.spec.validator.repository' {{ input_clusterpolicy }}
+      register: validator_operand_repo
+    - command: jq -r '.spec.validator.image' {{ input_clusterpolicy }}
+      register: validator_operand_image
+    - command: jq -r '.spec.migManager.version' {{ input_clusterpolicy }}
+      register: mig_manager_operand_tag
+    - command: jq -r '.spec.migManager.repository' {{ input_clusterpolicy }}
+      register: mig_manager_operand_repo
+    - command: jq -r '.spec.migManager.image' {{ input_clusterpolicy }}
+      register: mig_manager_operand_image
+    - command: jq -r '.spec.toolkit.version' {{ input_clusterpolicy }}
+      register: container_toolkit_operand_tag
+    - command: jq -r '.spec.toolkit.repository' {{ input_clusterpolicy }}
+      register: container_toolkit_operand_repo
+    - command: jq -r '.spec.toolkit.image' {{ input_clusterpolicy }}
+      register: container_toolkit_operanaimageg
+    - command: jq -r '.spec.nodeStatusExporter.version' {{ input_clusterpolicy }}
+      register: node_status_exporter_operand_tag
+    - command: jq -r '.spec.nodeStatusExporter.repository' {{ input_clusterpolicy }}
+      register: node_status_exporter_operand_repo
+    - command: jq -r '.spec.nodeStatusExporter.image' {{ input_clusterpolicy }}
+      register: node_status_exporter_operand_image
+
+  - name: Render buildconfig template
+    template:
+      src: "{{ operand_buildconfig }}"
+      dest: "{{ artifact_extra_logs_dir }}/{{ build_operand_canary_imagestream_name }}_buildconfig.yml"
+
+  - name: Delete any old image builder manifest
+    command: oc delete -f "{{ artifact_extra_logs_dir }}/{{ build_operand_canary_imagestream_name }}_buildconfig.yml" --ignore-not-found
+
+  - name: Apply the buildconfig manifest
+    command: oc apply -f "{{ artifact_extra_logs_dir }}/{{ build_operand_canary_imagestream_name }}_buildconfig.yml"
+
+  - name: Wait for the image to be built
+    shell: oc logs -f "buildconfig/{{ build_operand_canary_imagestream_name }}" -n "{{ build_operand_canary_namespace }}" > /dev/null
+
+- name: Ensure that the image exists
+  command: oc get imagestreamtag -n "{{ build_operand_canary_namespace }}" "{{ build_operand_canary_imagestream_name }}:{{ build_operand_canary_tag }}" -oname

--- a/roles/build-canary/templates/imagestream.yml.j2
+++ b/roles/build-canary/templates/imagestream.yml.j2
@@ -1,0 +1,9 @@
+---
+kind: ImageStream
+apiVersion: v1
+metadata:
+  name: "{{ build_operand_canary_imagestream_name }}"
+  namespace: "{{ build_operand_canary_namespace }}"
+  labels:
+    app: ci-artifacts
+spec: {}

--- a/roles/build-canary/templates/namespace.yml.j2
+++ b/roles/build-canary/templates/namespace.yml.j2
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: "{{ build_operand_canary_namespace }}"
+  labels:
+    app: ci-artifacts

--- a/roles/build-canary/vars/main/resources.yml
+++ b/roles/build-canary/vars/main/resources.yml
@@ -1,0 +1,3 @@
+---
+build_operand_canary_namespace_deployment: roles/build-canary/templates/namespace.yml.j2
+build_operand_canary_imagestream: roles/build-canary/templates/imagestream.yml.j2

--- a/run_toolbox.py
+++ b/run_toolbox.py
@@ -2,21 +2,15 @@
 
 import sys
 
-try:
-    import fire
-except ModuleNotFoundError:
-    print("The toolbox requires the Python `fire` package, see requirements.txt for a full list of requirements")
-    sys.exit(1)
-
+from toolbox.benchmarking import Benchmarking
 from toolbox.cluster import Cluster
 from toolbox.entitlement import Entitlement
 from toolbox.gpu_operator import GPUOperator
+from toolbox.local_ci import LocalCI
 from toolbox.nfd import NFD
 from toolbox.nfd_operator import NFDOperator
-from toolbox.local_ci import LocalCI
 from toolbox.repo import Repo
 from toolbox.special_resource_operator import SpecialResourceOperator
-from toolbox.benchmarking import Benchmarking
 
 
 class Toolbox:
@@ -41,7 +35,14 @@ class Toolbox:
         self.sro = SpecialResourceOperator
         self.benchmarking = Benchmarking
 
+
 def main(no_exit=False):
+    try:
+        import fire
+    except ModuleNotFoundError:
+        print("The toolbox requires the Python `fire` package, see requirements.txt for a full list of requirements")
+        sys.exit(1)
+
     # Print help rather than opening a pager
     fire.core.Display = lambda lines, out: print(*lines, file=out)
 

--- a/testing/custom/test_canary.sh
+++ b/testing/custom/test_canary.sh
@@ -1,0 +1,15 @@
+#! /usr/bin/env bash
+
+set -o pipefail
+set -o errexit
+set -o nounset
+
+# This file intentionally left blank.
+
+# This file will run when you comment "/test custom" on your PR.
+# Feel free to modify this file to run whatever you want in order to test your PR
+# Please restore the file to this original state once you're done
+
+source $THIS_DIR/../nightly/gpu-operator.sh source
+
+test_upgrade_commit

--- a/testing/nightly/gpu-operator/meld.jq
+++ b/testing/nightly/gpu-operator/meld.jq
@@ -1,0 +1,13 @@
+# recursively combines two composite JSON entities by concatenating arrays at the same position
+# taken from https://stackoverflow.com/a/53666584/791430
+def meld(a; b):
+  a as $a | b as $b
+  | if ($a|type) == "object" and ($b|type) == "object"
+    then reduce ([$a,$b]|add|keys_unsorted[]) as $k ({}; 
+      .[$k] = meld( $a[$k]; $b[$k]) )
+    elif ($a|type) == "array" and ($b|type) == "array"
+    then $a+$b
+    elif $b == null then $a
+    else $b
+    end;
+

--- a/testing/nightly/gpu-operator/upgrade_env_canaries.json
+++ b/testing/nightly/gpu-operator/upgrade_env_canaries.json
@@ -1,0 +1,84 @@
+{
+  "spec": {
+    "dcgmExporter": {
+      "env": [
+        {
+          "name": "CI_UPGRADE_CANARY",
+          "value": "UPGRADED"
+        }
+      ]
+    },
+    "dcgm": {
+      "env": [
+        {
+          "name": "CI_UPGRADE_CANARY",
+          "value": "UPGRADED"
+        }
+      ]
+    },
+    "devicePlugin": {
+      "env": [
+        {
+          "name": "CI_UPGRADE_CANARY",
+          "value": "UPGRADED"
+        }
+      ]
+    },
+    "driver": {
+      "env": [
+         {
+           "name": "CI_UPGRADE_CANARY",
+           "value": "UPGRADED"
+         }
+      ],
+      "manager": {
+        "env": [
+          {
+            "name": "CI_UPGRADE_CANARY",
+            "value": "UPGRADED"
+          }
+        ]
+      }
+    },
+    "gfd": {
+      "env": [
+        {
+          "name": "CI_UPGRADE_CANARY",
+          "value": "UPGRADED"
+        }
+      ]
+    },
+    "migManager": {
+      "env": [
+        {
+          "name": "CI_UPGRADE_CANARY",
+          "value": "UPGRADED"
+        }
+      ]
+    },
+    "nodeStatusExporter": {
+      "env": [
+        {
+          "name": "CI_UPGRADE_CANARY",
+          "value": "UPGRADED"
+        }
+      ]
+    },
+    "toolkit": {
+      "env": [
+        {
+          "name": "CI_UPGRADE_CANARY",
+          "value": "UPGRADED"
+        }
+      ]
+    },
+    "validator": {
+      "env": [
+        {
+          "name": "CI_UPGRADE_CANARY",
+          "value": "UPGRADED"
+        }
+      ]
+    }
+  }
+}

--- a/testing/nightly/gpu-operator/upgrade_image_canaries.json
+++ b/testing/nightly/gpu-operator/upgrade_image_canaries.json
@@ -1,0 +1,45 @@
+{
+  "spec": {
+    "dcgmExporter": {
+      "version": "latest",
+      "repository": "image-registry.openshift-image-registry.svc:5000/gpu-operator-resources"
+    },
+    "dcgm": {
+      "version": "latest",
+      "repository": "image-registry.openshift-image-registry.svc:5000/gpu-operator-resources"
+    },
+    "devicePlugin": {
+      "version": "latest",
+      "repository": "image-registry.openshift-image-registry.svc:5000/gpu-operator-resources"
+    },
+    "driver": {
+      "version": "latest",
+      "repository": "image-registry.openshift-image-registry.svc:5000/gpu-operator-resources",
+      "manager": {
+        "version": "latest",
+        "repository": "image-registry.openshift-image-registry.svc:5000/gpu-operator-resources"
+      }
+    },
+    "gfd": {
+      "version": "latest",
+      "repository": "image-registry.openshift-image-registry.svc:5000/gpu-operator-resources"
+    },
+    "migManager": {
+      "version": "latest",
+      "repository": "image-registry.openshift-image-registry.svc:5000/gpu-operator-resources"
+    },
+    "nodeStatusExporter": {
+      "image": "node-status-exporter",
+      "version": "latest",
+      "repository": "image-registry.openshift-image-registry.svc:5000/gpu-operator-resources"
+    },
+    "toolkit": {
+      "version": "latest",
+      "repository": "image-registry.openshift-image-registry.svc:5000/gpu-operator-resources"
+    },
+    "validator": {
+      "version": "latest",
+      "repository": "image-registry.openshift-image-registry.svc:5000/gpu-operator-resources"
+    }
+  }
+}

--- a/toolbox/_common.py
+++ b/toolbox/_common.py
@@ -4,6 +4,7 @@ import os
 import time
 import sys
 from pathlib import Path
+from typing import Iterable
 
 
 top_dir = Path(__file__).resolve().parent.parent
@@ -36,6 +37,38 @@ class PlaybookRun:
 
     def _run(self):
         run_ansible_playbook(self.playbook_name, self.opts)
+
+class PlaybookRuns:
+    """
+    Aggregates multiple instances of PlaybookRun, while exposing the same interface
+
+    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+    If you're seeing this text, put the --help flag earlier in your list
+    of command-line arguments, this is a limitation of the CLI parsing library
+    used by the toolbox.
+    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+    """
+    def __init__(self, runs: Iterable[PlaybookRun]):
+        self.runs = list(runs)
+
+    def __str__(self):
+        return ""
+
+    def _run(self):
+        for playbook_run in self.runs:
+            print(f"Running the {playbook_run} playbook")
+            try:
+                playbook_run._run()
+            except SystemExit as e:
+                if e.code != 0:
+                    raise
+
+        raise SystemExit(0)
 
 
 def flatten(lst):

--- a/toolbox/_common.py
+++ b/toolbox/_common.py
@@ -130,15 +130,15 @@ def run_ansible_playbook(playbook_name, opts: dict = dict()):
         ]
     )
 
+    with open(artifact_extra_logs_dir / "_ansible.env", "w") as f:
+        for k, v in os.environ.items():
+            print(f"{k}={v}", file=f)
+
     cmd = ["ansible-playbook", "-vv", *option_flags, f"playbooks/{playbook_name}.yml"]
 
     with open(artifact_extra_logs_dir / "_ansible.cmd", "w") as f:
         print(" ".join(cmd), file=f)
 
-    with open(artifact_extra_logs_dir / "_ansible.env", "w") as f:
-        for k, v in os.environ.items():
-            print(f"{k}={v}", file=f)
+    run_result = subprocess.run(cmd, env=os.environ.copy())
 
-    os.execvpe(cmd[0], cmd, os.environ)
-
-    raise RuntimeError("os.execvpe shouldn't return ...")
+    raise SystemExit(run_result.returncode)

--- a/toolbox/gpu-operator/canary-build/dcgm.yml
+++ b/toolbox/gpu-operator/canary-build/dcgm.yml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: BuildConfig
+metadata:
+  labels:
+    app: ci-artifacts
+  name: dcgm
+  namespace: gpu-operator-resources
+spec:
+  output:
+    to:
+      kind: ImageStreamTag
+      name: dcgm:latest
+      namespace: gpu-operator-resources
+  resources: {}
+  source:
+    type: Git
+    git:
+      uri: https://github.com/openshift-psap/gpu-operand-upgrade-canary.git
+      ref: main
+    contextDir: .
+  triggers:
+    - type: ConfigChange
+  strategy:
+    type: Docker
+    dockerStrategy:
+      buildArgs:
+        - name: OPERAND_IMAGE
+          value: "{{ dcgm_operand_repo.stdout }}/{{ build_operand_canary_imagestream_name }}{% if dcgm_operand_tag.stdout.startswith('sha256') %}@{% else %}:{% endif %}{{ dcgm_operand_tag.stdout }}"
+      dockerfilePath: Containerfile

--- a/toolbox/gpu-operator/canary-build/dcgm_exporter.yml
+++ b/toolbox/gpu-operator/canary-build/dcgm_exporter.yml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: BuildConfig
+metadata:
+  labels:
+    app: ci-artifacts
+  name: dcgm-exporter
+  namespace: gpu-operator-resources
+spec:
+  output:
+    to:
+      kind: ImageStreamTag
+      name: dcgm-exporter:latest
+      namespace: gpu-operator-resources
+  resources: {}
+  source:
+    type: Git
+    git:
+      uri: https://github.com/openshift-psap/gpu-operand-upgrade-canary.git
+      ref: main
+    contextDir: .
+  triggers:
+    - type: ConfigChange
+  strategy:
+    type: Docker
+    dockerStrategy:
+      buildArgs:
+        - name: OPERAND_IMAGE
+          value: "{{ dcgm_exporter_operand_repo.stdout }}/{{ build_operand_canary_imagestream_name }}{% if dcgm_exporter_operand_tag.stdout.startswith('sha256') %}@{% else %}:{% endif %}{{ dcgm_exporter_operand_tag.stdout }}"
+      dockerfilePath: Containerfile

--- a/toolbox/gpu-operator/canary-build/device_plugin.yml
+++ b/toolbox/gpu-operator/canary-build/device_plugin.yml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: BuildConfig
+metadata:
+  labels:
+    app: ci-artifacts
+  name: k8s-device-plugin
+  namespace: gpu-operator-resources
+spec:
+  output:
+    to:
+      kind: ImageStreamTag
+      name: k8s-device-plugin:latest
+      namespace: gpu-operator-resources
+  resources: {}
+  source:
+    type: Git
+    git:
+      uri: https://github.com/openshift-psap/gpu-operand-upgrade-canary.git
+      ref: main
+    contextDir: .
+  triggers:
+    - type: ConfigChange
+  strategy:
+    type: Docker
+    dockerStrategy:
+      buildArgs:
+        - name: OPERAND_IMAGE
+          value: "{{ device_plugin_operand_repo.stdout }}/{{ build_operand_canary_imagestream_name }}{% if device_plugin_operand_tag.stdout.startswith('sha256') %}@{% else %}:{% endif %}{{ device_plugin_operand_tag.stdout }}"
+      dockerfilePath: Containerfile

--- a/toolbox/gpu-operator/canary-build/driver.yml
+++ b/toolbox/gpu-operator/canary-build/driver.yml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: BuildConfig
+metadata:
+  labels:
+    app: ci-artifacts
+  name: driver
+  namespace: gpu-operator-resources
+spec:
+  output:
+    to:
+      kind: ImageStreamTag
+      name: "driver:latest-rhcos{{ ocp_version.stdout }}"
+      namespace: gpu-operator-resources
+  resources: {}
+  source:
+    type: Git
+    git:
+      uri: https://github.com/openshift-psap/gpu-operand-upgrade-canary.git
+      ref: main
+    contextDir: .
+  triggers:
+    - type: ConfigChange
+  strategy:
+    type: Docker
+    dockerStrategy:
+      buildArgs:
+        - name: OPERAND_IMAGE
+          value: "{{ driver_operand_repo.stdout }}/{{ build_operand_canary_imagestream_name }}{% if driver_operand_tag.stdout.startswith('sha256') %}@{% else %}:{% endif %}{{ driver_operand_tag.stdout }}"
+      dockerfilePath: Containerfile

--- a/toolbox/gpu-operator/canary-build/driver_manager.yml
+++ b/toolbox/gpu-operator/canary-build/driver_manager.yml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: BuildConfig
+metadata:
+  labels:
+    app: ci-artifacts
+  name: k8s-driver-manager
+  namespace: gpu-operator-resources
+spec:
+  output:
+    to:
+      kind: ImageStreamTag
+      name: k8s-driver-manager:latest
+      namespace: gpu-operator-resources
+  resources: {}
+  source:
+    type: Git
+    git:
+      uri: https://github.com/openshift-psap/gpu-operand-upgrade-canary.git
+      ref: main
+    contextDir: .
+  triggers:
+    - type: ConfigChange
+  strategy:
+    type: Docker
+    dockerStrategy:
+      buildArgs:
+        - name: OPERAND_IMAGE
+          value: "{{ driver_manager_operand_repo.stdout }}/{{ build_operand_canary_imagestream_name }}{% if driver_manager_operand_tag.stdout.startswith('sha256') %}@{% else %}:{% endif %}{{ driver_manager_operand_tag.stdout }}"
+      dockerfilePath: Containerfile

--- a/toolbox/gpu-operator/canary-build/gfd.yml
+++ b/toolbox/gpu-operator/canary-build/gfd.yml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: BuildConfig
+metadata:
+  labels:
+    app: ci-artifacts
+  name: gpu-feature-discovery
+  namespace: gpu-operator-resources
+spec:
+  output:
+    to:
+      kind: ImageStreamTag
+      name: gpu-feature-discovery:latest
+      namespace: gpu-operator-resources
+  resources: {}
+  source:
+    type: Git
+    git:
+      uri: https://github.com/openshift-psap/gpu-operand-upgrade-canary.git
+      ref: main
+    contextDir: .
+  triggers:
+    - type: ConfigChange
+  strategy:
+    type: Docker
+    dockerStrategy:
+      buildArgs:
+        - name: OPERAND_IMAGE
+          value: "{{ gfd_operand_repo.stdout }}/{{ build_operand_canary_imagestream_name }}{% if gfd_operand_tag.stdout.startswith('sha256') %}@{% else %}:{% endif %}{{ gfd_operand_tag.stdout }}"
+      dockerfilePath: Containerfile

--- a/toolbox/gpu-operator/canary-build/mig_manager.yml
+++ b/toolbox/gpu-operator/canary-build/mig_manager.yml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: BuildConfig
+metadata:
+  labels:
+    app: ci-artifacts
+  name: k8s-mig-manager
+  namespace: gpu-operator-resources
+spec:
+  output:
+    to:
+      kind: ImageStreamTag
+      name: k8s-mig-manager:latest
+      namespace: gpu-operator-resources
+  resources: {}
+  source:
+    type: Git
+    git:
+      uri: https://github.com/openshift-psap/gpu-operand-upgrade-canary.git
+      ref: main
+    contextDir: .
+  triggers:
+    - type: ConfigChange
+  strategy:
+    type: Docker
+    dockerStrategy:
+      buildArgs:
+        - name: OPERAND_IMAGE
+          value: "{{ mig_manager_operand_repo.stdout }}/{{ build_operand_canary_imagestream_name }}{% if mig_manager_operand_tag.stdout.startswith('sha256') %}@{% else %}:{% endif %}{{ mig_manager_operand_tag.stdout }}"
+      dockerfilePath: Containerfile

--- a/toolbox/gpu-operator/canary-build/node_status_exporter.yml
+++ b/toolbox/gpu-operator/canary-build/node_status_exporter.yml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: BuildConfig
+metadata:
+  labels:
+    app: ci-artifacts
+  name: node-status-exporter
+  namespace: gpu-operator-resources
+spec:
+  output:
+    to:
+      kind: ImageStreamTag
+      name: node-status-exporter:latest
+      namespace: gpu-operator-resources
+  resources: {}
+  source:
+    type: Git
+    git:
+      uri: https://github.com/openshift-psap/gpu-operand-upgrade-canary.git
+      ref: main
+    contextDir: .
+  triggers:
+    - type: ConfigChange
+  strategy:
+    type: Docker
+    dockerStrategy:
+      buildArgs:
+        - name: OPERAND_IMAGE
+          value: "{{ node_status_exporter_operand_repo.stdout }}/{{ node_status_exporter_operand_image.stdout }}{% if node_status_exporter_operand_tag.stdout.startswith('sha256') %}@{% else %}:{% endif %}{{ node_status_exporter_operand_tag.stdout }}"
+      dockerfilePath: Containerfile

--- a/toolbox/gpu-operator/canary-build/toolkit.yml
+++ b/toolbox/gpu-operator/canary-build/toolkit.yml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: BuildConfig
+metadata:
+  labels:
+    app: ci-artifacts
+  name: container-toolkit
+  namespace: gpu-operator-resources
+spec:
+  output:
+    to:
+      kind: ImageStreamTag
+      name: container-toolkit:latest
+      namespace: gpu-operator-resources
+  resources: {}
+  source:
+    type: Git
+    git:
+      uri: https://github.com/openshift-psap/gpu-operand-upgrade-canary.git
+      ref: main
+    contextDir: .
+  triggers:
+    - type: ConfigChange
+  strategy:
+    type: Docker
+    dockerStrategy:
+      buildArgs:
+        - name: OPERAND_IMAGE
+          value: "{{ container_toolkit_operand_repo.stdout }}/{{ build_operand_canary_imagestream_name }}{% if container_toolkit_operand_tag.stdout.startswith('sha256') %}@{% else %}:{% endif %}{{ container_toolkit_operand_tag.stdout }}"
+      dockerfilePath: Containerfile

--- a/toolbox/gpu-operator/canary-build/validator.yml
+++ b/toolbox/gpu-operator/canary-build/validator.yml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: BuildConfig
+metadata:
+  labels:
+    app: ci-artifacts
+  name: gpu-operator-validator
+  namespace: gpu-operator-resources
+spec:
+  output:
+    to:
+      kind: ImageStreamTag
+      name: gpu-operator-validator:latest
+      namespace: gpu-operator-resources
+  resources: {}
+  source:
+    type: Git
+    git:
+      uri: https://github.com/openshift-psap/gpu-operand-upgrade-canary.git
+      ref: main
+    contextDir: .
+  triggers:
+    - type: ConfigChange
+  strategy:
+    type: Docker
+    dockerStrategy:
+      buildArgs:
+        - name: OPERAND_IMAGE
+          value: "{{ validator_operand_repo.stdout }}/{{ build_operand_canary_imagestream_name }}{% if validator_operand_tag.stdout.startswith('sha256') %}@{% else %}:{% endif %}{{ validator_operand_tag.stdout }}"
+      dockerfilePath: Containerfile


### PR DESCRIPTION
This commit adds a new
`build/root/usr/local/bin/ci_entrypoint_gpu-operator.sh test_commit_upgrade`
command that behaves the same as `test_master_branch`/`test_commit` except that
after validating the gpu operator deployment it also modifies the cluster policy
to point to operands containing a canary file, then checks to make sure
the pods actually have that file. This way the nvidia cluster policy
reconciliation feature is verified. It also adds an environment variable
to each of the operands in the cluster policy and makes sure that the operand pods
actually has that environment variable applied.

The operand images with the canary file are generated on the fly by
running build configs based on the current operand images specified in
the cluster policy using this repo: https://github.com/openshift-psap/gpu-operand-upgrade-canary


/cc @kpouget