### PR TITLE
benchmarking_deploy_coco_dataset: make the client-cert optional and download from upstream

### DIFF
--- a/roles/benchmarking_deploy_coco_dataset/tasks/main.yml
+++ b/roles/benchmarking_deploy_coco_dataset/tasks/main.yml
@@ -7,12 +7,14 @@
   command: oc get nodes -l kubernetes.io/hostname={{ benchmarking_node_hostname }} -oname
 
 - name: Delete the mirror secret, if it exists
+  when: benchmarking_coco_dataset_client_cert | default('', true) | length != 0
   command:
     oc delete secret/mirror-secret
        -n {{ benchmarking_namespace }}
        --ignore-not-found=true
 
 - name: Create the mirror secret
+  when: benchmarking_coco_dataset_client_cert | default('', true) | length != 0
   command:
     oc create secret generic mirror-secret
        -n {{ benchmarking_namespace }}
@@ -76,7 +78,13 @@
     oc logs pod/coco-dataset-downloader
        -n {{ benchmarking_namespace }}
        > {{ artifact_extra_logs_dir }}/pod_downloader.log
+  failed_when: false
 
+- name: Get the description of the download Pod (debug)
+  shell:
+    oc logs pod/coco-dataset-downloader
+       -n {{ benchmarking_namespace }}
+       > {{ artifact_extra_logs_dir }}/pod_downloader.desc
   failed_when: false
 
 - name: Fail if the the downloader Pod failed

--- a/roles/benchmarking_deploy_coco_dataset/templates/pod.yml.j2
+++ b/roles/benchmarking_deploy_coco_dataset/templates/pod.yml.j2
@@ -16,9 +16,11 @@ spec:
     - name: DATASET_BASE_URL
       value: "{{ benchmarking_coco_dataset_mirror_base_url }}"
 {% endif %}
-{% if benchmarking_coco_dataset_client_cert|length %}
     - name: CERT_FILE
+{% if benchmarking_coco_dataset_client_cert|length %}
       value: /etc/mirror-secret/mirror.pem
+{% else %}
+      value:
 {% endif %}
     volumeMounts:
 {% if benchmarking_coco_dataset_client_cert|length %}

--- a/testing/prow/gpu-operator.sh
+++ b/testing/prow/gpu-operator.sh
@@ -385,8 +385,6 @@ trap run_finalizers EXIT
 action="$1"
 shift
 
-set -x
-
 case ${action} in
     "test_master_branch")
         test_master_branch "$@"
@@ -409,7 +407,6 @@ case ${action} in
         exit 0
         ;;
     "source")
-        set +x
         echo "INFO: GPU Operator CI entrypoint has been sourced"
         # file is being sourced by another script
         ;;

--- a/testing/recipes/run_cocodataset_nvidiadl_ssd.sh
+++ b/testing/recipes/run_cocodataset_nvidiadl_ssd.sh
@@ -13,7 +13,7 @@ source $THIS_DIR/../prow/gpu-operator.sh source
 
 prepare_cluster_for_gpu_operator
 
-gpu_node_hostname=$(oc get nodes -oname -lnode.kubernetes.io/instance-type=g4dn.xlarge -ojsonpath={.items[].metadata.labels} | jq -r '.["kubernetes.io/hostname"]')
+gpu_node_hostname=$(oc get nodes -oname -lfeature.node.kubernetes.io/pci-10de.present -ojsonpath={.items[].metadata.labels} | jq -r '.["kubernetes.io/hostname"]')
 
 if [ -z "$gpu_node_hostname" ]; then
     echo "Couldn't find the GPU node ..."
@@ -26,11 +26,20 @@ fi
 ./run_toolbox.py gpu_operator deploy_from_operatorhub --namespace openshift-operators
 ./run_toolbox.py gpu_operator wait_deployment
 
-for i in 1 2; do
-    ./run_toolbox.py benchmarking download_coco_dataset \
-                     "$gpu_node_hostname" \
-                     --mirror_base_url=https://mirror-dataset.apps.ci-mirror.psap.aws.rhperfscale.org/coco \
-                     --client-cert=${PSAP_SECRET_PATH}/entitled-mirror-client-creds.pem
+DL_OPT=""
+if [[ "$@" == *use_mirror* ]]; then
+   DL_OPT="${DL_OPT} --mirror_base_url=https://mirror-dataset.apps.ci-mirror.psap.aws.rhperfscale.org/coco"
+   DL_OPT="${DL_OPT} --client-cert=${PSAP_SECRET_PATH}/entitled-mirror-client-creds.pem"
+fi
+
+RUN_CNT=1
+if [[ "$@" == *download_twice* ]]; then
+    # for testing purposes, to make sure that the files are cached and not actually downloaded twice
+    RUN_CNT=2
+fi
+
+for i in $(seq $RUN_CNT); do
+    ./run_toolbox.py benchmarking download_coco_dataset "$gpu_node_hostname" $DL_OPT
 done
 
 ./run_toolbox.py benchmarking run_nvidiadl_ssd "$gpu_node_hostname"

--- a/toolbox/benchmarking.py
+++ b/toolbox/benchmarking.py
@@ -16,7 +16,7 @@ class Benchmarking:
             namespace: Name of the namespace in which the resources will be created.
             pvc_name: Name of the PVC that will be create to store the dataset files.
             mirror_base_url: Optional base URL where to fetch the dataset
-            client_cert: Optional tath to the client cert to use for accessing the base URL.
+            client_cert: Optional path to the client cert to use for accessing the base URL.
         """
         opts = {
             "benchmarking_node_hostname": node_hostname,


### PR DESCRIPTION
Downloading from the private mirror is for nighly/repetitive testing,
for a one-shot download, no need to rely on our private mirror + its client cert.

Tested on my local cluster.