### PR TITLE
toolbox: _common.py: accept ARTIFACT_TOOLBOX_NAME_PREFIX as a prefix to the artifacts_extra_logs_dir name

### DIFF
--- a/testing/ods/jh-at-scale.sh
+++ b/testing/ods/jh-at-scale.sh
@@ -41,6 +41,7 @@ switch_cluster() {
         echo "Requested to switch to an unknown cluster '$cluster_role', exiting."
         exit 1
     fi
+    export ARTIFACT_TOOLBOX_NAME_PREFIX="${cluster_role}_"
 }
 
 # ---

--- a/testing/ods/process_ctrl.sh
+++ b/testing/ods/process_ctrl.sh
@@ -30,14 +30,19 @@ process_ctrl::retry() {
     retry_delay=$1
     shift
 
+    tries=0
     retries_left=$total_retries
     while [[ $retries_left != 0 ]]; do
+        tries=$(($tries + 1))
         if "$@";
         then
+            echo "$@" "succeeded at the $tries/$total_retries try."
             return
         fi
         echo "Try $(($total_retries - $retries_left + 1))/$total_retries failed. " "$@"
         retries_left=$(($retries_left - 1))
         sleep $retry_delay
     done
+    echo "$@" "failed after $tries tries..."
+    false
 }

--- a/testing/ods/process_ctrl.sh
+++ b/testing/ods/process_ctrl.sh
@@ -2,14 +2,18 @@ process_ctrl__wait_list=()
 
 process_ctrl::run_in_bg() {
     "$@" &
-    echo "Adding '$!' to the wait-list '${process_ctrl__wait_list[@]}' ..."
+    echo "Adding '$!' ($@) to the wait-list '${process_ctrl__wait_list[@]}' ..."
     process_ctrl__wait_list+=("$!")
 }
 
 process_ctrl::wait_bg_processes() {
     echo "Waiting for the background processes '${process_ctrl__wait_list[@]}' to terminate ..."
     for pid in ${process_ctrl__wait_list[@]}; do
-        wait $pid # this syntax honors the `set -e` flag
+        if ! wait $pid # this syntax honors the `set -e` flag
+        then
+            echo "Process $pid failed :( retcode=$?"
+            false
+        fi
     done
     echo "All the processes are done!"
     process_ctrl__wait_list=()

--- a/toolbox/_common.py
+++ b/toolbox/_common.py
@@ -65,10 +65,10 @@ def run_ansible_role(role_name, opts: dict = dict()):
 
     if env.get("ARTIFACT_EXTRA_LOGS_DIR") is None:
         previous_extra_count = len(list(artifact_dir.glob("*__*")))
-        env["ARTIFACT_EXTRA_LOGS_DIR"] = str(
-            Path(env["ARTIFACT_DIR"]) /
-            f"{previous_extra_count:03d}__{env['ARTIFACT_DIRNAME']}"
-        )
+        prefix = env.get("ARTIFACT_TOOLBOX_NAME_PREFIX", "")
+        name = f"{previous_extra_count:03d}__{prefix}{env['ARTIFACT_DIRNAME']}"
+
+        env["ARTIFACT_EXTRA_LOGS_DIR"] = str(Path(env["ARTIFACT_DIR"]) / name)
 
     artifact_extra_logs_dir = Path(env["ARTIFACT_EXTRA_LOGS_DIR"])
     artifact_extra_logs_dir.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
This PR adds a prefix to the `artifacts_extra_logs_dir`.
We use it to distinguish more easily (and programmatically) if a command ran against the driver cluster or the sutest cluster.