### PR TITLE
Added junit ansible callback to generate junit xml files.

### DIFF
--- a/config/ansible.cfg
+++ b/config/ansible.cfg
@@ -17,7 +17,7 @@ roles_path = roles/
 gathering = smart
 fact_caching = yaml
 fact_caching_timeout = 600
-callback_whitelist = json_to_logfile, timer, profile_roles
+callback_whitelist = json_to_logfile, timer, profile_roles, junit
 inventory_ignore_extensions = secrets.py, .pyc, .cfg, .crt, .ini
 # work around privilege escalation timeouts in ansible:
 timeout = 30

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ yq
 pyyaml
 fire
 ansible==2.9.*
+junit_xml

--- a/toolbox/_common.py
+++ b/toolbox/_common.py
@@ -90,6 +90,10 @@ def run_ansible_playbook(playbook_name, opts: dict = dict()):
         os.environ["ANSIBLE_JSON_TO_LOGFILE"] = str(artifact_extra_logs_dir / "_ansible.log.json")
     print(f"Using '{os.environ['ANSIBLE_JSON_TO_LOGFILE']}' as ansible json log file.")
 
+    if os.environ.get("JUNIT_OUTPUT_DIR") is None:
+        os.environ["JUNIT_OUTPUT_DIR"] = str(artifact_extra_logs_dir / "junit")
+    print(f"Using '{os.environ['JUNIT_OUTPUT_DIR']}' as ansible junit.xml files folder.")
+
     option_flags = flatten(
         [
             ["-e", f"{option_name}={option_value}"]

--- a/toolbox/_common.sh
+++ b/toolbox/_common.sh
@@ -67,8 +67,12 @@ echo "Using '${ANSIBLE_CONFIG}' as ansible configuration file."
 if [ -z "${ANSIBLE_JSON_TO_LOGFILE:-}" ]; then
     export ANSIBLE_JSON_TO_LOGFILE="${ARTIFACT_EXTRA_LOGS_DIR}/_ansible.log.json"
 fi
-
 echo "Using '${ANSIBLE_JSON_TO_LOGFILE}' as ansible json log file."
+
+if [ -z "${JUNIT_OUTPUT_DIR:-}" ]; then
+    export JUNIT_OUTPUT_DIR="${ARTIFACT_EXTRA_LOGS_DIR}/junit"
+fi
+echo "Using '${JUNIT_OUTPUT_DIR}' as ansible junit.xml files folder."
 
 ###
 


### PR DESCRIPTION
We will use this addition to generate proper output that [osde2e](https://github.com/openshift/osde2e/blob/main/docs/Addons.md#the-structure-of-an-addon-test) expects in order to test the GPU addon.

- Added junit callback to whitelist
- Added junit_xml as a dependency
- in _common.py/sh setting the location of the dir output. (artifact_extra_logs_dir/junit)