### PR TITLE
Test single-namespace GPU Operator

### DIFF
--- a/roles/gpu_operator_bundle_from_commit/defaults/main/config.yml
+++ b/roles/gpu_operator_bundle_from_commit/defaults/main/config.yml
@@ -8,4 +8,4 @@ gpu_operator_bundle_image_tag: "gpu-operator-bundle-{{ gpu_operator_image_tag_ui
 # Namespace in which the GPU Operator will be deployed.
 # Before v1.9, the value must be "openshift-operators".
 # With >=v1.9, the namespace can freely chosen (except 'openshift-operators').
-gpu_operator_target_namespace: openshift-operators
+gpu_operator_target_namespace: nvidia-gpu-operator

--- a/roles/gpu_operator_bundle_from_commit/files/operator_bundle_image_builder_script.yml
+++ b/roles/gpu_operator_bundle_from_commit/files/operator_bundle_image_builder_script.yml
@@ -36,7 +36,8 @@ data:
     git show --quiet
     GIT_VERSION=$(git rev-parse --short HEAD)
 
-    CSV_VERSION="9.9.9-latest.git.${GIT_VERSION}"
+    DATE_VERSION=$(date -d "@$(git log -1 ${GIT_VERSION} --format="%at")" +%y.%-m.%-d) # gives 21.9.29
+    CSV_VERSION="${DATE_VERSION}-git.${GIT_VERSION}"
 
     # update operator image
     mv $CSV_FILE ${CSV_FILE}.orig

--- a/roles/gpu_operator_deploy_from_operatorhub/tasks/deploy_from_bundle.yml
+++ b/roles/gpu_operator_deploy_from_operatorhub/tasks/deploy_from_bundle.yml
@@ -34,6 +34,7 @@
   command:
     operator-sdk run bundle --timeout=5m
                  -n {{ gpu_operator_operator_namespace }}
+                 --install-mode OwnNamespace
                  {{ deploy_bundle_image }}
 
 - name: Store the version of the GPU Operator that will be installed

--- a/testing/nightly/gpu-operator.sh
+++ b/testing/nightly/gpu-operator.sh
@@ -121,7 +121,7 @@ test_master_branch() {
     #./run_toolbox.py gpu_operator deploy_from_bundle --bundle=master
 
     # meanwhile:
-    deploy_commit "https://github.com/NVIDIA/gpu-operator.git" "master"
+    deploy_commit "https://gitlab.com/nvidia/kubernetes/gpu-operator.git" "master"
 
     prepare_cluster_for_gpu_operator_with_alerts "$@"
 
@@ -286,7 +286,7 @@ case ${action} in
         exit 0
         ;;
     "test_commit")
-        test_commit "https://github.com/NVIDIA/gpu-operator.git" master "$@"
+        test_commit "https://gitlab.com/nvidia/kubernetes/gpu-operator.git" master "$@"
         exit 0
         ;;
     "test_operatorhub")

--- a/testing/nightly/gpu-operator.sh
+++ b/testing/nightly/gpu-operator.sh
@@ -147,6 +147,7 @@ deploy_commit() {
     gpu_operator_git_ref="${1:-}"
 
     CI_IMAGE_GPU_COMMIT_CI_IMAGE_UID="ci-image"
+    OPERATOR_NAMESPACE="nvidia-gpu-operator"
 
     if [[ -z "$gpu_operator_git_repo" || -z "$gpu_operator_git_ref" ]]; then
         echo "FATAL: test_commit must receive a git repo/ref to be tested."
@@ -162,10 +163,11 @@ deploy_commit() {
                                              "${gpu_operator_git_ref}" \
                                              "${GPU_OPERATOR_QUAY_BUNDLE_PUSH_SECRET}" \
                                              "${GPU_OPERATOR_QUAY_BUNDLE_IMAGE_NAME}" \
-                                             --tag_uid="${CI_IMAGE_GPU_COMMIT_CI_IMAGE_UID}"
+                                             --tag_uid "${CI_IMAGE_GPU_COMMIT_CI_IMAGE_UID}" \
+                                             --namespace "${OPERATOR_NAMESPACE}"
 
-    ./run_toolbox.py gpu_operator deploy_from_bundle "--bundle=${GPU_OPERATOR_QUAY_BUNDLE_IMAGE_NAME}:operator_bundle_gpu-operator-ci-image" \
-                                                     --namespace openshift-operators
+    ./run_toolbox.py gpu_operator deploy_from_bundle --bundle "${GPU_OPERATOR_QUAY_BUNDLE_IMAGE_NAME}:operator_bundle_gpu-operator-ci-image" \
+                                                     --namespace "${OPERATOR_NAMESPACE}"
 }
 
 prepare_cluster_for_gpu_operator_with_alerts() {


### PR DESCRIPTION
This PR updates the GPU Operator CI to test the [single-namespace refactoring](https://gitlab.com/nvidia/kubernetes/gpu-operator/-/merge_requests/287).

The goal of this PR is to update the testing to code
1. to keep working with already-released versions, in the nightly testing 
2. to keep working with the `master` branch of the GPU Operator, when the refactoring will be merged.

The last tests showed that these goals are now reached:
* [gpu-operator-commit](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/openshift-psap_ci-artifacts/242/pull-ci-openshift-psap-ci-artifacts-master-gpu-operator-commit/1432630008228089856/artifacts/gpu-operator-commit/presubmit-commit/artifacts/) passed (testing of the refactoring branch)
* [gpu-operator-e2e - OperatorHub](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/openshift-psap_ci-artifacts/242/pull-ci-openshift-psap-ci-artifacts-master-gpu-operator-e2e/1432630008261644288/artifacts/gpu-operator-e2e/presubmit-operatorhub/artifacts/) passed (testing the last released version)

It is *not* a goal to have the "gpu-operator-e2e - master branch" working, as it will pass as soon as the refactoring is merged.
It it *not* a goal (yet) to have the "gpu-operator-e2e - OperatorHub" test to work with the refactoring, we'll tackle that when v1.9 will be released.

/cc @dagrayvid @omertuc @ArangoGutierrez, I'll need your help to merge this large PR
I've already split it into https://github.com/openshift-psap/ci-artifacts/pull/248 and https://github.com/openshift-psap/ci-artifacts/pull/249 that can be merged independently. I'll rebase this PR once both of them have been merged.