### PR TITLE
Multiple bug fixes

### DIFF
--- a/callback_plugins/human_log.py
+++ b/callback_plugins/human_log.py
@@ -78,7 +78,7 @@ class CallbackModule(default_CallbackModule):
         self.__print_std_lines(result, "stderr", color)
 
     def __print_std_lines(self, result, std_name, color):
-        if not result._result[f'{std_name}_lines']:
+        if not result._result.get(f'{std_name}_lines'):
             return
 
         for line in result._result[f'{std_name}_lines']:

--- a/roles/cluster_deploy_operator/tasks/main.yml
+++ b/roles/cluster_deploy_operator/tasks/main.yml
@@ -260,7 +260,7 @@
          -ojsonpath={.status.phase}
          -n "{{ cluster_deploy_operator_namespace }}"
     register: operator_csv_phase
-    until: operator_csv_phase.stdout != "Pending" and operator_csv_phase.stdout != "InstallReady" and operator_csv_phase.stdout != "Installing"
+    until: operator_csv_phase.stdout and operator_csv_phase.stdout != "Pending" and operator_csv_phase.stdout != "InstallReady" and operator_csv_phase.stdout != "Installing"
     retries: 40
     delay: 30
 

--- a/roles/entitlement_deploy/tasks/main.yml
+++ b/roles/entitlement_deploy/tasks/main.yml
@@ -15,7 +15,7 @@
   command: md5sum '{{ entitlement_rhsm }}' '{{ entitlement_pem }}'
 
 - name: Get cluster control plane topology
-  command: oc get scheduler -ojsonpath="{.items[0].spec.mastersSchedulable}\n"
+  command: oc get scheduler -ojsonpath="{.items[0].spec.mastersSchedulable}"
   register: masters_are_also_workers
 
 - name: Set master as machine config target role in single node clusters
@@ -24,7 +24,7 @@
       machine_config_role: master
 
 - name: Set worker as machine config target role in non-single-node clusters
-  when: not masters_are_also_workers.stdout == "false"
+  when: masters_are_also_workers.stdout == "false"
   set_fact:
       machine_config_role: worker
 


### PR DESCRIPTION
Already merged in https://github.com/rh-ecosystem-edge/ci-artifacts/pull/10

---
* `cluster_deploy_operator: fix 'Wait for the ClusterServiceVersion install to complete'`

If the `.status.phase` of the CSV is empty (eg, right after its
creation), we should wait further, and not exit (and fail)
immediately.

This bug will be fixed:
```
2022-01-25 23:52:02,687 p=5430 u=edge-ci-runner n=ansible | roles/cluster_deploy_operator/tasks/main.yml:257
2022-01-25 23:52:02,687 p=5430 u=edge-ci-runner n=ansible | TASK: cluster_deploy_operator : Wait for the ClusterServiceVersion install to complete
2022-01-25 23:52:02,687 p=5430 u=edge-ci-runner n=ansible |
2022-01-25 23:52:02,687 p=5430 u=edge-ci-runner n=ansible | <command> oc get ClusterServiceVersion/gpu-operator-certified.v1.9.0 -ojsonpath={.status.phase} -n nvidia-gpu-operator
2022-01-25 23:52:02,687 p=5430 u=edge-ci-runner n=ansible |
2022-01-25 23:52:02,696 p=5430 u=edge-ci-runner n=ansible |
2022-01-25 23:52:02,696 p=5430 u=edge-ci-runner n=ansible | Tuesday 25 January 2022  23:52:02 +0000 (0:00:00.366)       0:00:40.096 *******
2022-01-25 23:52:02,715 p=5430 u=edge-ci-runner n=ansible | ---
2022-01-25 23:52:02,715 p=5430 u=edge-ci-runner n=ansible |
2022-01-25 23:52:02,715 p=5430 u=edge-ci-runner n=ansible |
2022-01-25 23:52:02,715 p=5430 u=edge-ci-runner n=ansible | ---
2022-01-25 23:52:02,715 p=5430 u=edge-ci-runner n=ansible | roles/cluster_deploy_operator/tasks/main.yml:267
2022-01-25 23:52:02,715 p=5430 u=edge-ci-runner n=ansible | TASK: cluster_deploy_operator : Fail if the ClusterServiceVersion install did not succeeded
2022-01-25 23:52:02,715 p=5430 u=edge-ci-runner n=ansible | ----- FAILED ----
2022-01-25 23:52:02,715 p=5430 u=edge-ci-runner n=ansible | msg: ClusterServiceVersion install not successful ()
2022-01-25 23:52:02,715 p=5430 u=edge-ci-runner n=ansible | ----- FAILED ----
```

---

* `callback_plugins/human_log.py: fix WARNING when there is no 'stdout_lines' in the result`


---

* `entitlement_deploy: fix bug when deploying with schedulable masters`


---