### PR TITLE
testing: prow/gpu-operator: fix dtk_image_is_valid

### DIFF
--- a/testing/prow/gpu-operator.sh
+++ b/testing/prow/gpu-operator.sh
@@ -38,7 +38,10 @@ dtk_image_is_valid() {
     MINI_POD_SPEC='{"apiVersion": "v1", "kind":"Pod","metadata":{"name":"test"},"spec":{"containers":[{"name":"cnt"}]}}'
     DTK_IMAGE="image-registry.openshift-image-registry.svc:5000/openshift/driver-toolkit:latest"
 
-    dtk_release=$(oc debug --quiet -f <(echo "$MINI_POD_SPEC") --image=${DTK_IMAGE} \
+    dtk_release=$(oc debug -f <(echo "$MINI_POD_SPEC") \
+                     --quiet \
+                     -n default \
+                     --image=${DTK_IMAGE} \
                      -- \
                      cat /etc/driver-toolkit-release.json)
     dtk_kernel=$(echo "$dtk_release" | jq -r .KERNEL_VERSION)


### PR DESCRIPTION
Fixing this:
```
+ MINI_POD_SPEC='{"apiVersion": "v1", "kind":"Pod","metadata":{"name":"test"},"spec":{"containers":[{"name":"cnt"}]}}'
+ DTK_IMAGE=image-registry.openshift-image-registry.svc:5000/openshift/driver-toolkit:latest
++ oc debug --quiet -f /dev/fd/63 --image=image-registry.openshift-image-registry.svc:5000/openshift/driver-toolkit:latest -- cat /etc/driver-toolkit-release.json
+++ echo '{"apiVersion": "v1", "kind":"Pod","metadata":{"name":"test"},"spec":{"containers":[{"name":"cnt"}]}}'
Error from server (NotFound): namespaces "ci-op-3nkbszr2" not found
```