### PR TITLE
gpu_operator_wait_deployment: validate the driver deployment only in >=1.8

### DIFF
--- a/roles/gpu_operator_wait_deployment/tasks/main.yml
+++ b/roles/gpu_operator_wait_deployment/tasks/main.yml
@@ -36,7 +36,7 @@
 
 
 - name: Wait for the GPU Operator to validate the driver deployment
-  when: gpu_operator_version is version("1.7.0", ">=")
+  when: gpu_operator_version is version("1.8.0", ">=")
   command:
     oc rsh
        -n {{ gpu_operator_namespace }}


### PR DESCRIPTION
Tests failed last night on 1.7.2 because this version of the operator doesn't expose the `nvidia-node-status-exporter` DaemonSet, used to validate the driver deployment.

/cc @omertuc 