### PR TITLE
Update the dockerfile

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -54,7 +54,7 @@ RUN sed -i 's|roles/|/opt/ci-artifacts/roles/|' /etc/ansible/ansible.cfg \
 # Set up the runner user
 ENV USER_NAME=psap-ci-runner \
     USER=psap-ci-runner \
-    HOME=/opt/ci-artifacts/src/ \
+    HOME=/opt/ci-artifacts/src \
     ANSIBLE_CONFIG="/etc/ansible/ansible.cfg" \
     INSIDE_CI_IMAGE="y"
 

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -10,7 +10,7 @@ LABEL 	io.k8s.display-name="OpenShift PSAP CI artifacts" \
 # Install openshift-ansible RPMs and some debugging tools
 RUN yum install -y --quiet \
 		glibc-langpack-en \
-		go git make jq vim wget rsync time gettext \
+		go git make jq vim wget rsync time gettext file \
 		python3 python3-devel python3-pip python3-setuptools && \
 	python3 -m pip install --no-cache-dir --quiet --upgrade setuptools pip wheel && \
 	yum clean all && \
@@ -26,6 +26,7 @@ RUN curl --silent ${OCP_CLI_URL} | tar xfz - -C /usr/local/bin oc
 ARG OCM_CLI_VERSION=v0.1.60
 ARG OCM_CLI_URL=https://github.com/openshift-online/ocm-cli/releases/download/${OCM_CLI_VERSION}/ocm-linux-amd64
 RUN curl --silent -L ${OCM_CLI_URL} --output /usr/local/bin/ocm
+RUN file /usr/local/bin/ocm | tee /dev/stderr | grep ELF -q # ensure that the file is an ELF binary
 RUN chmod +x /usr/local/bin/ocm
 
 # Install dependencies: `helm`

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -23,7 +23,7 @@ ARG OCP_CLI_URL=https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp
 RUN curl --silent ${OCP_CLI_URL} | tar xfz - -C /usr/local/bin oc
 
 # Install dependencies: `ocm`
-ARG OCM_CLI_VERSION=v0.1.60
+ARG OCM_CLI_VERSION=v0.1.63
 ARG OCM_CLI_URL=https://github.com/openshift-online/ocm-cli/releases/download/${OCM_CLI_VERSION}/ocm-linux-amd64
 RUN curl --silent -L ${OCM_CLI_URL} --output /usr/local/bin/ocm
 RUN file /usr/local/bin/ocm | tee /dev/stderr | grep ELF -q # ensure that the file is an ELF binary

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -25,7 +25,7 @@ RUN curl --silent ${OCP_CLI_URL} | tar xfz - -C /usr/local/bin oc
 # Install dependencies: `ocm`
 ARG OCM_CLI_VERSION=v0.1.63
 ARG OCM_CLI_URL=https://github.com/openshift-online/ocm-cli/releases/download/${OCM_CLI_VERSION}/ocm-linux-amd64
-RUN curl --silent -L ${OCM_CLI_URL} --output /usr/local/bin/ocm
+RUN wget --quiet ${OCM_CLI_URL} -O /usr/local/bin/ocm
 RUN file /usr/local/bin/ocm | tee /dev/stderr | grep ELF -q # ensure that the file is an ELF binary
 RUN chmod +x /usr/local/bin/ocm
 


### PR DESCRIPTION
* `build/Dockerfile: remove trailing/ in $HOME`


---

* `build/Dockerfile: ensure that ocm is an ELF binary`

This should prevent this runtime error:
```
 + bash -c '
      set -o errexit
      set -o nounset
      OCM_TOKEN=$(cat "$PSAP_ODS_SECRET_PATH/ocm.token" | grep "^${OCM_ENV}=" | cut -d= -f2-)
      echo "Login in $OCM_ENV with token length=$(echo "$OCM_TOKEN" | wc -c)"
      exec ocm login --token="$OCM_TOKEN" --url="$OCM_ENV"
      '
Login in staging with token length=755
/usr/local/bin/ocm: line 1: $'\r': command not found
/usr/local/bin/ocm: line 2: html: No such file or directory
/usr/local/bin/ocm: line 3: head: No such file or directory
/usr/local/bin/ocm: line 4: meta: No such file or directory
/usr/local/bin/ocm: line 5: title: No such file or directory
/usr/local/bin/ocm: line 5: middot: command not found
/usr/local/bin/ocm: line 5: /title: No such file or directory
/usr/local/bin/ocm: line 6: meta: No such file or directory
/usr/local/bin/ocm: line 7: style: No such file or directory
/usr/local/bin/ocm: line 8: body: command not found
/usr/local/bin/ocm: line 9: background-color:: command not found
/usr/local/bin/ocm: line 10: syntax error near unexpected token `('
/usr/local/bin/ocm: line 10: `        color: rgba(0, 0, 0, 0.5);
```

---

* `build/Dockerfile: update OCM to version v0.1.63`


---

* `build/Dockerfile: use wget instead of curl to download ocm`

to avoid this kind of error:
```
STEP 11/33: RUN curl --silent -L ${OCM_CLI_URL} --output /usr/local/bin/ocm
STEP 12/33: RUN file /tmp/ocm | grep ELF -q # ensure that the file is an ELF binary
error: build error: error building at STEP "RUN file /tmp/ocm | grep ELF -q # ensure that the file is an ELF binary": error while running
runtime: exit status 1
```

---

This should fix the issues with `ocm` we've seen today.

/cc @kpouget 