### PR TITLE
Add setup_golang() function to nto.sh

### DIFF
--- a/testing/prow/nto.sh
+++ b/testing/prow/nto.sh
@@ -7,6 +7,17 @@ set -o nounset
 THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 cd ${THIS_DIR}/../..
 
+setup_golang() {
+    local version=${1:-1.17.6}
+    local bin_dir=${HOME}/bin
+
+    mkdir -p $bin_dir
+    curl -sL -o $bin_dir/gimme https://raw.githubusercontent.com/travis-ci/gimme/master/gimme
+    chmod +x $bin_dir/gimme
+
+    eval $($bin_dir/gimme $version)
+}
+
 nto_e2e() {
     ./run_toolbox.py cluster capture_environment
     toolbox/nto/run_e2e_test.sh "$@"
@@ -24,6 +35,7 @@ set -x
 
 case ${action:-} in
     "e2e")
+        setup_golang
         nto_e2e "$@"
         exit 0
         ;;


### PR DESCRIPTION
Fetch a custom version of golang for NTO e2e tests.
