### PR TITLE
gpu_operator_bundle_from_commit: use golang 1.17 to build the GPU Operator

### DIFF
--- a/roles/gpu_operator_bundle_from_commit/templates/build_validator.yml.j2
+++ b/roles/gpu_operator_bundle_from_commit/templates/build_validator.yml.j2
@@ -28,7 +28,7 @@ spec:
         - name: VERSION
           value: v0.1.0
         - name: GOLANG_VERSION
-          value: '1.15'
+          value: '1.17'
         - name: CUDA_SAMPLE_IMAGE
           value: nvcr.io/nvidia/k8s/cuda-sample:vectoradd-cuda11.2.1-ubi8
         - name: CUDA_IMAGE

--- a/roles/gpu_operator_bundle_from_commit/templates/operator_image_builder_pod.yml.j2
+++ b/roles/gpu_operator_bundle_from_commit/templates/operator_image_builder_pod.yml.j2
@@ -23,7 +23,7 @@ spec:
       - name: OPERATOR_IMAGE_NAME
         value: "{{ operator_image_name }}"
       - name: BUILDER_FROM_IMAGE
-        value: "quay.io/openshift-psap/golang:1.15" # avoid using docker.io and its quotas...
+        value: "quay.io/openshift-psap/golang:1.17" # avoid using docker.io and its quotas...
     volumeMounts:
     - mountPath: /mnt/helper/run_operator_image_builder.sh
       name: operator-image-builder-script


### PR DESCRIPTION
The GPU Operator Master branch testing (`ci-artifacts` side) got broken following the merge of this commit: https://gitlab.com/nvidia/kubernetes/gpu-operator/-/merge_requests/370