### PR TITLE
Find gpu-operator subscriptions with `.spec.name` rather than `.metadata.name`

### DIFF
--- a/roles/gpu_operator_get_csv_version/tasks/main.yml
+++ b/roles/gpu_operator_get_csv_version/tasks/main.yml
@@ -9,11 +9,11 @@
   - name: Get the gpu-operator subscription package name
     block:
     - name: Count gpu operator subscription candidates
-      shell: oc get subscription --all-namespaces -ojson | jq '[.items[] | select(.metadata.name | test("gpu-operator"))] | length'
+      shell: oc get subscription --all-namespaces -ojson | jq '[.items[] | select(.spec.name | test("gpu-operator"))] | length'
       register: gpu_subscriptions
       failed_when: gpu_subscriptions.stdout != '1'
     - name: Read the package name from the first gpu-operator subscription
-      shell: oc get subscription -A -ojson | jq '[.items[] | select(.metadata.name | test("gpu-operator"))][0].spec.name'
+      shell: oc get subscription -A -ojson | jq '[.items[] | select(.spec.name | test("gpu-operator"))][0].spec.name'
       register: gpu_operator_subscription_package_name
   - name: Ensure that there is a CSV for the GPU Operator
     command:


### PR DESCRIPTION
The gpu-addon CI uses the ci-artifact's toolbox "gpu_operator wait_deployment" command which used to assume that the GPU-operator's `ClusterServiceVersion` would have a particular label. It turned out that this label is not constant and actually dependent on the `.spec.name` of the `Subscription` that triggered the creation of that CSV. So I adjusted the script to look for the gpu operator `Subscription` and determine the label that we need to look for according to that `Subscription`'s `.spec.name`.

The issue is in the "look for the gpu operator subscription" part - the gpu operator subscription has a different `.metadata.name` depending on how it's deployed (e.g. add-on vs something else). So my code would simply look for any `Subscription` containing the string "gpu-operator" (and it would also check that there's only one such subscription to make sure there's no funny business). But that seems to cause issues when it's deployed via add-on, because annoyingly the NFD being deployed has a `.metadata.name` that looks something like `node-feature-discovery-operator-4.8-addon-gpu-operator-certified-addon-catalog-openshift-marketplace`

As you can see it also contains "gpu-operator" so it becomes annoyingly non-trivial to find the gpu-operator subscription, we fail on the "Check that there's only one such subscription" part because they both have gpu-operator in their name.

This commit solves this issue by looking at the `.spec.name` rather than the `.metadata.name`. The NFD subscription does not contain the string "gpu-operator" in the `.spec.name`.