### PR TITLE
WIP: RHODS: test authentication with 300 simultaneous users

### DIFF
--- a/subprojects/matrix-benchmarking-workloads/rhods-ci/benchmarks/auth.yaml
+++ b/subprojects/matrix-benchmarking-workloads/rhods-ci/benchmarks/auth.yaml
@@ -1,0 +1,16 @@
+--path-tpl: auth_{user_count}users
+
+--remote-mode: false
+--stop-on-error: false
+
+--script-tpl: "exec/run_auth.sh"
+
+--expe-to-run:
+  - auth
+
+common_settings:
+
+expe:
+  auth:
+    user_count: 32, 64, 128, 256, 384
+    startup_delay: 0.5, 1, 1.5

--- a/subprojects/matrix-benchmarking-workloads/rhods-ci/exec/run_auth.sh
+++ b/subprojects/matrix-benchmarking-workloads/rhods-ci/exec/run_auth.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
+set -o errtrace
+set -x
+
+# This script expected:
+
+# - `MATBENCH_RHODS_CI_KUBECONFIG_SUTEST` (env var) to point to the kubeconfig of the SUTest cluster
+
+# - `MATBENCH_RHODS_CI_CI_ARTIFACTS_BASE_DIR` (env var) to point to the location where `ci-artifacts` base directory is available.
+# - `MATBENCH_RHODS_CI_NGINX_SERVER` (env var) to point to the server where the notebook is exposed
+# - `user_count` (param) to define the number of users to simulate
+# - `startup_delay` (param) to define the number of seconds that user should wait before starting their execution
+
+for i in "$@"; do
+    key=$(echo $i | cut -d= -f1)
+    val=$(echo $i | cut -d= -f2)
+    declare $key=$val
+    echo "$key ==> $val"
+done
+
+THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+source "$THIS_DIR/../../../../testing/ods/common.sh"
+export ARTIFACTS_COLLECTED=no-image-except-failed-and-zero
+export ARTIFACT_DIR=$PWD
+cd "$MATBENCH_RHODS_CI_CI_ARTIFACTS_BASE_DIR"
+
+REDIS_SERVER="redis.${STATESIGNAL_REDIS_NAMESPACE}.svc"
+# running with the driver cluster KUBECONFIG
+
+./run_toolbox.py rhods notebook_ux_e2e_scale_test \
+                 "$LDAP_IDP_NAME" \
+                 "$ODS_CI_USER_PREFIX" "$user_count" \
+                 "$S3_LDAP_PROPS" \
+                 "http://$MATBENCH_RHODS_CI_NGINX_SERVER/$ODS_NOTEBOOK_NAME" \
+                 --sut_cluster_kubeconfig="$MATBENCH_RHODS_CI_KUBECONFIG_SUTEST" \
+                 --artifacts-collected="$ARTIFACTS_COLLECTED" \
+                 --ods_sleep_factor="$startup_delay" \
+                 --ods_ci_artifacts_exporter_istag="$ODS_CI_IMAGESTREAM:$ODS_CI_ARTIFACTS_EXPORTER_TAG" \
+                 --ods_ci_exclude_tags="$ODS_EXCLUDE_TAGS" \
+                 --state_signal_redis_server="${REDIS_SERVER}"
+
+./run_toolbox.py cluster dump_prometheus_db
+
+export ARTIFACT_TOOLBOX_NAME_PREFIX="sutest_"
+export KUBECONFIG=$MATBENCH_RHODS_CI_KUBECONFIG_SUTEST
+
+./run_toolbox.py cluster dump_prometheus_db
+./run_toolbox.py rhods dump_prometheus_db

--- a/testing/ods/common.sh
+++ b/testing/ods/common.sh
@@ -6,7 +6,7 @@ elif [[ ! -d "$PSAP_ODS_SECRET_PATH" ]]; then
     false # can't exit here
 fi
 
-ODS_CI_NB_USERS=300 # number of users to simulate
+ODS_CI_NB_USERS=384 # number of users to simulate
 ODS_EXCLUDE_TAGS=Notebook # tags to exclude when running the robot test case
 
 
@@ -33,6 +33,8 @@ RHODS_NOTEBOOK_IMAGE_NAME=s2i-generic-data-science-notebook
 ODS_CI_TEST_NAMESPACE=loadtest
 ODS_CI_REPO="https://github.com/openshift-psap/ods-ci.git"
 ODS_CI_REF="jh-at-scale.v220822"
+
+TEST_MATBENCH_AUTH=y
 
 ODS_CI_IMAGESTREAM="ods-ci"
 ODS_CI_TAG="latest"

--- a/testing/ods/common.sh
+++ b/testing/ods/common.sh
@@ -6,6 +6,10 @@ elif [[ ! -d "$PSAP_ODS_SECRET_PATH" ]]; then
     false # can't exit here
 fi
 
+ODS_CI_NB_USERS=300 # number of users to simulate
+ODS_EXCLUDE_TAGS=Notebook # tags to exclude when running the robot test case
+
+
 OCM_ENV=staging # The valid aliases are 'production', 'staging', 'integration'
 
 S3_LDAP_PROPS="${PSAP_ODS_SECRET_PATH}/s3_ldap.passwords"
@@ -77,7 +81,7 @@ ENABLE_AUTOSCALER=
 SUTEST_COMPUTE_MACHINE_TYPE=m5.2xlarge
 DRIVER_COMPUTE_MACHINE_TYPE=m5.2xlarge
 
-SUTEST_FORCE_COMPUTE_NODES_COUNT= # if empty, uses ods/sizing/sizing to determine the right number of machines
+SUTEST_FORCE_COMPUTE_NODES_COUNT=2 # if empty, uses ods/sizing/sizing to determine the right number of machines
 DRIVER_FORCE_COMPUTE_NODES_COUNT= # if empty, uses ods/sizing/sizing to determine the right number of machines
 
 # OSP/OSD cluster naming is handled differently in this job


### PR DESCRIPTION
This WIP PR disables the `Notebook` part of the test suite (and forces the sutest node count to 1 as no notebook will be created), and launches N simultaneous users.