### PR TITLE
testing: test-commit.sh: allow testing any commit of a PR

### DIFF
--- a/testing/prow/gpu-operator.sh
+++ b/testing/prow/gpu-operator.sh
@@ -140,7 +140,7 @@ collect_must_gather() {
                 eval $ENV
 
                 echo "Copying must-gather results to $ARTIFACT_EXTRA_LOGS_DIR ..."
-                cp -r "$TMP_DIR"/* "$ARTIFACT_EXTRA_LOGS_DIR"
+                mv "$TMP_DIR"/* "$ARTIFACT_EXTRA_LOGS_DIR"
 
                 rmdir "$TMP_DIR"
             fi

--- a/testing/recipes/test.sh
+++ b/testing/recipes/test.sh
@@ -1,3 +1,4 @@
 #! /usr/bin/env bash
 
-exec echo "Hello World"
+echo "Hello World"
+echo "Args: $*"

--- a/testing/test-commit.sh
+++ b/testing/test-commit.sh
@@ -26,17 +26,19 @@ commit="HEAD"
 parent=$(git log --pretty=%P -n 1 $commit)
 
 if grep -q " " <<< "$parent"; then
-    commit=$(cut -d" " -f2 <<< "$parent")
-    echo "HEAD is a merge commit. Taking the 2nd parent from $parent"
+    commit=$(sed 's/ /../g' <<< "$parent")
+    echo "HEAD is a merge commit. Taking all the commit in $commit"
+    number=""
 else
     echo "HEAD is a simple commit."
+    number="-n 1"
 fi
 
 git show --quiet "$commit"
 
 echo ""
 
-testpaths=$(git log --format=%B -n 1 $commit | { grep -i "$ANCHOR" || true ;} | cut -b$(echo "$ANCHOR" | wc -c)-)
+testpaths=$(git log --format=%B $number $commit | { grep -i "$ANCHOR" || true ;} | cut -b$(echo "$ANCHOR" | wc -c)-)
 
 if [[ -z "$testpaths" ]]; then
     echo "Nothing to test in $commit."


### PR DESCRIPTION
`test-commit.sh` added the ability to trigger a test not hard-coded into `openshift/release`, like `/test gpu-operator-e2e` would do.

Instead, currently (before this PR), we can add to the top most commit of a PR:
```
test-path: recipes test "Hello World"
```
and trigger it with
```
/test test-commit
```
which will execute `run recipes test "Hello World"` in the image.

This helps running custom one-off tests like running [this script](https://github.com/openshift-psap/ci-artifacts/blob/master/testing/recipes/run_cocodataset_nvidiadl_ssd.sh):
```
test-path: recipes run_cocodataset_nvidiadl_ssd
```
---
One restriction of the current code is that the `test-path` must be in the top most commit (think `git show HEAD`), 
and that makes `/test test-commit` fail when you add another commit on top of the one defining the `test-path`.

This PR allows [`test-commit.sh`](https://github.com/openshift-psap/ci-artifacts/blob/master/testing/test-commit.sh) to look at all the commit messages of the PR.
