### PR TITLE
Fix: osde2e flow was missing xml files

### DIFF
--- a/testing/osde2e/gpu-addon.sh
+++ b/testing/osde2e/gpu-addon.sh
@@ -27,8 +27,9 @@ function exit_and_abort() {
 function run_test() {
     TARGET=${1:-}
     echo "====== Running toolbox '$TARGET'"
+    JUNIT_FILE_NAME=$(echo $TARGET | awk '{print "junit_"$1"_"$2".xml"}')
     TARGET_NAME=$(echo $TARGET | sed 's/ /_/g')
-    JUNIT_FILE="${ARTIFACT_DIR}/junit_${TARGET_NAME}.xml"
+    JUNIT_FILE="${ARTIFACT_DIR}/${JUNIT_FILE_NAME}"
     RUNTIME_FILE="${ARTIFACT_DIR}/runtime"
     OUTPUT_FILE="${ARTIFACT_DIR}/output"
 

--- a/testing/osde2e/gpu-addon.sh
+++ b/testing/osde2e/gpu-addon.sh
@@ -5,6 +5,8 @@ if ! [[ -d  $ARTIFACT_DIR ]] ; then
     exit 1
 fi
 
+CI_ARTIFACT_DIR=${ARTIFACT_DIR}/artifacts
+
 BURN_RUNTIME_SEC=600
 
 JUNIT_HEADER_TEMPLATE='<?xml version="1.0" encoding="utf-8"?>
@@ -18,6 +20,8 @@ JUNIT_FOOTER_TEMPLATE='
     </testcase>
 </testsuite>
 '
+
+mkdir -p $CI_ARTIFACT_DIR
 
 function exit_and_abort() {
     echo "Failed. Aborting."
@@ -37,7 +41,7 @@ function run_test() {
 $JUNIT_HEADER_TEMPLATE
 EOF
 
-    /usr/bin/time -o ${RUNTIME_FILE} ./run_toolbox.py ${TARGET} > $OUTPUT_FILE
+    ARTIFACT_DIR=$CI_ARTIFACT_DIR /usr/bin/time -o ${RUNTIME_FILE} ./run_toolbox.py ${TARGET} > $OUTPUT_FILE
     STATUS=$?
 
     cat $OUTPUT_FILE

--- a/testing/recipes/run_osde2e_gpu_addon.sh
+++ b/testing/recipes/run_osde2e_gpu_addon.sh
@@ -13,6 +13,6 @@ source $THIS_DIR/../prow/gpu-operator.sh source
 
 prepare_cluster_for_gpu_operator
 
-./run_toolbox.py gpu_operator deploy_from_operatorhub --namespace openshift-operators
+./run_toolbox.py gpu_operator deploy_from_operatorhub --namespace openshift-operators --version 1.8.2 --channel v1.8
 
 ./testing/osde2e/gpu-addon.sh


### PR DESCRIPTION
junit file name was generated in a way that was problematic. was including command arguments and flags.

This commit solves the issue, and all junit reports will be saved properly.