### PR TITLE
Fix ansible-linter warnings

### DIFF
--- a/roles/cluster_deploy_operator/tasks/main.yml
+++ b/roles/cluster_deploy_operator/tasks/main.yml
@@ -171,13 +171,13 @@
 
 - name: Store the CSV version
   set_fact:
-    startingCSV: "{{ operator_csv_name }}"
+    starting_csv: "{{ operator_csv_name }}"
 
 - name: Store the version of the Operator that will be installed
-  shell: echo "{{ startingCSV }}" > "{{ artifact_extra_logs_dir }}/operator_csv_name.txt"
+  shell: echo "{{ starting_csv }}" > "{{ artifact_extra_logs_dir }}/operator_csv_name.txt"
 
 - name: "Create the Subscription"
-  debug: msg="startingCSV is {{ startingCSV }}"
+  debug: msg="starting_csv is {{ starting_csv }}"
 
 - name: Create the namespace, if it did not exist
   when: not cluster_deploy_operator_all_namespaces | bool

--- a/roles/cluster_deploy_operator/templates/subscription.yml.j2
+++ b/roles/cluster_deploy_operator/templates/subscription.yml.j2
@@ -10,4 +10,4 @@ spec:
   name: "{{ cluster_deploy_operator_manifest_name }}"
   source: "{{ cluster_deploy_operator_catalog }}"
   sourceNamespace: openshift-marketplace
-  startingCSV: "{{ startingCSV }}"
+  startingCSV: "{{ starting_csv }}"

--- a/roles/gpu_operator_deploy_from_operatorhub/tasks/deploy_from_catalog.yml
+++ b/roles/gpu_operator_deploy_from_operatorhub/tasks/deploy_from_catalog.yml
@@ -87,7 +87,7 @@
 
 - name: Store the CSV version
   set_fact:
-    startingCSV: "{{ gpu_operator_csv_name }}"
+    starting_csv: "{{ gpu_operator_csv_name }}"
 
 - name: Prepare the GPU Operator namespace (only when deploying outside of openshift-operators namespace)
   when: deploy_bundle_namespace != "openshift-operators"

--- a/roles/gpu_operator_deploy_from_operatorhub/templates/020_operator_sub.yml.j2
+++ b/roles/gpu_operator_deploy_from_operatorhub/templates/020_operator_sub.yml.j2
@@ -9,4 +9,4 @@ spec:
   name: gpu-operator-certified
   source: certified-operators
   sourceNamespace: openshift-marketplace
-  startingCSV: "{{ startingCSV }}"
+  startingCSV: "{{ starting_csv }}"

--- a/roles/gpu_operator_wait_deployment/tasks/main.yml
+++ b/roles/gpu_operator_wait_deployment/tasks/main.yml
@@ -56,10 +56,10 @@
          -n {{ gpu_operator_namespace }}
          -oyaml
          -ojsonpath={.status.numberUnavailable}
-    register: operator_validator_numberUnavailable
+    register: operator_validator_number_unavailable
     until:
-    - operator_validator_numberUnavailable.rc == 0
-    - not operator_validator_numberUnavailable.stdout
+    - operator_validator_number_unavailable.rc == 0
+    - not operator_validator_number_unavailable.stdout
     retries: 15
     delay: 60
 


### PR DESCRIPTION
This PR fixes the few ansible-lint warning that were introduced while the linter Action was down.

They all relate to this [rule](https://ansible-lint.readthedocs.io/en/latest/default_rules.html#var-naming):

```
var-naming

All variables should be named using only lowercase and underscores
```