### PR TITLE
testing: ods: common: remove the hard-coded path to PSAP_ODS_SECRET_PATH

### DIFF
--- a/testing/ods/common.sh
+++ b/testing/ods/common.sh
@@ -1,4 +1,10 @@
-PSAP_ODS_SECRET_PATH="/var/run/psap-ods-secret-1"
+if [[ -z "${PSAP_ODS_SECRET_PATH:-}" ]]; then
+    echo "ERROR: the PSAP_ODS_SECRET_PATH was not provided"
+    false # can't exit here
+elif [[ ! -d "$PSAP_ODS_SECRET_PATH" ]]; then
+    echo "ERROR: the PSAP_ODS_SECRET_PATH does not point to a valid directory"
+    false # can't exit here
+fi
 
 OCM_ENV=staging # The valid aliases are 'production', 'staging', 'integration'
 


### PR DESCRIPTION
The path is now exposed in the test-side, see https://github.com/openshift/release/pull/29763