### PR TITLE
osde2e addon related tweaks

### DIFF
--- a/testing/run
+++ b/testing/run
@@ -139,7 +139,8 @@ if [[ $HOSTNAME == "addon-tests"* ]]; then
     # arguments is limited in osde2e
     echo "INFO: Running in OSDE2E addon test CI. Preparing for OSDE2E ..."
     set -- "osde2e" "gpu-addon"
-    export ARTIFACT_DIR="/test-run-results"
+    export ARTIFACT_DIR="/test-run-results/ci-artifacts"
+    mkdir -p $ARTIFACT_DIR
 fi
 
 ##############


### PR DESCRIPTION
 - Moved all artifacts generated by toolbox into a subdir inside ARTIFACT_DIR `ci-artifacts`
 - Because of a bug in osde2e testing, the new `ci-artifacts` is missing all of its sud-dirs. Added a `ci-artifacts.tar.gz` file. This file should contain all artifacts and be visible in prow.
 - fixed broken junit files due to traps in other scripts.

test-path: recipes run_osde2e_gpu_addon