### PR TITLE
gpu_operator_bundle_from_commit: use temporary updated driver image

### DIFF
--- a/roles/gpu_operator_bundle_from_commit/files/operator_bundle_image_builder_script.yml
+++ b/roles/gpu_operator_bundle_from_commit/files/operator_bundle_image_builder_script.yml
@@ -100,7 +100,7 @@ data:
     fi
 
     if [ "${WITH_DRIVER:-}" ]; then
-      # update vdriver image in the ClusterPolicy
+      # update driver image in the ClusterPolicy
       img="${OPERATOR_IMAGE_REPOSITORY}/${OPERATOR_IMAGE_NAME}:driver_${OPERATOR_IMAGES_TAG_SUFFIX}"
       podman pull --quiet $LOCAL_AUTH "$img"
       DRIVER_IMAGE_VERSION="$(podman inspect "$img" | jq -r .[].Digest)"
@@ -111,6 +111,17 @@ data:
         | jq '.[].spec.driver.image="'${OPERATOR_IMAGE_NAME}'"' \
         | jq '.[].spec.driver.repository="'${OPERATOR_IMAGE_REPOSITORY}'"' \
         | jq '.[].spec.driver.version="'${DRIVER_IMAGE_VERSION}'"' \
+        > clusterpolicy.json
+      rm  clusterpolicy.json.orig
+    else
+      # update driver image in the ClusterPolicy with TMP v1.9.0
+
+      mv clusterpolicy.json{,.orig}
+
+      cat clusterpolicy.json.orig \
+        | jq '.[].spec.driver.image="driver"' \
+        | jq '.[].spec.driver.repository="quay.io/shivamerla"' \
+        | jq '.[].spec.driver.version="470.57.02"' \
         > clusterpolicy.json
       rm  clusterpolicy.json.orig
     fi

--- a/testing/prow/gpu-operator.sh
+++ b/testing/prow/gpu-operator.sh
@@ -177,8 +177,8 @@ deploy_commit() {
                                              "${GPU_OPERATOR_QUAY_BUNDLE_IMAGE_NAME}" \
                                              --tag_uid "${CI_IMAGE_GPU_COMMIT_CI_IMAGE_UID}" \
                                              --namespace "${OPERATOR_NAMESPACE}" \
-                                             --with_driver=true \
-                                             --with_validator=true
+                                             --with_validator=true \
+                                             --publish_to_quay=true
 
     ./run_toolbox.py gpu_operator deploy_from_bundle --bundle "${GPU_OPERATOR_QUAY_BUNDLE_IMAGE_NAME}:operator_bundle_gpu-operator-ci-image" \
                                                      --namespace "${OPERATOR_NAMESPACE}"


### PR DESCRIPTION
Previous behavior relying on the image SHA was causing a race condition in the nightly CI ...