### PR TITLE
nfd_operator_deploy_custom_commit: fix build error when 'as' is in lower case

### DIFF
--- a/roles/nfd_operator_deploy_custom_commit/files/operator_image_builder_script.yml
+++ b/roles/nfd_operator_deploy_custom_commit/files/operator_image_builder_script.yml
@@ -31,7 +31,7 @@ data:
 
     podman pull docker.io/library/golang:1.16.3-buster
     podman pull registry.access.redhat.com/ubi8/ubi:latest
-    sed -i 's|FROM registry.ci.openshift.org/ocp/builder:rhel-.*-golang-\(.*\)-openshift-.* AS|FROM docker.io/library/golang:\1 AS|' Dockerfile
+    sed -i 's|FROM registry.ci.openshift.org/ocp/builder:rhel-.*-golang-\(.*\)-openshift-.* [Aa][sS]|FROM docker.io/library/golang:\1 AS|' Dockerfile
     sed -i '10s|.*|FROM registry.access.redhat.com/ubi8/ubi|' Dockerfile
 
     IMAGE_NAME="nfd-operator-ci:latest"


### PR DESCRIPTION
Fixes [this](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/periodic-ci-openshift-psap-ci-artifacts-release-4.9-nfd-operator-e2e-master/1512943639049801728/artifacts/operator-e2e-master/nightly/artifacts/002__nfd_operator__deploy_from_commit/_ansible.log) nightly failure (OCP 4.8 and 4.9):
```
2022-04-10 00:53:12,696 p=710 u=psap-ci-runner n=ansible | <stdout> + sed -i 's|FROM registry.ci.openshift.org/ocp/builder:rhel-.*-golang-\(.*\)-openshift-.* AS|FROM docker.io/library/golang:\1 AS|' Dockerfile
2022-04-10 00:53:12,696 p=710 u=psap-ci-runner n=ansible | <stdout> + sed -i '10s|.*|FROM registry.access.redhat.com/ubi8/ubi|' Dockerfile
2022-04-10 00:53:12,696 p=710 u=psap-ci-runner n=ansible | <stdout> + IMAGE_NAME=nfd-operator-ci:latest
2022-04-10 00:53:12,697 p=710 u=psap-ci-runner n=ansible | <stdout> + make image IMAGE_TAG=nfd-operator-ci:latest
2022-04-10 00:53:12,697 p=710 u=psap-ci-runner n=ansible | <stdout> make: go: No such file or directory
2022-04-10 00:53:12,697 p=710 u=psap-ci-runner n=ansible | <stdout> docker build -t nfd-operator-ci:latest \
2022-04-10 00:53:12,697 p=710 u=psap-ci-runner n=ansible | <stdout> 	 \
2022-04-10 00:53:12,697 p=710 u=psap-ci-runner n=ansible | <stdout> 	 ./
2022-04-10 00:53:12,697 p=710 u=psap-ci-runner n=ansible | <stdout> [1/2] STEP 1/4: FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.16-openshift-4.9 AS builder
2022-04-10 00:53:12,697 p=710 u=psap-ci-runner n=ansible | <stdout> Trying to pull registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.16-openshift-4.9...
2022-04-10 00:53:12,697 p=710 u=psap-ci-runner n=ansible | <stdout> [2/2] STEP 1/10: FROM registry.access.redhat.com/ubi8/ubi
2022-04-10 00:53:12,697 p=710 u=psap-ci-runner n=ansible | <stdout> Error: error creating build container: initializing source docker://registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.16-openshift-4.9: reading manifest rhel-8-golang-1.16-openshift-4.9 in registry.ci.openshift.org/ocp/builder: unauthorized: authentication required
```
caused by the `AS` directive of the old Dockerfile written in lower case, eg:
- [master](https://github.com/openshift/cluster-nfd-operator/blob/master/Dockerfile#L2)
- [4.9](https://github.com/openshift/cluster-nfd-operator/blob/release-4.9/Dockerfile#L2)