### PR TITLE
_common.py: switch back to subprocess

### DIFF
--- a/toolbox/_common.py
+++ b/toolbox/_common.py
@@ -107,6 +107,6 @@ def run_ansible_playbook(playbook_name, opts: dict = dict()):
         for k, v in os.environ.items():
             print(f"{k}={v}", file=f)
 
-    os.execvpe(cmd[0], cmd, os.environ)
+    run_result = subprocess.run(cmd, env=os.environ.copy(), check=False)
 
-    raise RuntimeError("os.execvpe shouldn't return ...")
+    raise SystemExit(run_result.returncode)


### PR DESCRIPTION
subprocess makes reusing the Toolbox easier.

Signed-off-by: François Cami <fcami@redhat.com>