### PR TITLE
Better handling of empty base_machineset

### DIFF
--- a/roles/cluster_ensure_machineset/defaults/main/config.yml
+++ b/roles/cluster_ensure_machineset/defaults/main/config.yml
@@ -1,6 +1,3 @@
 ---
 # The instance type to use for the machineset being scaled
 machineset_instance_type: "g4dn.xlarge"
-# Optional: name of a machineset to use to derive the new one
-# If empty, using the first machineset found in the listing
-base_machineset: ""

--- a/toolbox/cluster.py
+++ b/toolbox/cluster.py
@@ -6,7 +6,7 @@ class Cluster:
     Commands relating to cluster scaling, upgrading and environment capture
     """
     @staticmethod
-    def set_scale(instance_type, scale, base_machineset="", force=False):
+    def set_scale(instance_type, scale, base_machineset=None, force=False):
         """
         Ensures that the cluster has exactly `scale` nodes with instance_type `instance_type`
 
@@ -31,10 +31,12 @@ class Cluster:
             base_machineset: Name of a machineset to use to derive the new one. Default: pickup the first machineset found in `oc get machinesets -n openshift-machine-api`.
         """
         opts = {
-                "machineset_instance_type": instance_type,
-                "scale": scale,
-                "base_machineset": base_machineset,
-            }
+            "machineset_instance_type": instance_type,
+            "scale": scale,
+        }
+
+        if base_machineset is not None:
+            opts["base_machineset"] = base_machineset
 
         if force:
             opts["force_scale"] = "true"


### PR DESCRIPTION
Before this change, not specifying the base machineset would cause an
error because the ansible code treated an empty "" string differently
from an unset variable altogether.

This change makes it so the toolbox script leaves the base_machineset
variable empty, rather than have it be an empty string

