### PR TITLE
[deploy-cluster] Deploy entitlement on master and workers on SNO

### DIFF
--- a/subprojects/deploy-cluster/cluster_sno.mk
+++ b/subprojects/deploy-cluster/cluster_sno.mk
@@ -5,6 +5,7 @@ cluster_sno:
 	@make config_sno
 	@make manifest
 	@make manifest_entitle
+	@make manifest_entitle_master
 	@make install
 	@make kubeconfig
 

--- a/subprojects/deploy-cluster/entitlement.mk
+++ b/subprojects/deploy-cluster/entitlement.mk
@@ -15,10 +15,24 @@ _manifest_entitle:
 	@cat "${ENTITLEMENT_TEMPLATE}" \
 	  | sed "s/BASE64_ENCODED_PEM_FILE/$(shell base64 -w 0 ${ENTITLEMENT_PEM})/g" \
 	  | sed "s/BASE64_ENCODED_RHSM_FILE/$(shell base64 -w 0 ${ENTITLEMENT_RHSM})/g" \
-	  > "${ENTITLEMENT_DST_BASENAME}.yaml"
-	@# Split "${ENTITLEMENT_DST_BASENAME}.yaml" into multiple files containing a single YAML object
+	  > "${ENTITLEMENT_DST_BASENAME}_worker.yaml"
+	@# Split "${ENTITLEMENT_DST_BASENAME}_worker.yaml" into multiple files containing a single YAML object
 	@# openshift-install doesn't allow files with multiple objects
-	@awk '{ print > "${ENTITLEMENT_DST_BASENAME}_"++i".yaml" }' RS='---\n' "${ENTITLEMENT_DST_BASENAME}.yaml"
-	@rm "${ENTITLEMENT_DST_BASENAME}.yaml"
+	@awk '{ print > "${ENTITLEMENT_DST_BASENAME}_worker_"++i".yaml" }' RS='---\n' "${ENTITLEMENT_DST_BASENAME}_worker.yaml"
+	@rm "${ENTITLEMENT_DST_BASENAME}_worker.yaml"
 	@echo "Entitlement MachineConfig generated:"
 	@ls "${ENTITLEMENT_DST_BASENAME}"_*
+
+manifest_entitle_master:
+	@cat "${ENTITLEMENT_TEMPLATE}" \
+	  | sed "s/BASE64_ENCODED_PEM_FILE/$(shell base64 -w 0 ${ENTITLEMENT_PEM})/g" \
+	  | sed "s/BASE64_ENCODED_RHSM_FILE/$(shell base64 -w 0 ${ENTITLEMENT_RHSM})/g" \
+	  | sed "s|machineconfiguration.openshift.io/role: worker|machineconfiguration.openshift.io/role: master|" \
+	  | sed "s/name: 50-/name: 50-master-/" \
+	  > "${ENTITLEMENT_DST_BASENAME}_master.yaml"
+	@# Split "${ENTITLEMENT_DST_BASENAME}.yaml" into multiple files containing a single YAML object
+	@# openshift-install doesn't allow files with multiple objects
+	@awk '{ print > "${ENTITLEMENT_DST_BASENAME}_master_"++i".yaml" }' RS='---\n' "${ENTITLEMENT_DST_BASENAME}_master.yaml"
+	@rm "${ENTITLEMENT_DST_BASENAME}_master.yaml"
+	@echo "Entitlement MachineConfig generated:"
+	@ls "${ENTITLEMENT_DST_BASENAME}_master"_*

--- a/subprojects/deploy-cluster/utils/entitlement/cluster-wide.entitlement.machineconfigs.yaml.template
+++ b/subprojects/deploy-cluster/utils/entitlement/cluster-wide.entitlement.machineconfigs.yaml.template
@@ -7,7 +7,7 @@ metadata:
 spec:
   config:
     ignition:
-      version: 2.2.0
+      version: 3.2.0
     storage:
       files:
       - contents:
@@ -25,7 +25,7 @@ metadata:
 spec:
   config:
     ignition:
-      version: 2.2.0
+      version: 3.2.0
     storage:
       files:
       - contents:
@@ -43,7 +43,7 @@ metadata:
 spec:
   config:
     ignition:
-      version: 2.2.0
+      version: 3.2.0
     storage:
       files:
       - contents:


### PR DESCRIPTION
SNO clusters have a `master,worker` node, which requires a `role:
master` to receive MachineConfigs.

If we scale up the cluster with new nodes, they'll only have the `worker` role, so we need both `master` and `worker` objects to cover them all.