### PR TITLE
rhods_test_jupyterlab: test-jupyterlab-psap-simplenotebook: remove 'Clean up the files and folders we created'

### DIFF
--- a/roles/rhods_test_jupyterlab/files/ods-ci/test-jupyterlab-psap-simplenotebook.robot
+++ b/roles/rhods_test_jupyterlab/files/ods-ci/test-jupyterlab-psap-simplenotebook.robot
@@ -80,12 +80,6 @@ Run the PSAP jh-at-scale Simple Notebook
   Should Not Match  ${output}  ERROR*
   Capture Page Screenshot
 
-
-Clean up the files and folders we created
-  [Tags]  Notebook  End Sequence
-  Add and Run JupyterLab Code Cell in Active Notebook  !rm -rf ~/*
-  Capture Page Screenshot
-
 Can Close Notebook when done
   [Tags]  Notebook  End Sequence
   Stop JupyterLab Notebook Server


### PR DESCRIPTION
This PR removes the `Clean up the files and folders we created` step from the simple test robot.
This steps often fails, and it isn't relevant for us (we delete the PVCs after the testing).