### PR TITLE
gpu_operator: metrics: do not check namespace monitoring

### DIFF
--- a/roles/gpu_operator_deploy_from_operatorhub/tasks/deploy_from_bundle.yml
+++ b/roles/gpu_operator_deploy_from_operatorhub/tasks/deploy_from_bundle.yml
@@ -25,11 +25,6 @@
   command:
     oc create namespace {{ gpu_operator_operator_namespace }}
 
-- name: Label the GPU Operator namespace for monitoring, if it did not exist
-  when: namespace_exists_cmd.rc != 0
-  command:
-    oc label ns/{{ gpu_operator_operator_namespace }} openshift.io/cluster-monitoring=true
-
 - name: Deploy the GPU Operator from the bundle
   command:
     operator-sdk run bundle --timeout=5m

--- a/roles/gpu_operator_wait_deployment/tasks/main.yml
+++ b/roles/gpu_operator_wait_deployment/tasks/main.yml
@@ -97,16 +97,5 @@
   - name: The GFD did not label the nodes
     fail: msg="The GFD did not label the nodes"
 
-- block:
-  - name: Check if the namespace has the openshift.io/cluster-monitoring label
-    shell: oc get ns -l openshift.io/cluster-monitoring -oname | grep {{ gpu_operator_namespace }}
-  rescue:
-  - name: Get the namespace yaml specification
-    command: oc get ns/{{ gpu_operator_namespace }} -oyaml
-
-  - name: Make sure that namespace has the openshift.io/cluster-monitoring label
-    command: oc label ns/{{ gpu_operator_namespace }} openshift.io/cluster-monitoring=true
-
-
 - name: Validate the GPU Operator metrics
   include_tasks: metrics.yml

--- a/roles/gpu_operator_wait_deployment/tasks/metrics.yml
+++ b/roles/gpu_operator_wait_deployment/tasks/metrics.yml
@@ -88,7 +88,7 @@
 ### Node Metrics
 
 - name: Validate that the GPU Operator node-status metrics are correctly exposed
-  when: gpu_operator_version >= "1.8.0"
+  when: gpu_operator_version is version("1.8.0", ">=")
   block:
   - name: Wait for the node-status-exporter Pod to start running
     shell:
@@ -164,7 +164,7 @@
 ### Operator metrics
 
 - name: Validate that the GPU Operator operator metrics are correctly exposed
-  when: gpu_operator_version >= "1.8.0"
+  when: gpu_operator_version is version("1.8.0", ">=")
   block:
   - name: Check if the namespace has the openshift.io/cluster-monitoring label
     block:

--- a/roles/gpu_operator_wait_deployment/tasks/metrics.yml
+++ b/roles/gpu_operator_wait_deployment/tasks/metrics.yml
@@ -5,11 +5,22 @@
       set -o pipefail;
       oc get ns -l openshift.io/cluster-monitoring -oname | grep {{ gpu_operator_namespace }}
   rescue:
+  - name: The GPU Operator namespace is not properly labelled for monitoring
+    when: gpu_operator_version is version("1.9.0", ">=")
+    fail: msg="The GPU Operator namespace is not properly labelled for monitoring"
+
   - name: Get the namespace yaml specification
     command: oc get ns/{{ gpu_operator_namespace }} -oyaml
 
   - name: Make sure that namespace has the openshift.io/cluster-monitoring label
     command: oc label ns/{{ gpu_operator_namespace }} openshift.io/cluster-monitoring=true
+
+- name: Ensure that the GPU Operator operator namespace has the openshift.io/cluster-monitoring label
+  when: gpu_operator_version is version("1.9.0", "<")
+  command:
+    oc label ns/{{ gpu_operator_operator_namespace }}
+             openshift.io/cluster-monitoring=true
+             --overwrite
 
 ### DCGM metrics
 
@@ -166,17 +177,6 @@
 - name: Validate that the GPU Operator operator metrics are correctly exposed
   when: gpu_operator_version is version("1.8.0", ">=")
   block:
-  - name: Check if the namespace has the openshift.io/cluster-monitoring label
-    block:
-    - name: Check if the namespace has the openshift.io/cluster-monitoring label
-      shell:
-        set -o pipefail;
-        oc get ns -l openshift.io/cluster-monitoring -oname
-        | grep {{ gpu_operator_operator_namespace }}
-    rescue:
-    - name: Make sure that namespace has the openshift.io/cluster-monitoring label
-      command: oc label ns/{{ gpu_operator_operator_namespace }} openshift.io/cluster-monitoring=true
-
   - name: Fetch the GPU Operator operator metrics
     shell:
       bash "{{ gpu_operator_fetch_pod_metrics_script }}"


### PR DESCRIPTION
* `gpu_operator_wait_deployment: metrics: use version("1.8.0", ">=") for version checking`


---

* `gpu_operator_deploy_from_operatorhub: deploy_from_bundle: remove duplicate namespace monitoring label`


---

* `gpu_operator_wait_deployment: metrics: remove duplicate namespace monitoring label`


---

* `gpu_operator_wait_deployment: metrics: add namespace monitoring label only in v1.8.x`


---

* `gpu_operator_wait_deployment: metrics: do not check namespace monitoring`

The operator always takes care of it

---