### PR TITLE
[sno-snapshot] New subproject for OpenShift SNO Snapshot/Rollback with AWS

### DIFF
--- a/subprojects/sno-snapshot/README.md
+++ b/subprojects/sno-snapshot/README.md
@@ -1,0 +1,63 @@
+OpenShift SNO Snapshot/Rollback with AWS
+========================================
+
+This WIP sub-project aims at providing a snapshot/rollback capability
+to a single-node OpenShift cluster running on AWS.
+
+Snapshotting
+------------
+
+```
+./snapshot.py
+
+    Creates the snapshot of the current state of the SNO node, if no
+    snapshot already exists.
+
+./snapshot.py --wait
+
+    Creates or awaits for the completion of the current AWS
+    snapshot. This takes several minutes to complete, but 1/ the
+    cluster is available during the snapshot creation and 2/ any
+    changes performed after the snapshot creation time will not be
+    included in the snapshot.
+
+./snapshot.py --delete
+
+    Deletes the AWS snapshot associated with this cluster, so that a
+    new one can be created.
+```
+
+*Open questions*:
+
+- Should the node be turned off before triggering the snapshot?
+
+*Todo*:
+
+- Include a human-readable timestamp in the snapshot name and printed
+  in (instead of the snapshot ID)
+- Delete all the OpenShift/Kubernetes objects backed by AWS objects
+  (extra machines, routes, auto-scaling, ...)
+  - These objects will be deleted during the cluster tear down anyway,
+    but better avoid letting them dangling if we can.
+
+Rolling Back
+------------
+
+```
+./rollback.py
+
+    Rolls back the cluster to the snapshot time.
+    Fails if there is exising snapshot.
+    Fails if the snapshot isn't completed yet.
+    Waits for the completion of the AWS snapshot rollback and the
+    reloading of RHCOS/OpenShift.
+
+
+./rollback.py --wait-snapshot
+
+   Wait for the completion of the AWS snapshot if it is not ready.
+
+./rollback.py --only-wait-openshift
+
+  Only wait for OpenShift to respond properly.
+```

--- a/subprojects/sno-snapshot/requirements.txt
+++ b/subprojects/sno-snapshot/requirements.txt
@@ -1,0 +1,2 @@
+boto3==1.19
+openshift-python-wrapper==2.1

--- a/subprojects/sno-snapshot/src/common.py
+++ b/subprojects/sno-snapshot/src/common.py
@@ -1,0 +1,114 @@
+import time, datetime
+
+print("Importing OpenShift/Kubernetes packages ...")
+
+import kubernetes
+import ocp_resources
+import openshift
+
+from ocp_resources.node import Node
+from ocp_resources.machine import Machine
+from ocp_resources.node import Node
+
+from openshift.dynamic import DynamicClient
+try:
+    client_k8s = DynamicClient(client=kubernetes.config.new_client_from_config())
+except Exception:
+    client_k8s = None
+    print("WARNING: kubernetes not available.")
+
+print("Importing AWS boto3 ...")
+
+import boto3
+
+# https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ec2.html
+
+client_ec2 = boto3.client('ec2')
+resource_ec2 = boto3.resource('ec2')
+
+print("Ready.")
+
+def wait_openshift():
+    first = True
+    print("Waiting for OpenShift cluster to be ready ...")
+    import urllib3
+    while True:
+        try:
+            global client_k8s
+            client_k8s = DynamicClient(client=kubernetes.config.new_client_from_config())
+
+            nodes = [m for m in Node.get(dyn_client=client_k8s)]
+            if len(nodes) != 0:
+                print(f"Found {len(nodes)} node, OpenShift Cluster is ready!")
+                break
+        except urllib3.exceptions.MaxRetryError: pass
+        except kubernetes.client.exceptions.ApiException: pass
+
+        time.sleep(10)
+
+def get_machine_props():
+    if not client_k8s:
+        return None, None
+
+    machines = [m for m in Machine.get(dyn_client=client_k8s)]
+    if len(machines) != 1:
+        raise RuntimeError("Should be only one machine ...")
+
+    machine = machines[0]
+
+    cluster_name = machine.cluster_name
+    print(f"Cluster name: {cluster_name}")
+    instance = resource_ec2.Instance(machine.instance.status.providerStatus.instanceId)
+    instance.load()
+    print(f"Instance Id: {instance.id}")
+
+    zone = machine.instance.spec.providerSpec.value.placement.availabilityZone
+    print(f"Availability zone: {zone}")
+    return cluster_name, instance, zone
+
+
+def get_instance_root_volume(instance):
+    volumes = [v for v in instance.volumes.all()]
+    if len(volumes) > 1:
+        print("WARNING: more than 1 volume found ...")
+
+    return volumes[0]
+
+def get_cluster_snapshot(cluster_name, instance, zone):
+    resp = client_ec2.describe_snapshots(
+        Filters=[{
+            'Name': f'tag:kubernetes.io/cluster/{cluster_name}',
+            'Values': ['owned']
+        }])
+
+    snapshots = resp["Snapshots"]
+    if len(snapshots) == 0:
+        return None
+
+    if len(snapshots) > 1:
+        print("WARNING: more than 1 snapshot found ... taking the first one.")
+
+    snapshot = resource_ec2.Snapshot(snapshots[0]['SnapshotId'])
+    snapshot.load()
+
+    return snapshot
+
+def await_snapshot(snapshot):
+    prev = ""
+    if snapshot.progress == "100%":
+        print(f"Snapshot {snapshot.id} is ready.")
+
+    while not snapshot.progress == "100%":
+        if prev == "":
+            print(f"Awaiting for the completion of snapshot {snapshot.id} ...")
+            print(snapshot.progress)
+            prev = snapshot.progress
+
+        time.sleep(10)
+        snapshot.reload()
+        if prev != snapshot.progress:
+            prev = snapshot.progress
+            print(snapshot.progress)
+
+def human_ts():
+    return datetime.datetime.now().strftime("%Y-%m-%dT%H:%M")

--- a/subprojects/sno-snapshot/src/rollback.py
+++ b/subprojects/sno-snapshot/src/rollback.py
@@ -1,0 +1,123 @@
+#! /usr/bin/env python
+
+import sys, time
+
+import common
+
+from ocp_resources.node import Node
+from ocp_resources.machine import Machine
+
+client_ec2 = common.client_ec2
+resource_ec2 = common.resource_ec2
+client_k8s = common.client_k8s
+
+def rollback(snapshot, cluster_name, instance, zone):
+    volume = common.get_instance_root_volume(instance)
+
+    ts = common.human_ts()
+
+    print(f"Old Volume Id: {volume.id}")
+
+    print("Triggering the rollback!")
+    resp = client_ec2.create_replace_root_volume_task(
+        InstanceId=instance.id,
+        SnapshotId=snapshot.id,
+        TagSpecifications=[
+            {
+                'ResourceType': 'volume',
+                'Tags': [
+                    {'Key': 'Name', 'Value': f'{cluster_name}-restored-at-{ts}'},
+                    {'Key': f'kubernetes.io/cluster/{cluster_name}', 'Value': 'owned'},
+                ]
+            },
+            {
+                'ResourceType': 'replace-root-volume-task',
+                'Tags': [
+                    {'Key': f'kubernetes.io/cluster/{cluster_name}', 'Value': 'owned'},
+                ]
+            },
+        ]
+    )
+
+    replace_id = resp["ReplaceRootVolumeTask"]["ReplaceRootVolumeTaskId"]
+    print(f"Replacement Id: {replace_id}")
+    state = resp["ReplaceRootVolumeTask"]["TaskState"]
+    prev = state
+    print(f"Waiting for the completion of the replacement ... (state={state})")
+    while state in ('pending', 'in-progress'):
+        time.sleep(10)
+
+        resp = client_ec2.describe_replace_root_volume_tasks(
+            ReplaceRootVolumeTaskIds=[replace_id]
+        )
+        state = resp["ReplaceRootVolumeTasks"][0]["TaskState"]
+        if prev != state:
+            print(state)
+            prev = state
+
+    if state != "succeeded":
+        print("Rollback failed ...")
+        return 1
+
+    print(f"Cluster rolled back to snapshot {snapshot.id}")
+
+    volume.delete()
+    print(f"Old volume {volume.id} deleted.")
+
+def has_ongoing_rollback(cluster_name, instance, zone):
+    first = True
+
+    resp = client_ec2.describe_replace_root_volume_tasks(
+        Filters=[{
+            'Name': f'tag:kubernetes.io/cluster/{cluster_name}',
+            'Values': ['owned']
+        }]
+    )
+
+    ongoing = False
+    for task in resp["ReplaceRootVolumeTasks"]:
+        state = task["TaskState"]
+        if state in ('pending', 'in-progress'):
+            ongoing = True
+            if first:
+                first = False
+                print("Found ongoing an task:")
+            print(task)
+
+    return ongoing
+
+def main():
+    machine_props = common.get_machine_props()
+    print()
+
+    if "--only-wait-openshift" in sys.argv:
+        common.wait_openshift()
+        return
+
+    snapshot = common.get_cluster_snapshot(*machine_props)
+
+    if snapshot is None:
+        print("ERROR: no snapshot to restore ...")
+        return 1
+
+    if snapshot.progress != "100%":
+        if "--wait-snapshot" not in sys.argv:
+            print("ERROR: cannot restore the snapshot before it completed.")
+            print(f"Pass '--wait-snapshot' to wait for its completion. ({snapshot.progress})")
+            return 1
+
+        common.await_snapshot(snapshot)
+
+
+    if has_ongoing_rollback(*machine_props):
+        print("ERROR: cannot trigger multiple rollbacks at the same time ...")
+        return 1
+
+    rollback(snapshot, *machine_props)
+
+    common.wait_openshift()
+
+    return
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/subprojects/sno-snapshot/src/snapshot.py
+++ b/subprojects/sno-snapshot/src/snapshot.py
@@ -1,0 +1,83 @@
+#! /usr/bin/env python
+
+import sys
+
+import common
+
+client_ec2 = common.client_ec2
+resource_ec2 = common.resource_ec2
+client_k8s = common.client_k8s
+
+def create_snapshot(cluster_name, instance, zone):
+    volume = common.get_instance_root_volume(instance)
+
+    print(f"Volume Id: {volume.id}")
+
+    ts = common.human_ts()
+
+    snapshot = volume.create_snapshot(
+        Description=f'Snapshot of cluster {cluster_name}.',
+        TagSpecifications=[{
+            'ResourceType': 'snapshot',
+            'Tags': [
+                {'Key': 'Name', 'Value': f'{cluster_name}-{ts}'},
+                {'Key': f'kubernetes.io/cluster/{cluster_name}', 'Value': 'owned'},
+            ]
+        }],)
+
+    print(f"Snapshot Id: {snapshot.id}")
+
+    resp = client_ec2.enable_fast_snapshot_restores(
+        AvailabilityZones=[zone,],
+        SourceSnapshotIds=[snapshot.id,],
+    )
+
+    if not "Successful" in resp.keys():
+        raise RuntimeError(f"aws.ec2.enable_fast_snapshot_restores failed ... {resp}")
+
+    print(f"Snapshot added to availability zone {zone}.")
+
+    return snapshot
+
+
+def main():
+    machine_props = common.get_machine_props()
+    print()
+
+    snapshot = common.get_cluster_snapshot(*machine_props)
+    created = False
+
+    if snapshot is None:
+        if "--delete" in sys.argv:
+            print("ERROR: no snapshot to delete ...")
+            return 1
+
+        snapshot = create_snapshot(*machine_props)
+        created = True
+
+    awaited = False
+    if "--wait" in sys.argv:
+        awaited = True
+        common.await_snapshot(snapshot)
+    elif created:
+        print("Not waiting for the snapshot creation. Pass '--wait' to wait for its completion.")
+
+    if created:
+        return
+
+    if "--delete" not in sys.argv:
+        if not awaited:
+            print(f"WARNING: a snapshot ({snapshot.id}) already exists.")
+            print("Pass '--delete' to delete it.")
+            if snapshot.progress != "100%":
+                print(f"Pass '--wait' to wait for its completion. ({snapshot.progress})")
+        return
+
+    print(f"Deleting the snapshot {snapshot.id} ...")
+    snapshot.delete()
+    print("Done.")
+
+    return 0
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
This WIP sub-project aims at providing a snapshot/rollback capability to a single-node OpenShift cluster running on AWS.

Snapshotting
------------

```
./snapshot.py

    Creates the snapshot of the current state of the SNO node, if no
    snapshot already exists.

./snapshot.py --wait

    Creates or awaits for the completion of the current AWS
    snapshot. This takes several minutes to complete, but 1/ the
    cluster is available during the snapshot creation and 2/ any
    changes performed after the snapshot creation time will not be
    included in the snapshot.

./snapshot.py --delete

    Deletes the AWS snapshot associated with this cluster, so that a
    new one can be created.
```

*Open questions*:

- Should the node be turned off before triggering the snapshot?

*Todo*:

- Include a human-readable timestamp in the snapshot name and printed in (instead of the snapshot ID)
- Delete all the OpenShift/Kubernetes objects backed by AWS objects (extra machines, routes, auto-scaling, ...)
  - These objects will be deleted during the cluster tear down anyway, but better avoid letting them dangling if we can.
   

Rolling Back
------------

```
./rollback.py

    Rolls back the cluster to the snapshot time.
    Fails if there is exising snapshot.
    Fails if the snapshot isn't completed yet.
    Waits for the completion of the AWS snapshot rollback and the
    reloading of RHCOS/OpenShift.

./rollback.py --wait-snapshot

   Wait for the completion of the AWS snapshot if it is not ready.

./rollback.py --only-wait-openshift

  Only wait for OpenShift to respond properly.
```