### PR TITLE
testing: prow/gpu-operator: fix DTK+entitlement handling and improve artifacts logging

### DIFF
--- a/docs/ci/files.rst
+++ b/docs/ci/files.rst
@@ -37,10 +37,21 @@ interpreted to enhance the dashboard display:
 - ``$ARTIFACT_DIR/FAILURE``: the presence this file after the CI
   execution indicates that the testing failed.
 
-- ``$ARTIFACT_DIR/FLAKE``: the presence of this file after a toolbox
-  command fail indicates that a known flake occurred. The file
-  contains a brief description of the problem that happened.
+- ``$ARTIFACT_DIR/<toolbox step>/FLAKE``: the presence of this file
+  after a toolbox command fail indicates that a known flake
+  occurred. The file contains a brief description of the problem(s)
+  that happened, each on a dedicated line.
 
-- ``$ARTIFACT_DIR/UNREACHABLE``: the presence this file after the CI
-  execution indicates that the testing failed and the cluster was
-  unreachable during our tear-down execution.
+- ``$ARTIFACT_DIR/<toolbox step>/EXPECTED_FAIL``: the presence of this
+  file after a test run indicates that this toolbox box step failure
+  was expected (i.e., not a failure, only a condition test). The file
+  contains a brief description of what was being tested.
+
+
+- ``$ARTIFACT_DIR/FLAKE``: the presence of this file after a test run
+  indicates that a known flake occurred. The file contains a brief
+  description of the problem that happened.
+
+- ``$ARTIFACT_DIR/_WARNINGS``: the presence of this directory after a
+  test run indicates that some warnings were raised. The files contain
+  a brief description of the problem that happened.

--- a/roles/check_deps/tasks/main.yml
+++ b/roles/check_deps/tasks/main.yml
@@ -16,7 +16,7 @@
       oc version -o json
       | jq --raw-output '.openshiftVersion'
     register: ocp_version
-    failed_when: ocp_version.stdout == 'nul' or ocp_version.stdout == ""
+    failed_when: ocp_version.stdout == 'null' or ocp_version.stdout == ""
   rescue:
   - name: Fail because of a dependency issue
     fail:

--- a/roles/gpu_operator_deploy_from_operatorhub/tasks/deploy_from_catalog.yml
+++ b/roles/gpu_operator_deploy_from_operatorhub/tasks/deploy_from_catalog.yml
@@ -39,7 +39,7 @@
   - name: Mark the failure as flake
     shell:
       echo "Failed because of the GPU Operator packagemanifest not available"
-           > "{{ artifact_dir }}/FLAKE"
+           >> "{{ artifact_extra_logs_dir }}/FLAKE"
 
   - name: Failed because the GPU Operator could not be install from the Catalog Operator
     fail: msg="Failed because the GPU Operator could not be install from the Catalog Operator"

--- a/roles/nfd_operator_deploy_from_operatorhub/tasks/main.yml
+++ b/roles/nfd_operator_deploy_from_operatorhub/tasks/main.yml
@@ -19,7 +19,7 @@
   - name: Mark the failure as flake
     shell:
       echo "Failed because of the NFD Operator packagemanifest not available"
-           > "{{ artifact_dir }}/FLAKE"
+           >> "{{ artifact_extra_logs_dir }}/FLAKE"
 
   - name: Failing because of previous error
     fail: msg="Failing because of the NFD Operator packagemanifest not available"

--- a/testing/run
+++ b/testing/run
@@ -89,10 +89,13 @@ postchecks() {
     shift
 
     if [[ "$reason" == ERR ]]; then
-        touch $ARTIFACT_DIR/FAILURE
+        last_toolbox_dir=$(ls ${ARTIFACT_DIR}/*__* -d | tail -1)
+
+        echo "Last step:  ${last_toolbox_dir/$ARTIFACT_DIR\//}" > $ARTIFACT_DIR/FAILURE
 
         if ! oc version >/dev/null 2>&1; then
-            echo "Cluster unreachable" > $ARTIFACT_DIR/UNREACHABLE
+            mkdir -p $ARTIFACT_DIR/FLAKE
+            echo "Cluster unreachable" >> $ARTIFACT_DIR/FLAKE
         fi
     elif [[ "$reason" == EXIT ]]; then
         echo ""


### PR DESCRIPTION
Functions `_warning` and `_expected_fail` are used to track information into `${ARTIFACT_DIR}`, so that `ci-dashboard` will be able to parse it and display it in the GPU Operator dashboard:
- `_warning` will end up as messages below the test line (eg, `WARNING: Driver Toolkit image is not valid, using entitled-build fallback`)
- `_expected_fail` will be used to count the number of expected step failures (eg, ` if cluster doesn't have NFD labels (expected fail), deploy NFD`)
- and updating `$ARTIFACT_DIR/FLAKE` and `$ARTIFACT_DIR/<toolbox step>/FLAKE` here and there to be able to store mutiple messages (one per line)
- 