### PR TITLE
Automation for running NVIDIA MLPerf SSD training

### DIFF
--- a/roles/benchmarking_run_nvidiadl_ssd/defaults/main/config.yml
+++ b/roles/benchmarking_run_nvidiadl_ssd/defaults/main/config.yml
@@ -14,3 +14,7 @@ benchmarking_coco_dataset_pvc_name: "benchmarking-coco-dataset"
 
 # name of the config map where the benchmark entrypoint will be stored
 benchmarking_nvidiadl_ssd_entrypoint_cm_name: "benchmarking-nvidiadl-ssd-entrypoint"
+
+# benchmark default hyperparams
+benchmarking_epochs: ""
+benchmarking_threshold: ""

--- a/roles/benchmarking_run_nvidiadl_ssd/files/entrypoint.sh
+++ b/roles/benchmarking_run_nvidiadl_ssd/files/entrypoint.sh
@@ -26,4 +26,5 @@ exec python -u -m bind_launch --nsockets_per_node=1 --ncores_per_socket=4 --npro
               --threshold=0.25 \
               --data /storage \
               --batch-size=32 \
-              --warmup=1
+              --warmup=1 \
+              --local_rank=0

--- a/roles/benchmarking_run_nvidiadl_ssd/files/entrypoint.sh
+++ b/roles/benchmarking_run_nvidiadl_ssd/files/entrypoint.sh
@@ -2,7 +2,7 @@
 
 ls /storage
 
-exec python -u -m bind_launch --nproc_per_node=1 \
+exec python -u -m bind_launch --nsockets_per_node=1 --ncores_per_socket=4 --nproc_per_node=4 \
      train.py --epochs 80 \
               --warmup-factor 0 \
               --threshold=0.23 \

--- a/roles/benchmarking_run_nvidiadl_ssd/files/entrypoint.sh
+++ b/roles/benchmarking_run_nvidiadl_ssd/files/entrypoint.sh
@@ -1,5 +1,10 @@
 #! /bin/bash
 
+export DATASET_DIR=/storage
+export TORCH_HOME=/storage/torchvision
+'[' '!' -f /data/coco2017/annotations/bbox_only_instances_val2017.json ']'
+'[' '!' -f /data/coco2017/annotations/bbox_only_instances_train2017.json ']'
+
 ls /storage
 ls -alF /storage/annotations
 unset CUDA_VISIBLE_DEVICES

--- a/roles/benchmarking_run_nvidiadl_ssd/files/entrypoint.sh
+++ b/roles/benchmarking_run_nvidiadl_ssd/files/entrypoint.sh
@@ -3,7 +3,7 @@
 ls /storage
 
 exec python -u -m bind_launch --nsockets_per_node=1 --ncores_per_socket=4 --nproc_per_node=4 \
-     train.py --epochs 80 \
+     train.py --epochs 100 \
               --warmup-factor 0 \
               --threshold=0.23 \
               --data /storage \

--- a/roles/benchmarking_run_nvidiadl_ssd/files/entrypoint.sh
+++ b/roles/benchmarking_run_nvidiadl_ssd/files/entrypoint.sh
@@ -8,4 +8,4 @@ exec python -u -m bind_launch --nsockets_per_node=1 --ncores_per_socket=4 --npro
               --threshold=0.25 \
               --data /storage \
               --batch-size=32 \
-              --warmup=2
+              --warmup=1

--- a/roles/benchmarking_run_nvidiadl_ssd/files/entrypoint.sh
+++ b/roles/benchmarking_run_nvidiadl_ssd/files/entrypoint.sh
@@ -2,9 +2,10 @@
 
 ls /storage
 
-exec python -m torch.distributed.launch --nproc_per_node=1 \
-        main.py --batch-size 32 \
-          --mode benchmark-training \
-          --benchmark-warmup 100 \
-          --benchmark-iterations 100 \
-          --data /storage
+exec python -u -m bind_launch --nproc_per_node=1 \
+     train.py --epochs 80 \
+              --warmup-factor 0 \
+              --threshold=0.23 \
+              --data /storage \
+              --batch-size=32 \
+              --warmup=100

--- a/roles/benchmarking_run_nvidiadl_ssd/files/entrypoint.sh
+++ b/roles/benchmarking_run_nvidiadl_ssd/files/entrypoint.sh
@@ -1,9 +1,14 @@
 #! /bin/bash
 
-export DATASET_DIR=/storage
-export TORCH_HOME=/storage/torchvision
-'[' '!' -f /storage/annotations/bbox_only_instances_val2017.json ']'
-'[' '!' -f /storage/coco2017/annotations/bbox_only_instances_train2017.json ']'
+DATASET_DIR=/storage
+if [ ! -f ${DATASET_DIR}/annotations/bbox_only_instances_train2017.json ]; then
+    echo "Prepare instances_train2017.json ..."
+    ./prepare-json.py \
+        "${DATASET_DIR}/annotations/instances_train2017.json" \
+        "${DATASET_DIR}/annotations/bbox_only_instances_train2017.json"
+fi
+
+export TORCH_HOME=${DATASET_DIR}/torchvision
 
 ls /storage
 ls -alF /storage/annotations

--- a/roles/benchmarking_run_nvidiadl_ssd/files/entrypoint.sh
+++ b/roles/benchmarking_run_nvidiadl_ssd/files/entrypoint.sh
@@ -21,7 +21,7 @@ python -c "$PYCMD"
 
 export NCCL_DEBUG=INFO
 export CUDA_VISIBLE_DEVICES=0
-exec python -u -m bind_launch --nsockets_per_node=1 --ncores_per_socket=4 --nproc_per_node=4 \
+exec python -u -m bind_launch --nsockets_per_node=1 --ncores_per_socket=1 --nproc_per_node=1 \
      train.py --epochs 2 \
               --warmup-factor 0 \
               --threshold=0.25 \

--- a/roles/benchmarking_run_nvidiadl_ssd/files/entrypoint.sh
+++ b/roles/benchmarking_run_nvidiadl_ssd/files/entrypoint.sh
@@ -19,7 +19,8 @@ EOF
 
 python -c "$PYCMD"
 
-exec CUDA_VISIBLE_DEVICES=0 python -u -m bind_launch --nsockets_per_node=1 --ncores_per_socket=4 --nproc_per_node=4 \
+export CUDA_VISIBLE_DEVICES=0
+exec python -u -m bind_launch --nsockets_per_node=1 --ncores_per_socket=4 --nproc_per_node=4 \
      train.py --epochs 2 \
               --warmup-factor 0 \
               --threshold=0.25 \

--- a/roles/benchmarking_run_nvidiadl_ssd/files/entrypoint.sh
+++ b/roles/benchmarking_run_nvidiadl_ssd/files/entrypoint.sh
@@ -5,17 +5,8 @@ set -o errexit
 set -o nounset
 set -x
 
-if [ -z "$1" ]; then
-    EPOCHS=80
-else
-    EPOCHS=$1
-fi
-
-if [ -z "$2" ]; then
-    THRESHOLD=0.23
-else
-    THRESHOLD=$2
-fi
+EPOCHS=${1:-80}
+THRESHOLD=${2:-0.23}
 
 DATASET_DIR=/storage
 if [ ! -f ${DATASET_DIR}/annotations/bbox_only_instances_train2017.json ]; then

--- a/roles/benchmarking_run_nvidiadl_ssd/files/entrypoint.sh
+++ b/roles/benchmarking_run_nvidiadl_ssd/files/entrypoint.sh
@@ -2,8 +2,8 @@
 
 export DATASET_DIR=/storage
 export TORCH_HOME=/storage/torchvision
-'[' '!' -f /data/coco2017/annotations/bbox_only_instances_val2017.json ']'
-'[' '!' -f /data/coco2017/annotations/bbox_only_instances_train2017.json ']'
+'[' '!' -f /storage/annotations/bbox_only_instances_val2017.json ']'
+'[' '!' -f /storage/coco2017/annotations/bbox_only_instances_train2017.json ']'
 
 ls /storage
 ls -alF /storage/annotations

--- a/roles/benchmarking_run_nvidiadl_ssd/files/entrypoint.sh
+++ b/roles/benchmarking_run_nvidiadl_ssd/files/entrypoint.sh
@@ -5,8 +5,13 @@ set -o errexit
 set -o nounset
 set -x
 
-EPOCHS=${1:-80}
-THRESHOLD=${2:-0.23}
+# Chosen as it's tested to terminate within the alloted time
+SEED=95137217
+
+EPOCHS=${BENCHMARKING_EPOCHS:-80}
+echo "Using epochs=$EPOCHS"
+THRESHOLD=${BENCHMARKING_THRESHOLD:-0.23}
+echo "Using threshold=$THRESHOLD"
 
 DATASET_DIR=/storage
 if [ ! -f ${DATASET_DIR}/annotations/bbox_only_instances_train2017.json ]; then
@@ -55,4 +60,4 @@ exec python -u -m bind_launch --nsockets_per_node=1 --ncores_per_socket=1 --npro
               --batch-size=32 \
               --warmup=1 \
               --local_rank=0 \
-              --seed 95137217
+              --seed $SEED

--- a/roles/benchmarking_run_nvidiadl_ssd/files/entrypoint.sh
+++ b/roles/benchmarking_run_nvidiadl_ssd/files/entrypoint.sh
@@ -8,6 +8,13 @@ if [ ! -f ${DATASET_DIR}/annotations/bbox_only_instances_train2017.json ]; then
         "${DATASET_DIR}/annotations/bbox_only_instances_train2017.json"
 fi
 
+if [ ! -f ${DATASET_DIR}/annotations/bbox_only_instances_val2017.json ]; then
+    echo "Prepare instances_val2017.json ..."
+    ./prepare-json.py --keep-keys \
+        "${DATASET_DIR}/annotations/instances_val2017.json" \
+        "${DATASET_DIR}/annotations/bbox_only_instances_val2017.json"
+fi
+
 export TORCH_HOME=${DATASET_DIR}/torchvision
 
 ls /storage

--- a/roles/benchmarking_run_nvidiadl_ssd/files/entrypoint.sh
+++ b/roles/benchmarking_run_nvidiadl_ssd/files/entrypoint.sh
@@ -54,4 +54,5 @@ exec python -u -m bind_launch --nsockets_per_node=1 --ncores_per_socket=1 --npro
               --data /storage \
               --batch-size=32 \
               --warmup=1 \
-              --local_rank=0
+              --local_rank=0 \
+              --seed 95137217

--- a/roles/benchmarking_run_nvidiadl_ssd/files/entrypoint.sh
+++ b/roles/benchmarking_run_nvidiadl_ssd/files/entrypoint.sh
@@ -6,7 +6,7 @@ set -o nounset
 set -x
 
 # Chosen as it's tested to terminate within the alloted time
-SEED=95137217
+SEED=5652442
 
 EPOCHS=${BENCHMARKING_EPOCHS:-80}
 echo "Using epochs=$EPOCHS"
@@ -54,10 +54,14 @@ export NCCL_DEBUG=INFO
 export CUDA_VISIBLE_DEVICES=0
 exec python -u -m bind_launch --nsockets_per_node=1 --ncores_per_socket=1 --nproc_per_node=1 \
      train.py --epochs ${EPOCHS} \
-              --warmup-factor 0 \
               --threshold=${THRESHOLD} \
               --data /storage \
-              --batch-size=32 \
-              --warmup=1 \
+              --no-save \
+              --use-fp16 --nhwc \
+              --evaluation 1 2 3 6 12 40 70 \
+              --num-workers=1 \
+              --batch-size=16 \
               --local_rank=0 \
+              --warmup=1 \
+              --warmup-factor 1 \
               --seed $SEED

--- a/roles/benchmarking_run_nvidiadl_ssd/files/entrypoint.sh
+++ b/roles/benchmarking_run_nvidiadl_ssd/files/entrypoint.sh
@@ -1,6 +1,7 @@
 #! /bin/bash
 
 ls /storage
+ls -alF /storage/annotations
 unset CUDA_VISIBLE_DEVICES
 
 PYCMD=$(cat <<EOF

--- a/roles/benchmarking_run_nvidiadl_ssd/files/entrypoint.sh
+++ b/roles/benchmarking_run_nvidiadl_ssd/files/entrypoint.sh
@@ -1,6 +1,23 @@
 #! /bin/bash
 
 ls /storage
+unset CUDA_VISIBLE_DEVICES
+
+PYCMD=$(cat <<EOF
+import pycuda
+from pycuda import compiler
+import pycuda.driver as drv
+
+drv.init()
+print("%d device(s) found." % drv.Device.count())
+           
+for ordinal in range(drv.Device.count()):
+    dev = drv.Device(ordinal)
+    print (ordinal, dev.name())
+EOF
+)
+
+python -c "$PYCMD"
 
 exec python -u -m bind_launch --nsockets_per_node=1 --ncores_per_socket=4 --nproc_per_node=4 \
      train.py --epochs 2 \

--- a/roles/benchmarking_run_nvidiadl_ssd/files/entrypoint.sh
+++ b/roles/benchmarking_run_nvidiadl_ssd/files/entrypoint.sh
@@ -3,9 +3,9 @@
 ls /storage
 
 exec python -u -m bind_launch --nsockets_per_node=1 --ncores_per_socket=4 --nproc_per_node=4 \
-     train.py --epochs 100 \
+     train.py --epochs 2 \
               --warmup-factor 0 \
-              --threshold=0.23 \
+              --threshold=0.25 \
               --data /storage \
               --batch-size=32 \
-              --warmup=100
+              --warmup=2

--- a/roles/benchmarking_run_nvidiadl_ssd/files/entrypoint.sh
+++ b/roles/benchmarking_run_nvidiadl_ssd/files/entrypoint.sh
@@ -19,6 +19,7 @@ EOF
 
 python -c "$PYCMD"
 
+export NCCL_DEBUG=INFO
 export CUDA_VISIBLE_DEVICES=0
 exec python -u -m bind_launch --nsockets_per_node=1 --ncores_per_socket=4 --nproc_per_node=4 \
      train.py --epochs 2 \

--- a/roles/benchmarking_run_nvidiadl_ssd/files/entrypoint.sh
+++ b/roles/benchmarking_run_nvidiadl_ssd/files/entrypoint.sh
@@ -5,16 +5,16 @@ set -o errexit
 set -o nounset
 set -x
 
-if [ -z "$0" ]; then
+if [ -z "$1" ]; then
     EPOCHS=80
 else
-    EPOCHS=$0
+    EPOCHS=$1
 fi
 
-if [ -z "$1" ]; then
+if [ -z "$2" ]; then
     THRESHOLD=0.23
 else
-    THRESHOLD=$1
+    THRESHOLD=$2
 fi
 
 DATASET_DIR=/storage

--- a/roles/benchmarking_run_nvidiadl_ssd/files/entrypoint.sh
+++ b/roles/benchmarking_run_nvidiadl_ssd/files/entrypoint.sh
@@ -1,5 +1,22 @@
 #! /bin/bash
 
+set -o pipefail
+set -o errexit
+set -o nounset
+set -x
+
+if [ -z "$0" ]; then
+    EPOCHS=80
+else
+    EPOCHS=$0
+fi
+
+if [ -z "$1" ]; then
+    THRESHOLD=0.23
+else
+    THRESHOLD=$1
+fi
+
 DATASET_DIR=/storage
 if [ ! -f ${DATASET_DIR}/annotations/bbox_only_instances_train2017.json ]; then
     echo "Prepare instances_train2017.json ..."
@@ -40,9 +57,9 @@ python -c "$PYCMD"
 export NCCL_DEBUG=INFO
 export CUDA_VISIBLE_DEVICES=0
 exec python -u -m bind_launch --nsockets_per_node=1 --ncores_per_socket=1 --nproc_per_node=1 \
-     train.py --epochs 2 \
+     train.py --epochs ${EPOCHS} \
               --warmup-factor 0 \
-              --threshold=0.25 \
+              --threshold=${THRESHOLD} \
               --data /storage \
               --batch-size=32 \
               --warmup=1 \

--- a/roles/benchmarking_run_nvidiadl_ssd/files/entrypoint.sh
+++ b/roles/benchmarking_run_nvidiadl_ssd/files/entrypoint.sh
@@ -19,7 +19,7 @@ EOF
 
 python -c "$PYCMD"
 
-exec python -u -m bind_launch --nsockets_per_node=1 --ncores_per_socket=4 --nproc_per_node=4 \
+exec CUDA_VISIBLE_DEVICES=0 python -u -m bind_launch --nsockets_per_node=1 --ncores_per_socket=4 --nproc_per_node=4 \
      train.py --epochs 2 \
               --warmup-factor 0 \
               --threshold=0.25 \

--- a/roles/benchmarking_run_nvidiadl_ssd/tasks/main.yml
+++ b/roles/benchmarking_run_nvidiadl_ssd/tasks/main.yml
@@ -53,7 +53,7 @@
     -n {{ benchmarking_namespace }}
   register: wait_benchmark_pod_cmd
   until: "'Succeeded' in wait_benchmark_pod_cmd.stdout or 'Failed' in wait_benchmark_pod_cmd.stdout or 'Error' in wait_benchmark_pod_cmd.stdout"
-  retries: 40
+  retries: 100
   delay: 60
 
 - name: Store the logs of benchmark execution (for post-processing)

--- a/roles/benchmarking_run_nvidiadl_ssd/tasks/main.yml
+++ b/roles/benchmarking_run_nvidiadl_ssd/tasks/main.yml
@@ -45,7 +45,7 @@
   command:
     oc create -f "{{ artifact_extra_logs_dir }}/001_pod_run-nvidiadl-ssd.yml"
 
--block: 
+- block: 
   - name: Wait for the benchmark completion
     command:
       oc get pod/{{ benchmarking_nvidiadl_ssd_name }}

--- a/roles/benchmarking_run_nvidiadl_ssd/tasks/main.yml
+++ b/roles/benchmarking_run_nvidiadl_ssd/tasks/main.yml
@@ -45,33 +45,37 @@
   command:
     oc create -f "{{ artifact_extra_logs_dir }}/001_pod_run-nvidiadl-ssd.yml"
 
-- name: Wait for the benchmark completion
-  command:
-    oc get pod/{{ benchmarking_nvidiadl_ssd_name }}
-    --no-headers
-    -ocustom-columns=phase:status.phase
-    -n {{ benchmarking_namespace }}
-  register: wait_benchmark_pod_cmd
-  until: "'Succeeded' in wait_benchmark_pod_cmd.stdout or 'Failed' in wait_benchmark_pod_cmd.stdout or 'Error' in wait_benchmark_pod_cmd.stdout"
-  retries: 60
-  delay: 60
+-block: 
+  - name: Wait for the benchmark completion
+    command:
+      oc get pod/{{ benchmarking_nvidiadl_ssd_name }}
+      --no-headers
+      -ocustom-columns=phase:status.phase
+      -n {{ benchmarking_namespace }}
+    register: wait_benchmark_pod_cmd
+    until: "'Succeeded' in wait_benchmark_pod_cmd.stdout or 'Failed' in wait_benchmark_pod_cmd.stdout or 'Error' in wait_benchmark_pod_cmd.stdout"
+    retries: 60
+    delay: 60
 
-- name: Store the logs of benchmark execution (for post-processing)
-  shell:
-    oc logs pod/{{ benchmarking_nvidiadl_ssd_name }} -n {{ benchmarking_namespace }}
-       > "{{ artifact_extra_logs_dir }}/pod_run-nvidiadl-ssd.log"
-  failed_when: false
+  - name: Fail if the pod execution failed
+    when: "'Failed' in wait_benchmark_pod_cmd.stdout or 'Error' in wait_benchmark_pod_cmd.stdout"
+    fail: msg="The benchmark execution failed"
 
-- name: Store the status of the benchmark execution (for post-processing)
-  shell:
-    echo "{{ wait_benchmark_pod_cmd.stdout }}" > "{{ artifact_extra_logs_dir }}/pod_run-nvidiadl-ssd.status"
+  always:
+  - name: Store the logs of benchmark execution (for post-processing)
+    shell:
+      oc logs pod/{{ benchmarking_nvidiadl_ssd_name }} -n {{ benchmarking_namespace }}
+        > "{{ artifact_extra_logs_dir }}/pod_run-nvidiadl-ssd.log"
+    failed_when: false
 
-- name: Store the description of benchmark execution (debug)
-  shell:
-    oc describe pod/{{ benchmarking_nvidiadl_ssd_name }} -n {{ benchmarking_namespace }}
-       > "{{ artifact_extra_logs_dir }}/pod_run-nvidiadl-ssd.descr"
-  failed_when: false
+  always:
+  - name: Store the status of the benchmark execution (for post-processing)
+    shell:
+      echo "{{ wait_benchmark_pod_cmd.stdout }}" > "{{ artifact_extra_logs_dir }}/pod_run-nvidiadl-ssd.status"
 
-- name: Fail if the pod execution failed
-  when: "'Failed' in wait_benchmark_pod_cmd.stdout or 'Error' in wait_benchmark_pod_cmd.stdout"
-  fail: msg="The benchmark execution failed"
+  always:
+  - name: Store the description of benchmark execution (debug)
+    shell:
+      oc describe pod/{{ benchmarking_nvidiadl_ssd_name }} -n {{ benchmarking_namespace }}
+        > "{{ artifact_extra_logs_dir }}/pod_run-nvidiadl-ssd.descr"
+    failed_when: false

--- a/roles/benchmarking_run_nvidiadl_ssd/tasks/main.yml
+++ b/roles/benchmarking_run_nvidiadl_ssd/tasks/main.yml
@@ -68,12 +68,10 @@
         > "{{ artifact_extra_logs_dir }}/pod_run-nvidiadl-ssd.log"
     failed_when: false
 
-  always:
   - name: Store the status of the benchmark execution (for post-processing)
     shell:
       echo "{{ wait_benchmark_pod_cmd.stdout }}" > "{{ artifact_extra_logs_dir }}/pod_run-nvidiadl-ssd.status"
 
-  always:
   - name: Store the description of benchmark execution (debug)
     shell:
       oc describe pod/{{ benchmarking_nvidiadl_ssd_name }} -n {{ benchmarking_namespace }}

--- a/roles/benchmarking_run_nvidiadl_ssd/tasks/main.yml
+++ b/roles/benchmarking_run_nvidiadl_ssd/tasks/main.yml
@@ -53,7 +53,7 @@
     -n {{ benchmarking_namespace }}
   register: wait_benchmark_pod_cmd
   until: "'Succeeded' in wait_benchmark_pod_cmd.stdout or 'Failed' in wait_benchmark_pod_cmd.stdout or 'Error' in wait_benchmark_pod_cmd.stdout"
-  retries: 100
+  retries: 60
   delay: 60
 
 - name: Store the logs of benchmark execution (for post-processing)

--- a/roles/benchmarking_run_nvidiadl_ssd/templates/nvidiadl-ssd-pod.yml.j2
+++ b/roles/benchmarking_run_nvidiadl_ssd/templates/nvidiadl-ssd-pod.yml.j2
@@ -24,7 +24,13 @@ spec:
     command:
     - bash
     - -c
-    - "/mnt/entrypoint/entrypoint.sh {{ benchmarking_epochs }} {{ benchmarking_threshold }}"
+    - "/mnt/entrypoint/entrypoint.sh"
+    env:
+    - name: BENCHMARKING_EPOCHS
+      value: "{{ benchmarking_epochs }}"
+    env:
+    - name: BENCHMARKING_THRESHOLD
+      value: "{{ benchmarking_threshold }}"
   volumes:
   - name: entrypoint-volume
     configMap:

--- a/roles/benchmarking_run_nvidiadl_ssd/templates/nvidiadl-ssd-pod.yml.j2
+++ b/roles/benchmarking_run_nvidiadl_ssd/templates/nvidiadl-ssd-pod.yml.j2
@@ -25,8 +25,7 @@ spec:
     - bash
     - -c
     - "/mnt/entrypoint/entrypoint.sh"
-    - {{ benchmarking_epochs }}
-    - {{ benchmarking_threshold }}
+    args:["{{ benchmarking_epochs }}", "{{ benchmarking_threshold }}"]
   volumes:
   - name: entrypoint-volume
     configMap:

--- a/roles/benchmarking_run_nvidiadl_ssd/templates/nvidiadl-ssd-pod.yml.j2
+++ b/roles/benchmarking_run_nvidiadl_ssd/templates/nvidiadl-ssd-pod.yml.j2
@@ -24,10 +24,7 @@ spec:
     command:
     - bash
     - -c
-    - "/mnt/entrypoint/entrypoint.sh"
-    args:
-    - {{ benchmarking_epochs }}
-    - {{ benchmarking_threshold }}
+    - "/mnt/entrypoint/entrypoint.sh {{ benchmarking_epochs }} {{ benchmarking_threshold }}"
   volumes:
   - name: entrypoint-volume
     configMap:

--- a/roles/benchmarking_run_nvidiadl_ssd/templates/nvidiadl-ssd-pod.yml.j2
+++ b/roles/benchmarking_run_nvidiadl_ssd/templates/nvidiadl-ssd-pod.yml.j2
@@ -15,7 +15,7 @@ spec:
       limits:
         nvidia.com/gpu: 1
       requests:
-        memory: 8Gi
+        memory: 6Gi
     volumeMounts:
     - name: entrypoint-volume
       mountPath: /mnt/entrypoint/entrypoint.sh

--- a/roles/benchmarking_run_nvidiadl_ssd/templates/nvidiadl-ssd-pod.yml.j2
+++ b/roles/benchmarking_run_nvidiadl_ssd/templates/nvidiadl-ssd-pod.yml.j2
@@ -25,7 +25,9 @@ spec:
     - bash
     - -c
     - "/mnt/entrypoint/entrypoint.sh"
-    args:["{{ benchmarking_epochs }}", "{{ benchmarking_threshold }}"]
+    args:
+    - {{ benchmarking_epochs }}
+    - {{ benchmarking_threshold }}
   volumes:
   - name: entrypoint-volume
     configMap:

--- a/roles/benchmarking_run_nvidiadl_ssd/templates/nvidiadl-ssd-pod.yml.j2
+++ b/roles/benchmarking_run_nvidiadl_ssd/templates/nvidiadl-ssd-pod.yml.j2
@@ -15,7 +15,7 @@ spec:
       limits:
         nvidia.com/gpu: 1
       requests:
-        memory: 12Gi
+        memory: 8Gi
     volumeMounts:
     - name: entrypoint-volume
       mountPath: /mnt/entrypoint/entrypoint.sh

--- a/roles/benchmarking_run_nvidiadl_ssd/templates/nvidiadl-ssd-pod.yml.j2
+++ b/roles/benchmarking_run_nvidiadl_ssd/templates/nvidiadl-ssd-pod.yml.j2
@@ -14,8 +14,6 @@ spec:
     resources:
       limits:
         nvidia.com/gpu: 1
-      requests:
-        memory: 6Gi
     volumeMounts:
     - name: entrypoint-volume
       mountPath: /mnt/entrypoint/entrypoint.sh

--- a/roles/benchmarking_run_nvidiadl_ssd/templates/nvidiadl-ssd-pod.yml.j2
+++ b/roles/benchmarking_run_nvidiadl_ssd/templates/nvidiadl-ssd-pod.yml.j2
@@ -14,6 +14,8 @@ spec:
     resources:
       limits:
         nvidia.com/gpu: 1
+      requests:
+        memory: 12Gi
     volumeMounts:
     - name: entrypoint-volume
       mountPath: /mnt/entrypoint/entrypoint.sh
@@ -21,6 +23,8 @@ spec:
       subPath: entrypoint.sh
     - mountPath: /storage/
       name: storage-volume
+    - mountPath: /dev/shm
+      name: dshm
     command:
     - bash
     - -c
@@ -38,3 +42,6 @@ spec:
   - name: storage-volume
     persistentVolumeClaim:
       claimName: {{ benchmarking_coco_dataset_pvc_name }}
+  - name: dshm
+    emptyDir:
+      medium: Memory

--- a/roles/benchmarking_run_nvidiadl_ssd/templates/nvidiadl-ssd-pod.yml.j2
+++ b/roles/benchmarking_run_nvidiadl_ssd/templates/nvidiadl-ssd-pod.yml.j2
@@ -28,7 +28,6 @@ spec:
     env:
     - name: BENCHMARKING_EPOCHS
       value: "{{ benchmarking_epochs }}"
-    env:
     - name: BENCHMARKING_THRESHOLD
       value: "{{ benchmarking_threshold }}"
   volumes:

--- a/roles/benchmarking_run_nvidiadl_ssd/templates/nvidiadl-ssd-pod.yml.j2
+++ b/roles/benchmarking_run_nvidiadl_ssd/templates/nvidiadl-ssd-pod.yml.j2
@@ -10,7 +10,7 @@ spec:
     kubernetes.io/hostname: {{ benchmarking_node_hostname }}
   containers:
   - name: nvidiadl
-    image: quay.io/openshift-psap/nvidiadl-ssd-training-benchmark
+    image: quay.io/openshift-psap/ci-artifacts:nvidiadl-ssd-training-benchmark
     resources:
       limits:
         nvidia.com/gpu: 1

--- a/roles/benchmarking_run_nvidiadl_ssd/templates/nvidiadl-ssd-pod.yml.j2
+++ b/roles/benchmarking_run_nvidiadl_ssd/templates/nvidiadl-ssd-pod.yml.j2
@@ -25,6 +25,8 @@ spec:
     - bash
     - -c
     - "/mnt/entrypoint/entrypoint.sh"
+    - {{ benchmarking_epochs }}
+    - {{ benchmarking_threshold }}
   volumes:
   - name: entrypoint-volume
     configMap:

--- a/testing/recipes/run_cocodataset_nvidiadl_ssd.sh
+++ b/testing/recipes/run_cocodataset_nvidiadl_ssd.sh
@@ -16,7 +16,6 @@ source $THIS_DIR/../prow/gpu-operator.sh source
 
 # WDM_DEPENDENCY_FILE exported in ^^^^
 ./toolbox/wdm ensure has_gpu_operator
-./run_toolbox.py gpu_operator wait_deployment
 
 gpu_node_hostname=$(oc get nodes -oname -lfeature.node.kubernetes.io/pci-10de.present -ojsonpath={.items[].metadata.labels} | jq -r '.["kubernetes.io/hostname"]')
 

--- a/testing/recipes/run_cocodataset_nvidiadl_ssd.sh
+++ b/testing/recipes/run_cocodataset_nvidiadl_ssd.sh
@@ -6,6 +6,7 @@ set -o errexit
 set -o nounset
 
 EPOCHS=3
+THRESHOLD=0.20
 
 THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
@@ -49,5 +50,5 @@ if [[ "$@" == *benchmark_twice* ]]; then
 fi
 
 for i in $(seq $RUN_CNT); do
-    ./run_toolbox.py benchmarking run_nvidiadl_ssd "$gpu_node_hostname" --epochs=$EPOCHS
+    ./run_toolbox.py benchmarking run_nvidiadl_ssd "$gpu_node_hostname" --epochs=$EPOCHS --threshold=$THRESHOLD
 done

--- a/testing/recipes/run_cocodataset_nvidiadl_ssd.sh
+++ b/testing/recipes/run_cocodataset_nvidiadl_ssd.sh
@@ -5,8 +5,8 @@ set -o pipefail
 set -o errexit
 set -o nounset
 
-EPOCHS=3
-THRESHOLD=0.20
+EPOCHS=4
+THRESHOLD=0.07
 
 THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 

--- a/testing/recipes/run_cocodataset_nvidiadl_ssd.sh
+++ b/testing/recipes/run_cocodataset_nvidiadl_ssd.sh
@@ -5,6 +5,8 @@ set -o pipefail
 set -o errexit
 set -o nounset
 
+EPOCHS=3
+
 THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 PSAP_SECRET_PATH=/var/run/psap-entitlement-secret
@@ -47,5 +49,5 @@ if [[ "$@" == *benchmark_twice* ]]; then
 fi
 
 for i in $(seq $RUN_CNT); do
-    ./run_toolbox.py benchmarking run_nvidiadl_ssd "$gpu_node_hostname"
+    ./run_toolbox.py benchmarking run_nvidiadl_ssd "$gpu_node_hostname" --epochs=$EPOCHS
 done

--- a/testing/recipes/run_cocodataset_nvidiadl_ssd.sh
+++ b/testing/recipes/run_cocodataset_nvidiadl_ssd.sh
@@ -5,8 +5,8 @@ set -o pipefail
 set -o errexit
 set -o nounset
 
-EPOCHS=4
-THRESHOLD=0.07
+EPOCHS=3
+THRESHOLD=0.05
 
 THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 

--- a/testing/recipes/run_cocodataset_nvidiadl_ssd.sh
+++ b/testing/recipes/run_cocodataset_nvidiadl_ssd.sh
@@ -16,6 +16,7 @@ source $THIS_DIR/../prow/gpu-operator.sh source
 
 # WDM_DEPENDENCY_FILE exported in ^^^^
 ./toolbox/wdm ensure has_gpu_operator
+./run_toolbox.py gpu_operator wait_deployment
 
 gpu_node_hostname=$(oc get nodes -oname -lfeature.node.kubernetes.io/pci-10de.present -ojsonpath={.items[].metadata.labels} | jq -r '.["kubernetes.io/hostname"]')
 

--- a/testing/wdm/gpu-operator.yml
+++ b/testing/wdm/gpu-operator.yml
@@ -4,14 +4,14 @@ spec:
   - has_nfd
   - has_gpu_nodes
   tests:
-  - name: has_gpu_operatpr
+  - name: has_gpu_operator
     type: shell
-    spec: oc get pod -l app.kubernetes.io/component=gpu-operator -A -oname
+    spec: oc get pod -l app.kubernetes.io/component=gpu-operator -A -oname | grep .
   install:
   - name: install_gpu_operator
     type: shell
     spec: ./run_toolbox.py gpu_operator deploy_from_operatorhub
-  - name: install_gpu_operator
+  - name: wait_gpu_deployment
     type: shell
     spec: ./run_toolbox.py gpu_operator wait_deployment
 ---

--- a/toolbox/benchmarking.py
+++ b/toolbox/benchmarking.py
@@ -43,7 +43,7 @@ class Benchmarking:
         return PlaybookRun("benchmarking_deploy_coco_dataset", opts)
 
     @staticmethod
-    def run_nvidiadl_ssd(node_hostname, namespace="default", pvc_name=None):
+    def run_nvidiadl_ssd(node_hostname, namespace="default", pvc_name=None, epochs=None, threshold=None):
         """
         Run NVIDIA Deep Learning SSD Detection training benchmark.
 
@@ -51,15 +51,34 @@ class Benchmarking:
             node_hostname: Hostname of the node where the ssd benchmark will be executed.
             namespace: Name of the namespace in which the resources will be created.
             pvc_name: Name of the PVC that will be create to store the dataset files.
+            epochs: Number of epochs to run the benchmark for.
+            threshold: Benchmark threshold target value.
         """
 
         opts = {
             "benchmarking_node_hostname": node_hostname,
             "benchmarking_namespace": namespace,
         }
+
         if pvc_name is not None:
             opts["benchmarking_coco_dataset_pvc_name"] = pvc_name
             print(
                 f"Using '{pvc_name}' as PVC where the coco dataset is stored."
             )
+
+        if epochs:
+            try:
+                epochs = str(int(epochs))
+                opts["benchmarking_epochs"] = epochs
+            except ValueError:
+                print("ERROR: epochs must be of type int")
+                exit(1)
+        if threshold:
+            try:
+                threshold = str(float(threshold))
+                opts["benchmarking_threshold"] = threshold
+            except ValueError:
+                print("ERROR: threshold must be of type float")
+                exit(1)
+
         return PlaybookRun("benchmarking_run_nvidiadl_ssd", opts)


### PR DESCRIPTION
Get nvidiadl ssd training benchmark working with new auto-updated image

NOTE: `test-path: recipes run_cocodataset_nvidiadl_ssd`