### PR TITLE
gpu_operator_run_gpu-burn: use 'template' and remove 4.9-specific code hook

### DIFF
--- a/roles/gpu_operator_run_gpu-burn/tasks/main.yml
+++ b/roles/gpu_operator_run_gpu-burn/tasks/main.yml
@@ -10,8 +10,7 @@
     ) | grep .
 
 - name: Get the list of nodes with GPUs
-  shell:
-    set -o pipefail;
+  command:
     oc get nodes
        -lnvidia.com/gpu.present=true
        -o custom-columns=NAME:metadata.name
@@ -27,32 +26,26 @@
   with_items: "{{ gpu_burn_gpu_nodes.stdout_lines }}"
   failed_when: false
 
-- name: Create GPU burn Pods
-  with_items: "{{ gpu_burn_gpu_nodes.stdout_lines }}"
-  shell: |
-    set -eo pipefail;
+- name: Instanciate GPU Burn Pods from template
+  loop: "{{ gpu_burn_gpu_nodes.stdout_lines }}"
+  loop_control:
+    loop_var: gpu_node_name
+  template:
+    src: "{{ gpu_burn_pod }}"
+    dest: "{{ artifact_extra_logs_dir }}/gpu_burn.{{ gpu_node_name }}.yml"
+    mode: 0400
 
-    if [[ "{{ openshift_release_major }}" == 4 && "{{ openshift_release_minor }}" -le 8 ]]; then
-      GPU_NODE_HOSTNAME=$(echo '{{ item }}' | cut -d. -f1);
-    else
-      GPU_NODE_HOSTNAME=$(echo '{{ item }}' );
-    fi
+- name: Create GPU Burn Pods from template
+  loop: "{{ gpu_burn_gpu_nodes.stdout_lines }}"
+  command: oc apply -f "{{ artifact_extra_logs_dir }}/gpu_burn.{{ item }}.yml"
 
-    echo "Hostname: $GPU_NODE_HOSTNAME";
-    oc --ignore-not-found=true delete pod/gpu-burn-$GPU_NODE_HOSTNAME -n default
-    cat "{{ gpu_burn_pod }}" \
-      | sed "s|{{ '{{' }} gpu_node_name {{ '}}' }}|{{ item }}|" \
-      | sed "s|{{ '{{' }} gpu_node_hostname {{ '}}' }}|$GPU_NODE_HOSTNAME|" \
-      | sed "s|{{ '{{' }} gpu_burn_time {{ '}}' }}|{{ gpu_burn_time }}|" \
-      | oc apply -f-
-
-- name: "Let the GPU burn Pods run {{ gpu_burn_time }}seconds"
+- name: "Let the GPU burn Pods run {{ gpu_burn_time }} seconds"
   command: "sleep {{ gpu_burn_time }}"
 
 - name: Ensure that the GPU burn ran successfully
   block:
   - name: Wait for GPU burn Pods to complete
-    with_items: "{{ gpu_burn_gpu_nodes.stdout_lines }}"
+    loop: "{{ gpu_burn_gpu_nodes.stdout_lines }}"
     command:
       oc get pod/gpu-burn-{{ item }}
          -n default
@@ -65,7 +58,7 @@
     delay: 30
 
   - name: Ensure that no GPU was faulty
-    with_items: "{{ gpu_burn_gpu_nodes.stdout_lines }}"
+    loop: "{{ gpu_burn_gpu_nodes.stdout_lines }}"
     shell:
       oc logs pod/gpu-burn-{{ item }} -n default | grep FAULTY
     register: gpu_burn_test_faulty

--- a/roles/gpu_operator_run_gpu-burn/templates/gpu_burn_pod.yml
+++ b/roles/gpu_operator_run_gpu-burn/templates/gpu_burn_pod.yml
@@ -7,6 +7,7 @@ metadata:
   namespace: default
 spec:
   restartPolicy: Never
+  nodeName: "{{ gpu_node_name }}"
   containers:
   - image: nvcr.io/nvidia/cuda:11.2.2-devel-ubi8
     imagePullPolicy: Always
@@ -28,4 +29,3 @@ spec:
         name: gpu-burn-entrypoint
   nodeSelector:
     nvidia.com/gpu.present: "true"
-    kubernetes.io/hostname: "{{ gpu_node_hostname }}"

--- a/roles/gpu_operator_run_gpu-burn/vars/main/resources.yml
+++ b/roles/gpu_operator_run_gpu-burn/vars/main/resources.yml
@@ -1,2 +1,2 @@
 gpu_burn_cm_entrypoint: roles/gpu_operator_run_gpu-burn/files/gpu_burn_cm_entrypoint.yml
-gpu_burn_pod: roles/gpu_operator_run_gpu-burn/files/gpu_burn_pod.yml
+gpu_burn_pod: roles/gpu_operator_run_gpu-burn/templates/gpu_burn_pod.yml


### PR DESCRIPTION
SImple refactoring of the code to improve readability and avoid having 4.9-specific hooks (node name != hostname)