### PR TITLE
testing: run: fix cluster_destroyed flake handling

### DIFF
--- a/testing/run
+++ b/testing/run
@@ -94,11 +94,11 @@ postchecks() {
     shift
 
     if [[ "$reason" == ERR ]]; then
-        touch $ARTIFACT_DIR/FAILURE
+        touch "$ARTIFACT_DIR/FAILURE"
 
         if ! oc version >/dev/null 2>&1; then
-            mkdir -p $ARTIFACT_DIR/FLAKE
-            echo "Cluster unreachable" >> $ARTIFACT_DIR/FLAKE
+            mkdir -p "$ARTIFACT_DIR/FLAKE"
+            echo "Cluster unreachable" >> "$ARTIFACT_DIR/FLAKE/cluster_destroyed"
         fi
     elif [[ "$reason" == EXIT ]]; then
         echo ""


### PR DESCRIPTION
fixing this:
```
 The connection to the server api.ci-ocp-4-10-amd64-aws-us-east-1-tlbhj.hive.aws.ci.openshift.org:6443 was refused - did you specify the right host or port?
----
   |Running 'has_nfd_operatorhub': Failure
   |___
ERROR: 'has_nfd_in_operatorhub' test failed, but no install script provided.
+ run_finalizers
+ '[' 0 -eq 0 ']'
+ return
/opt/ci-artifacts/src//testing/run: line 101: /logs/artifacts/FLAKE: Is a directory
Test of 'test-commit' failed. 
```