### PR TITLE
gpu_operator_bundle_from_commit: also build the validator image

### DIFF
--- a/roles/gpu_operator_bundle_from_commit/files/operator_bundle_image_builder_script.yml
+++ b/roles/gpu_operator_bundle_from_commit/files/operator_bundle_image_builder_script.yml
@@ -34,6 +34,7 @@ data:
     git show --quiet
     GIT_VERSION=$(git rev-parse --short HEAD)
 
+    # update operator image
     mv $CSV_FILE ${CSV_FILE}.orig
     cat ${CSV_FILE}.orig | yq \
       | jq .metadata.annotations.containerImage=\"$OPERATOR_IMAGE_NAME\" \
@@ -42,10 +43,30 @@ data:
       | jq .spec.install.spec.deployments[0].spec.template.spec.containers[0].image=\"$OPERATOR_IMAGE_NAME\" \
       > $CSV_FILE
 
-    rm ${CSV_FILE}.orig
     cat $CSV_FILE | grep containerImage
+    rm ${CSV_FILE}.orig
 
-    # build
+    # update validator image in the ClusterPolicy
+
+    cat ${CSV_FILE} | yq \
+      | jq '.metadata.annotations."alm-examples"' -r \
+      > clusterpolicy.json.orig
+
+    cat clusterpolicy.json.orig \
+      | jq '.[].spec.validator.image="gpu-operator-ci"' \
+      | jq '.[].spec.validator.repository="image-registry.openshift-image-registry.svc:5000/gpu-operator-ci"' \
+      | jq '.[].spec.validator.version="'$VALIDATOR_IMAGE_VERSION'"' \
+      > clusterpolicy.json
+    rm  clusterpolicy.json.orig
+
+    # update ClusterPolicy in the CSV
+
+    mv $CSV_FILE ${CSV_FILE}.orig
+    yq --yaml-roundtrip --rawfile alm_examples clusterpolicy.json '.metadata.annotations."alm-examples" = $alm_examples' ${CSV_FILE}.orig > ${CSV_FILE}
+    rm ${CSV_FILE}.orig
+    rm  clusterpolicy.json
+
+    # build the bundle image
 
     podman build -f $CONTAINER_FILE $CONTEXT_LOCATION -t $QUAY_BUNDLE_IMAGE_NAME
 

--- a/roles/gpu_operator_bundle_from_commit/files/operator_bundle_image_builder_script.yml
+++ b/roles/gpu_operator_bundle_from_commit/files/operator_bundle_image_builder_script.yml
@@ -46,7 +46,7 @@ data:
     cat $CSV_FILE | grep containerImage
     rm ${CSV_FILE}.orig
 
-    # update validator image in the ClusterPolicy
+    # update validator & node-status-exporter images in the ClusterPolicy
 
     cat ${CSV_FILE} | yq \
       | jq '.metadata.annotations."alm-examples"' -r \
@@ -56,6 +56,9 @@ data:
       | jq '.[].spec.validator.image="gpu-operator-ci"' \
       | jq '.[].spec.validator.repository="image-registry.openshift-image-registry.svc:5000/gpu-operator-ci"' \
       | jq '.[].spec.validator.version="'$VALIDATOR_IMAGE_VERSION'"' \
+      | jq '.[].spec.nodeStatusExporter.image="gpu-operator-ci"' \
+      | jq '.[].spec.nodeStatusExporter.repository="image-registry.openshift-image-registry.svc:5000/gpu-operator-ci"' \
+      | jq '.[].spec.nodeStatusExporter.version="'$VALIDATOR_IMAGE_VERSION'"' \
       > clusterpolicy.json
     rm  clusterpolicy.json.orig
 

--- a/roles/gpu_operator_bundle_from_commit/tasks/build_bundle.yml
+++ b/roles/gpu_operator_bundle_from_commit/tasks/build_bundle.yml
@@ -37,11 +37,25 @@
        -n gpu-operator-ci
        --from-file kubeconfig={{ lookup('env', 'KUBECONFIG') }}
 
-- name: Authorize 'ns/openshift-operators' Pods to access ns/gpu-operator-ci images
+- name: Authorize 'ns/openshift-operators' Pods to access 'ns/gpu-operator-ci' images
   command:
     oc policy add-role-to-user
               system:image-puller system:serviceaccount:openshift-operators:gpu-operator
               --namespace=gpu-operator-ci
+
+- name: Authorize 'ns/gpu-operator-resources' Pods to access 'ns/gpu-operator-ci' images
+  command:
+    oc policy add-role-to-user
+              system:image-puller system:serviceaccount:gpu-operator-resources:{{ item }}
+              --namespace=gpu-operator-ci
+  with_items:
+  - nvidia-driver
+  - nvidia-container-toolkit
+  - nvidia-device-plugin
+  - nvidia-dcgm
+  - nvidia-dcgm-exporter
+  - nvidia-gpu-feature-discovery
+  - nvidia-node-status-exporter
 
 - name: Apply the operator bundle image builder script manifest
   command: oc apply -f "{{ gpu_operator_bundle_image_builder_script }}"

--- a/roles/gpu_operator_bundle_from_commit/tasks/build_validator.yml
+++ b/roles/gpu_operator_bundle_from_commit/tasks/build_validator.yml
@@ -1,0 +1,68 @@
+---
+#
+# Operator image
+#
+
+- name: Compute local imagestreamtag name
+  set_fact:
+    validator_image_version: "validator_{{ gpu_operator_image_tag }}"
+    validator_imagestreamtag: "gpu-operator-ci:validator_{{ gpu_operator_image_tag }}"
+
+- name: Compute local image name
+  set_fact:
+    validator_image_name: "image-registry.openshift-image-registry.svc:5000/gpu-operator-ci/{{ validator_imagestreamtag }}"
+
+- name: Check if the validator image already exists
+  command: oc get "imagestreamtag/{{ validator_imagestreamtag }}" -n gpu-operator-ci
+  failed_when: false
+  register: has_validator_image
+
+- name: Build the validator image
+  when: has_validator_image.rc != 0
+  block:
+  - name: The validator image does not exist, build it
+    debug: msg="The validator image does not exist, build it"
+
+  - name: Instantiate the template of the validator image buildconfig
+    template:
+      src: "{{ gpu_operator_validator_image_buildconfig }}"
+      dest: "{{ artifact_extra_logs_dir }}/validator-image-buildconfig.yml"
+      mode: 0400
+
+  - name: Delete the validator image build config
+    command: oc delete -f "{{ artifact_extra_logs_dir }}/validator-image-buildconfig.yml"
+    failed_when: false
+
+  - name: Apply the validator image build config
+    command: oc apply -f "{{ artifact_extra_logs_dir }}/validator-image-buildconfig.yml"
+
+  - name: Get the name of the Build
+    command:
+      oc get builds
+         -lbuildconfig=gpu-operator-validator
+         -oname
+         -n gpu-operator-ci
+    register: build_name_cmd
+    failed_when: build_name_cmd.stdout | length == 0
+
+  - block:
+    - name: Wait for the validator image to be built
+      command:
+        oc get {{ build_name_cmd.stdout }}
+           -ojsonpath={.status.phase}
+           -n gpu-operator-ci
+      register: wait_validator_build
+      until: "'Complete' in wait_validator_build.stdout or 'Failed' in wait_validator_build.stdout"
+      retries: 40
+      delay: 30
+
+    - name: Fail if the operator image failed to be built
+      when: "'Failed' in wait_validator_build.stdout"
+      fail: msg="The validator image failed to build"
+
+    always:
+    - name: Store the logs of validator image build (debug)
+      shell:
+        oc logs {{ build_name_cmd.stdout }} -n gpu-operator-ci
+           > {{ artifact_extra_logs_dir }}/validator-image-build.log
+      failed_when: false

--- a/roles/gpu_operator_bundle_from_commit/tasks/main.yml
+++ b/roles/gpu_operator_bundle_from_commit/tasks/main.yml
@@ -20,6 +20,9 @@
 - name: Build the operator image from custom commit
   include_tasks: build_operator.yml
 
+- name: Build the validator image from custom commit
+  include_tasks: build_validator.yml
+
 - name: Build the bundle image from custom commit
   include_tasks: build_bundle.yml
 

--- a/roles/gpu_operator_bundle_from_commit/tasks/prepare.yml
+++ b/roles/gpu_operator_bundle_from_commit/tasks/prepare.yml
@@ -19,10 +19,10 @@
   command: oc apply -f "{{ gpu_operator_ci_utils }}"
 
 - name: Apply the namespace manifest
-  command: oc apply -f "{{ gpu_operator_namespace }}"
+  command: oc apply -f "{{ gpu_operator_ci_namespace }}"
 
 - name: Apply the imagestream manifest
-  command: oc apply -f "{{ gpu_operator_imagestream }}"
+  command: oc apply -f "{{ gpu_operator_ci_imagestream }}"
 
 - name: Authorize 'ns/gpu-operator-ci' Pods to access ns/gpu-operator-ci-utils images
   command:

--- a/roles/gpu_operator_bundle_from_commit/templates/build_validator.yml.j2
+++ b/roles/gpu_operator_bundle_from_commit/templates/build_validator.yml.j2
@@ -1,0 +1,40 @@
+---
+apiVersion: v1
+kind: BuildConfig
+metadata:
+  labels:
+    app: ci-artifacts
+  name: gpu-operator-validator
+  namespace: gpu-operator-ci
+spec:
+  output:
+    to:
+      kind: ImageStreamTag
+      name: "{{ validator_imagestreamtag }}"
+      namespace: gpu-operator-ci
+  resources: {}
+  source:
+    type: Git
+    git:
+      uri: "{{ gpu_operator_git_repo }}"
+      ref: "{{ gpu_operator_git_ref }}"
+    contextDir: .
+  triggers:
+    - type: ConfigChange
+  strategy:
+    type: Docker
+    dockerStrategy:
+      buildArgs:
+        - name: VERSION
+          value: v0.1.0
+        - name: GOLANG_VERSION
+          value: '1.15'
+        - name: CUDA_SAMPLE_IMAGE
+          value: nvcr.io/nvidia/k8s/cuda-sample:vectoradd-cuda11.2.1-ubi8
+        - name: CUDA_IMAGE
+          value: nvidia/cuda
+        - name: CUDA_VERSION
+          value: 11.2.1
+        - name: BASE_DIST
+          value: ubi8
+      dockerfilePath: validator/Dockerfile

--- a/roles/gpu_operator_bundle_from_commit/templates/operator_bundle_image_builder_pod.yml.j2
+++ b/roles/gpu_operator_bundle_from_commit/templates/operator_bundle_image_builder_pod.yml.j2
@@ -24,6 +24,8 @@ spec:
         value: "{{ gpu_operator_git_ref }}"
       - name: OPERATOR_IMAGE_NAME
         value: "{{ operator_image_name }}"
+      - name: VALIDATOR_IMAGE_VERSION
+        value: "{{ validator_image_version }}"
       - name: IMAGESTREAM_SECRET_NAME
         value: "{{ builder_secret }}"
       - name: QUAY_BUNDLE_IMAGE_NAME

--- a/roles/gpu_operator_bundle_from_commit/vars/main/resources.yml
+++ b/roles/gpu_operator_bundle_from_commit/vars/main/resources.yml
@@ -5,8 +5,8 @@ tuned_module_fuse_label: tuned.module.fuse
 # Manifest for installing the GPU operator from a custom commit
 tuned_module_fuse: roles/gpu_operator_bundle_from_commit/files/tuned_module_fuse.yml
 gpu_operator_ci_utils: roles/gpu_operator_bundle_from_commit/files/operator_ci_utils.yml
-gpu_operator_namespace: roles/gpu_operator_bundle_from_commit/files/operator_namespace.yml
-gpu_operator_imagestream: roles/gpu_operator_bundle_from_commit/files/operator_imagestream.yml
+gpu_operator_ci_namespace: roles/gpu_operator_bundle_from_commit/files/operator_namespace.yml
+gpu_operator_ci_imagestream: roles/gpu_operator_bundle_from_commit/files/operator_imagestream.yml
 gpu_operator_image_builder_script: roles/gpu_operator_bundle_from_commit/files/operator_image_builder_script.yml
 gpu_operator_helper_image_builder: roles/gpu_operator_bundle_from_commit/files/operator_helper_image_builder.yml
 #---
@@ -15,3 +15,4 @@ gpu_operator_bundle_image_builder_script: roles/gpu_operator_bundle_from_commit/
 # Templates
 gpu_operator_image_builder_pod: roles/gpu_operator_bundle_from_commit/templates/operator_image_builder_pod.yml.j2
 gpu_operator_bundle_image_builder_pod: roles/gpu_operator_bundle_from_commit/templates/operator_bundle_image_builder_pod.yml.j2
+gpu_operator_validator_image_buildconfig: roles/gpu_operator_bundle_from_commit/templates/build_validator.yml.j2


### PR DESCRIPTION
This PR builds the GPU Operator validator image, as part of `gpu_operator_bundle_from_commit`.

This is mandatory for testing the single-namespace PR https://github.com/openshift-psap/ci-artifacts/pull/242/commits, as modifications are done in this controller.

This can be useful in the future as well for testing modifications of the `node-status-exporter` metrics (same code-base)