### PR TITLE
WiP: Switch from UBI to CentOS stream container image.

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi
+FROM quay.io/centos/centos:stream8
 
 MAINTAINER OpenShift PSAP Team <openshift-psap@redhat.com>
 


### PR DESCRIPTION
After the bump to k8s 1.22, NTO e2e tests are breaking as they require golang 1.16.  CentOS stream 8 already ships golang 1.16.
