### PR TITLE
Improve expected failure tracking

### DIFF
--- a/testing/prow/entitle.sh
+++ b/testing/prow/entitle.sh
@@ -11,6 +11,16 @@ if ! [ -f ./toolbox/entitlement.py ]; then
   exit 1
 fi
 
+_expected_fail() {
+    # mark the last toolbox step as an expected fail (for clearer
+    # parsing/display in ci-dashboard)
+    # eg: if cluster doesn't have NFD labels (expected fail), deploy NFD
+    # eg: if cluster doesn't have GPU nodes (expected fail), scale up with GPU nodes
+
+    last_toolbox_dir=$(ls ${ARTIFACT_DIR}/*__* -d | tail -1)
+    echo "$1" > ${last_toolbox_dir}/EXPECTED_FAIL
+}
+
 extract_entitlement_key() {
     resource=$1
     key=$2
@@ -28,6 +38,9 @@ if ./run_toolbox.py entitlement test_cluster --no_inspect; then
     echo "INFO: Cluster already entitled, skipping entitlement."
     exit 0
 fi
+
+# mark the failure of "entitlement test_cluster" ^^^ as expected
+_expected_fail "Checking if the cluster was entitled"
 
 ENTITLEMENT_SECRET_PATH=/var/run/psap-entitlement-secret
 ENTITLEMENT_VERSION=${ENTITLEMENT_SECRET_PATH}/version

--- a/testing/prow/gpu-operator.sh
+++ b/testing/prow/gpu-operator.sh
@@ -87,7 +87,6 @@ prepare_cluster_for_gpu_operator() {
         if oc get packagemanifests/nfd -n openshift-marketplace > /dev/null; then
             ./run_toolbox.py nfd_operator deploy_from_operatorhub
         else
-            # in 4.9, NFD is currently not available from its default location,
             _warning "NFD_deployed_from_master" "NFD was deployed from master (not available in OperatorHub)"
 
             # install the NFD Operator from sources

--- a/testing/prow/nfd-operator.sh
+++ b/testing/prow/nfd-operator.sh
@@ -7,11 +7,25 @@ set -o nounset
 THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 cd ${THIS_DIR}/../..
 
+_expected_fail() {
+    # mark the last toolbox step as an expected fail (for clearer
+    # parsing/display in ci-dashboard)
+    # eg: if cluster doesn't have NFD labels (expected fail), deploy NFD
+    # eg: if cluster doesn't have GPU nodes (expected fail), scale up with GPU nodes
+
+    last_toolbox_dir=$(ls ${ARTIFACT_DIR}/*__* -d | tail -1)
+    echo "$1" > ${last_toolbox_dir}/EXPECTED_FAIL
+}
+
 prepare_cluster_for_nfd() {
     if ./run_toolbox.py nfd has_labels; then
         echo "FATAL: NFD labels found in the cluster"
         exit 1
     fi
+
+    # mark the failure of "nfd has_labels" ^^^ as expected
+    _expected_fail "Checking if the cluster had NFD labels"
+
     ./run_toolbox.py cluster capture_environment
 }
 

--- a/testing/prow/sro.sh
+++ b/testing/prow/sro.sh
@@ -7,6 +7,17 @@ set -o nounset
 THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 cd ${THIS_DIR}/../..
 
+_warning() {
+    fname="$1"
+    msg="$2"
+
+    DEST_DIR="${ARTIFACT_DIR}/_WARNING/"
+    mkdir -p "$DEST_DIR"
+    echo "$msg" > "${DEST_DIR}/$fname"
+
+    echo "WARNING: $msg"
+}
+
 _expected_fail() {
     # mark the last toolbox step as an expected fail (for clearer
     # parsing/display in ci-dashboard)
@@ -31,8 +42,8 @@ prepare_cluster_for_sro() {
         if oc get packagemanifests/nfd -n openshift-marketplace > /dev/null; then
             ./run_toolbox.py nfd_operator deploy_from_operatorhub
         else
-            # in 4.9, NFD is currently not available from its default location,
-            touch "${ARTIFACT_DIR}/NFD_DEPLOYED_FROM_MASTER"
+            _warning "NFD_deployed_from_master" "NFD was deployed from master (not available in OperatorHub)"
+
             # install the NFD Operator from sources
             CI_IMAGE_NFD_COMMIT_CI_REPO="${1:-https://github.com/openshift/cluster-nfd-operator.git}"
             CI_IMAGE_NFD_COMMIT_CI_REF="${2:-master}"


### PR DESCRIPTION
* `testing/prow/entitle.sh: mark the failure of 'entitlement test_cluster' as expected`


---

* `testing/prow/nfd-operator.sh: mark the failure of 'nfd has_labels' as expected`


---

* `testing/prow/sro.sh: mark the failure of 'nfd has_labels' as expected`


---

* `testing/prow/sro.sh: mark 'NFD missing from operatorhub' as a warning`


---

* `testing/prow/gpu-operator.sh: remove mention that NFD is not available in 4.9 OperatorHub`


---

See https://github.com/openshift-psap/ci-dashboard/pull/37 for the `ci-dashboard` part of it