### PR TITLE
Add support for different GPU operator subscription .spec.name

### DIFF
--- a/roles/gpu_operator_get_csv_version/tasks/main.yml
+++ b/roles/gpu_operator_get_csv_version/tasks/main.yml
@@ -6,12 +6,21 @@
     register: gpu_operator_csv_version_cmd
     failed_when: gpu_operator_csv_version_cmd.stdout | length == 0
   rescue:
+  - name: Get the gpu-operator subscription package name
+    block:
+    - name: Count gpu operator subscription candidates
+      shell: oc get subscription --all-namespaces -ojson | jq '[.items[] | select(.metadata.name | test("gpu-operator"))] | length'
+      register: gpu_subscriptions
+      failed_when: gpu_subscriptions.stdout != '1'
+    - name: Read the package name from the first gpu-operator subscription
+      shell: oc get subscription -A -ojson | jq '[.items[] | select(.metadata.name | test("gpu-operator"))][0].spec.name'
+      register: gpu_operator_subscription_package_name
   - name: Ensure that there is a CSV for the GPU Operator
     command:
       oc get csv
          -oname
          -n {{ gpu_operator_operator_namespace }}
-         -loperators.coreos.com/gpu-operator-certified.{{ gpu_operator_operator_namespace }}
+         -loperators.coreos.com/{{ gpu_operator_subscription_package_name.stdout }}.{{ gpu_operator_operator_namespace }}
     register: gpu_operator_csv_name_cmd
     failed_when: gpu_operator_csv_name_cmd.stdout | length == 0
 

--- a/roles/gpu_operator_wait_deployment/meta/main.yml
+++ b/roles/gpu_operator_wait_deployment/meta/main.yml
@@ -1,5 +1,5 @@
 ---
 dependencies:
   - role: check_deps
-  - role: gpu_operator_get_csv_version
   - role: gpu_operator_set_namespace
+  - role: gpu_operator_get_csv_version


### PR DESCRIPTION
commit a2c17d064c48e99583b20aeaa3dd129821d08977

    Search for GPU operator CSV using a more generic label
    
    Previously the `operators.coreos.com/gpu-operator-certified.{{ gpu_operator_operator_namespace }}`
    label was used to find the GPU operator's CSV file. This label is being
    automatically generated by OLM from the subscription using this code:
    
    https://github.com/operator-framework/operator-lifecycle-manager/blob/20ded32d2260a8f1eeb594b9ec2147ad0134cfc6/pkg/controller/operators/adoption_controller_test.go#L107
    
    It's possible to see that the `gpu-operator-certified` part of the label is not set in
    stone, and is actually just taken from the Subscription's `.spec.name`
    field.
    
    This change makes it so the ansible role will dynamically generate this
    label in a similar manner to OLM, to allow the label to be found even
    when the Subscription's `.spec.name` is different from
    `gpu-operator-certified`.
    
    We ran into this issue when trying to run the toolbox `gpu_operator wait_deployment`
    command on a cluster deployed on OCM with the GPU-addon, where the
    `.spec.name` in the subscription is `gpu-operator-certified-addon`
    rather than `gpu-operator-certified`.

commit 9b2acd4b3fb6e5afc8640540b59f0bf9303b6c97

    Change confusing role dependency order
    
    wait_deployment depended on get_csv and set_namespace,
    but get_csv already also depends on set_namespace,
    which is why in reality set_namespace gets ran before get_csv,
    which is why it worked so far. But the order in which
    get_csv and set_namespace were listed inside the wait_deployment
    dependencies made it look like set_namespace was only running after,
    which is impossible because it defines the namespace var which is
    needed by get_csv - this made following where the namespace is set
    and coming from very confusing
