### PR TITLE
benchmarking: make the execution easier to reproduce

### DIFF
--- a/roles/benchmarking_deploy_coco_dataset/tasks/main.yml
+++ b/roles/benchmarking_deploy_coco_dataset/tasks/main.yml
@@ -26,46 +26,52 @@
        -n {{ benchmarking_namespace }}
        --ignore-not-found=true
 
-- name: Create the entrypoint config map
-  command:
+- name: Create the entrypoint ConfigMap file
+  shell:
     oc create cm coco-dataset-downloader
        --from-file="entrypoint.sh={{ coco_dataset_entrypoint }}"
        -n {{ benchmarking_namespace }}
+       --dry-run=client
+       -oyaml
+       > {{ artifact_extra_logs_dir }}/000_configmap_coco-dataset_entrypoint.yml
+
+- name: Create the entrypoint ConfigMap resource
+  command: oc apply -f {{ artifact_extra_logs_dir }}/000_configmap_coco-dataset_entrypoint.yml
 
 - name: Apply the PVC template
   template:
     src: "{{ coco_dataset_pvc }}"
-    dest: "{{ artifact_extra_logs_dir }}/pvc.yml"
+    dest: "{{ artifact_extra_logs_dir }}/001_pvc_coco-dataset.yml"
     mode: 0400
 
 - name: Check if the PVC already exists
-  command: oc get -f "{{ artifact_extra_logs_dir }}/pvc.yml" -oname
+  command: oc get -f "{{ artifact_extra_logs_dir }}/001_pvc_coco-dataset.yml" -oname
   failed_when: false
   register: has_pvc
 
 - name: Create a PVC for storing the COCO dataset
   when: has_pvc.rc != 0
   command:
-    oc apply -f "{{ artifact_extra_logs_dir }}/pvc.yml"
+    oc apply -f "{{ artifact_extra_logs_dir }}/001_pvc_coco-dataset.yml"
 
 - name: Apply the Pod template
   template:
     src: "{{ coco_dataset_pod }}"
-    dest: "{{ artifact_extra_logs_dir }}/pod.yml"
+    dest: "{{ artifact_extra_logs_dir }}/002_pod_coco-dataset.yml"
     mode: 0400
 
 - name: Delete the Pod, if it exists
   command:
-    oc delete -f "{{ artifact_extra_logs_dir }}/pod.yml"
+    oc delete -f "{{ artifact_extra_logs_dir }}/002_pod_coco-dataset.yml"
        --ignore-not-found=true
 
 - name: Create a Pod for downloading the COCO dataset
   command:
-    oc apply -f "{{ artifact_extra_logs_dir }}/pod.yml"
+    oc apply -f "{{ artifact_extra_logs_dir }}/002_pod_coco-dataset.yml"
 
 - name: Wait for the downloader Pod to terminate
   command:
-    oc get -f "{{ artifact_extra_logs_dir }}/pod.yml"
+    oc get -f "{{ artifact_extra_logs_dir }}/002_pod_coco-dataset.yml"
        --no-headers
        -ocustom-columns=phase:status.phase
   register: wait_dataset_downloader_pod

--- a/roles/benchmarking_deploy_coco_dataset/tasks/main.yml
+++ b/roles/benchmarking_deploy_coco_dataset/tasks/main.yml
@@ -20,12 +20,6 @@
        -n {{ benchmarking_namespace }}
        --from-file=mirror.pem={{ benchmarking_coco_dataset_client_cert }}
 
-- name: Delete the entrypoint CM, if it exists
-  command:
-    oc delete cm/coco-dataset-downloader
-       -n {{ benchmarking_namespace }}
-       --ignore-not-found=true
-
 - name: Create the entrypoint ConfigMap file
   shell:
     oc create cm coco-dataset-downloader

--- a/roles/benchmarking_deploy_coco_dataset/templates/pod.yml.j2
+++ b/roles/benchmarking_deploy_coco_dataset/templates/pod.yml.j2
@@ -6,6 +6,7 @@ metadata:
 spec:
   restartPolicy: Never
   nodeSelector:
+    # Force the Pod to run on a given Node
     kubernetes.io/hostname: {{ benchmarking_node_hostname }}
   containers:
   - name: coco-dataset-downloader
@@ -16,11 +17,9 @@ spec:
     - name: DATASET_BASE_URL
       value: "{{ benchmarking_coco_dataset_mirror_base_url }}"
 {% endif %}
-    - name: CERT_FILE
 {% if benchmarking_coco_dataset_client_cert|length %}
+    - name: CERT_FILE
       value: /etc/mirror-secret/mirror.pem
-{% else %}
-      value:
 {% endif %}
     volumeMounts:
 {% if benchmarking_coco_dataset_client_cert|length %}

--- a/roles/benchmarking_run_nvidiadl_ssd/tasks/main.yml
+++ b/roles/benchmarking_run_nvidiadl_ssd/tasks/main.yml
@@ -11,32 +11,39 @@
     oc get pvc/{{ benchmarking_coco_dataset_pvc_name }}
        -n {{ benchmarking_namespace }}
 
-- name: Delete the entrypoint ConfigMap, if it exists
-  command:
-    oc delete cm {{ benchmarking_nvidiadl_ssd_entrypoint_cm_name }}
-       --ignore-not-found=true
+- name: Fetch the coco dataset PVC definition (debug)
+  shell:
+    oc get pvc/{{ benchmarking_coco_dataset_pvc_name }}
        -n {{ benchmarking_namespace }}
+       -oyaml
+       > {{ artifact_extra_logs_dir }}/pvc_coco-dataset.yml
 
-- name: Create the entrypoint ConfigMap
-  command:
+- name: Create the entrypoint ConfigMap file
+  shell:
     oc create cm {{ benchmarking_nvidiadl_ssd_entrypoint_cm_name }}
        --from-file="{{ benchmarking_nvidiadl_ssd_entrypoint }}"
        -n {{ benchmarking_namespace }}
+       --dry-run=client
+       -oyaml
+       > {{ artifact_extra_logs_dir }}/000_configmap_run-nvidiadl-ssd_entrypoint.yml
+
+- name: Create the entrypoint ConfigMap resource
+  command: oc apply -f {{ artifact_extra_logs_dir }}/000_configmap_run-nvidiadl-ssd_entrypoint.yml
 
 - name: Apply the Pod template
   template:
     src: "{{ benchmarking_nvidiadl_ssd_pod }}"
-    dest: "{{ artifact_extra_logs_dir }}/pod.yml"
+    dest: "{{ artifact_extra_logs_dir }}/001_pod_run-nvidiadl-ssd.yml"
     mode: 0400
 
 - name: Delete the Pod, if it exists
   command:
-    oc delete -f "{{ artifact_extra_logs_dir }}/pod.yml"
+    oc delete -f "{{ artifact_extra_logs_dir }}/001_pod_run-nvidiadl-ssd.yml"
        --ignore-not-found=true
 
 - name: Deploy the Pod to run the benchmark
   command:
-    oc create -f "{{ artifact_extra_logs_dir }}/pod.yml"
+    oc create -f "{{ artifact_extra_logs_dir }}/001_pod_run-nvidiadl-ssd.yml"
 
 - name: Wait for the benchmark completion
   command:
@@ -52,12 +59,18 @@
 - name: Store the logs of benchmark execution (for post-processing)
   shell:
     oc logs pod/{{ benchmarking_nvidiadl_ssd_name }} -n {{ benchmarking_namespace }}
-       > "{{ artifact_extra_logs_dir }}/nvidiadl_ssd_pod.log"
+       > "{{ artifact_extra_logs_dir }}/pod_run-nvidiadl-ssd.log"
   failed_when: false
 
 - name: Store the status of the benchmark execution (for post-processing)
   shell:
-    echo "{{ wait_benchmark_pod_cmd.stdout }}" > "{{ artifact_extra_logs_dir }}/status"
+    echo "{{ wait_benchmark_pod_cmd.stdout }}" > "{{ artifact_extra_logs_dir }}/pod_run-nvidiadl-ssd.status"
+
+- name: Store the description of benchmark execution (debug)
+  shell:
+    oc describe pod/{{ benchmarking_nvidiadl_ssd_name }} -n {{ benchmarking_namespace }}
+       > "{{ artifact_extra_logs_dir }}/pod_run-nvidiadl-ssd.descr"
+  failed_when: false
 
 - name: Fail if the pod execution failed
   when: "'Failed' in wait_benchmark_pod_cmd.stdout or 'Error' in wait_benchmark_pod_cmd.stdout"

--- a/roles/benchmarking_run_nvidiadl_ssd/templates/nvidiadl-ssd-pod.yml.j2
+++ b/roles/benchmarking_run_nvidiadl_ssd/templates/nvidiadl-ssd-pod.yml.j2
@@ -1,20 +1,19 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "{{ benchmarking_nvidiadl_ssd_name }}"
-  namespace: "{{ benchmarking_namespace }}"
+  name: {{ benchmarking_nvidiadl_ssd_name }}
+  namespace: {{ benchmarking_namespace }}
 spec:
   restartPolicy: Never
+  # Force the Pod to run on the same Node where the PVC was bound
   nodeSelector:
     kubernetes.io/hostname: {{ benchmarking_node_hostname }}
   containers:
   - name: nvidiadl
     image: quay.io/openshift-psap/nvidiadl-ssd-training-benchmark
     resources:
-      # limits:
-      #   nvidia.com/gpu: 0
-      # requests:
-      #   nvidia.com/gpu: 0
+      limits:
+        nvidia.com/gpu: 1
     volumeMounts:
     - name: entrypoint-volume
       mountPath: /mnt/entrypoint/entrypoint.sh

--- a/testing/recipes/run_cocodataset_nvidiadl_ssd.sh
+++ b/testing/recipes/run_cocodataset_nvidiadl_ssd.sh
@@ -42,4 +42,12 @@ for i in $(seq $RUN_CNT); do
     ./run_toolbox.py benchmarking download_coco_dataset "$gpu_node_hostname" $DL_OPT
 done
 
-./run_toolbox.py benchmarking run_nvidiadl_ssd "$gpu_node_hostname"
+RUN_CNT=1
+if [[ "$@" == *benchmark_twice* ]]; then
+    # for testing purposes, to make sure that the files are cached and not actually downloaded twice
+    RUN_CNT=2
+fi
+
+for i in $(seq $RUN_CNT); do
+    ./run_toolbox.py benchmarking run_nvidiadl_ssd "$gpu_node_hostname"
+done


### PR DESCRIPTION
This PR stores the YAML definition of the resources used to 1) download the COCO dataset and 2) trigger the benchmark
into dedicate files, so that it's easier for anyone to re-execute these steps outside of the CI, and without `ci-artifacts` toolbox.

See the files `00x` in these two directories:
- https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/openshift-psap_ci-artifacts/301/pull-ci-openshift-psap-ci-artifacts-master-test-commit/1469245167625048064/artifacts/test-commit/test-commit/artifacts/recipes_run_cocodataset_nvidiadl_ssd_download_twice_benchmark_twice/014__benchmarking__run_nvidiadl_ssd/
- https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/openshift-psap_ci-artifacts/301/pull-ci-openshift-psap-ci-artifacts-master-test-commit/1469245167625048064/artifacts/test-commit/test-commit/artifacts/recipes_run_cocodataset_nvidiadl_ssd_download_twice_benchmark_twice/012__benchmarking__download_coco_dataset/