### PR TITLE
.github/workflows/revert-testing.yml: new post-push action to remove tmp test commits

### DIFF
--- a/.github/workflows/revert-testing.yml
+++ b/.github/workflows/revert-testing.yml
@@ -1,0 +1,40 @@
+name: 'Revert "[TEST TMP]" commit'
+on:
+  push:
+    branches: [master]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
+
+      - name: 'Revert "[TEST TMP]" commit'
+        run: |
+          set -euxo pipefail;
+
+          git config --global user.email "github.action@ci-artifacts.psap"
+          git config --global user.name "Github Action"
+
+          COMMIT_MSG=$(git log --pretty='format:%Creset%s' --no-merges -1)
+          COMMIT_AUTHOR=$(git show -s --format='%an <%ae>' HEAD)
+
+          if ! echo "$COMMIT_MSG" | grep '^\[TEST TMP\]' -q; then
+            echo "Not a temporary test commit, do nothing."
+          fi
+
+          echo "Temporary test commit detected, reverting $COMMIT_MSG ..."
+          git show --stat HEAD
+          git revert HEAD
+          git commit --amend --author="$COMMIT_AUTHOR" --no-edit
+          git push


### PR DESCRIPTION
This PUSH Github action will revert the last commit of a PR being
merged if its message starts with '[TEST TMP]'.

This allows running custom PR tests in OpenShift CI, without affecting
the routes taken by the nightly CI.