### PR TITLE
RHODS: add cluster-autoscaling flag and improve stability

### DIFF
--- a/roles/cluster_capture_environment/tasks/main.yml
+++ b/roles/cluster_capture_environment/tasks/main.yml
@@ -15,6 +15,22 @@
     oc get clusterversion/version -oyaml
        > {{ artifact_extra_logs_dir }}/ocp_clusterversion.yml
 
+- name: Store the OpenShift nodes
+  shell:
+    oc get nodes
+       > {{ artifact_extra_logs_dir }}/nodes.status;
+    oc get nodes -oyaml
+       > {{ artifact_extra_logs_dir }}/nodes.yaml;
+
+- name: Store the OpenShift machines
+  shell:
+    oc get machines -n openshift-machine-api
+       > {{ artifact_extra_logs_dir }}/machines.status;
+    oc get machines -n openshift-machine-api -oyaml
+       > {{ artifact_extra_logs_dir }}/machines.yaml;
+
+# ---
+
 - name: Fetch ci-artifact version from Git
   command:
     git describe HEAD --long --always

--- a/roles/rhods_test_jupyterlab/defaults/main/config.yml
+++ b/roles/rhods_test_jupyterlab/defaults/main/config.yml
@@ -5,7 +5,7 @@ rhods_test_jupyterlab_secret_properties:
 rhods_test_jupyterlab_idp_name:
 rhods_test_jupyterlab_sut_cluster_kubeconfig:
 rhods_test_jupyterlab_artifacts_collected: all
-rhods_test_jupyterlab_artifacts_exclude_tags: None
+rhods_test_jupyterlab_ods_ci_exclude_tags: None
 rhods_test_jupyterlab_ods_ci_test_case: test-jupyterlab-psap-simplenotebook.robot
 
 rhods_test_namespace: loadtest

--- a/roles/rhods_test_jupyterlab/files/entrypoint.sh
+++ b/roles/rhods_test_jupyterlab/files/entrypoint.sh
@@ -13,11 +13,14 @@ do_oc_login() {
 
     touch "$KUBECONFIG"
     retries=5
+    tries=1
     while true; do
         # run this in a subshell to avoid printing the password in clear because of 'set -x'
         if bash -ec "PASSWORD=\$(yq e .TEST_USER.PASSWORD /tmp/test-variables.yml); oc login --server=\$K8S_API --username=\$USERNAME --password=\$PASSWORD --insecure-skip-tls-verify"; then
+            echo "$tries"> "$ARTIFACTS_DIR/oc_login.tries"
             break
         fi
+        tries=$(($tries + 1))
         retries=$(($retries - 1))
         [[ $retries == 0 ]] && return 1
         sleep 10

--- a/roles/rhods_test_jupyterlab/files/entrypoint.sh
+++ b/roles/rhods_test_jupyterlab/files/entrypoint.sh
@@ -12,13 +12,23 @@ do_oc_login() {
     export USERNAME=$(yq e .TEST_USER.USERNAME /tmp/test-variables.yml)
 
     touch "$KUBECONFIG"
-    # run this in a subshell to avoid printing the password in clear because of 'set -x'
-    bash -ec "PASSWORD=\$(yq e .TEST_USER.PASSWORD /tmp/test-variables.yml); oc login --server=\$K8S_API --username=\$USERNAME --password=\$PASSWORD --insecure-skip-tls-verify"
+    retries=5
+    while true; do
+        # run this in a subshell to avoid printing the password in clear because of 'set -x'
+        if bash -ec "PASSWORD=\$(yq e .TEST_USER.PASSWORD /tmp/test-variables.yml); oc login --server=\$K8S_API --username=\$USERNAME --password=\$PASSWORD --insecure-skip-tls-verify"; then
+            break
+        fi
+        retries=$(($retries - 1))
+        [[ $retries == 0 ]] && return 1
+        sleep 10
+    done
 }
 
 if [[ -z "{ARTIFACTS_DIR:-}" ]]; then
     ARTIFACTS_DIR=/tmp/ods-ci
 fi
+
+mkdir -p "${ARTIFACTS_DIR}"
 
 trap "touch $ARTIFACTS_DIR/test.exit_code" EXIT
 
@@ -30,8 +40,6 @@ cp "/mnt/rhods-jupyterlab-entrypoint/$RUN_ROBOT_TEST_CASE" .
 # `run_robot_test.sh` initialization stops complaining when we provide
 # no KUBECONFIG.
 do_oc_login
-
-mkdir -p "${ARTIFACTS_DIR}"
 
 test_exit_code=0
 (bash -x ./run_robot_test.sh \

--- a/roles/rhods_test_jupyterlab/tasks/main.yml
+++ b/roles/rhods_test_jupyterlab/tasks/main.yml
@@ -208,6 +208,7 @@
   retries: 60
   delay: 40
   until: not wait_rhods_test_job.stdout
+  failed_when: false
 
 # ---
 
@@ -218,24 +219,28 @@
     oc delete pvc --all -n {{ rhods_notebook_namespace }}
   environment:
     KUBECONFIG: '{{ sut_cluster_kubeconfig }}'
+  ignore_errors: yes
 
 - name: Get the status of the tester Pods
   shell:
     oc get pods -ljob-name=ods-ci
        -n {{ rhods_test_namespace }}
         > "{{ artifact_extra_logs_dir }}/tester_pods.status"
+  ignore_errors: yes
 
 - name: Get the status of the tester Job
   shell:
     oc get job/ods-ci
        -n {{ rhods_test_namespace }}
         > "{{ artifact_extra_logs_dir }}/tester_job.status"
+  ignore_errors: yes
 
 - name: Get the names of the tester_pods
   command:
     oc get pods -oname -ljob-name=ods-ci
        -n {{ rhods_test_namespace }}
   register: pod_names_cmd
+  ignore_errors: yes
 
 - name: Get the logs of the tester Pod
   shell: |
@@ -247,28 +252,28 @@
     done
 
   loop: "{{ pod_names_cmd.stdout_lines }}"
-  failed_when: false
+  ignore_errors: yes
 
 - name: Get the yaml of the tester Pods
   shell:
     oc get pods -ljob-name=ods-ci -oyaml
        -n {{ rhods_test_namespace }}
        > "{{ artifact_extra_logs_dir }}/tester_pods.yaml"
-  failed_when: false
+  ignore_errors: yes
 
 - name: Get the yaml of the tester Job
   shell:
     oc get job/ods-ci -oyaml
        -n {{ rhods_test_namespace }}
        > "{{ artifact_extra_logs_dir }}/tester_job.yaml"
-  failed_when: false
+  ignore_errors: yes
 
 - name: Get the events of the tester namespace
   shell:
     oc get ev -oyaml
        -n {{ rhods_test_namespace }}
        > "{{ artifact_extra_logs_dir }}/tester_events.yaml"
-  failed_when: false
+  ignore_errors: yes
 
 - name: Get the events of the notebook namespace
   environment:
@@ -277,17 +282,19 @@
     oc get ev -oyaml
        -n {{ rhods_notebook_namespace }}
        > "{{ artifact_extra_logs_dir }}/notebook_events.yaml"
-  failed_when: false
+  ignore_errors: yes
 
 - name: Get Minio Pod name
   command: oc get pod -lapp=minio -n minio -ojsonpath={.items[0].metadata.name}
   register: minio_podname_cmd
+  ignore_errors: yes
 
 - name: Export the data out of the S3 bucket
   command:
     oc -n minio -c mc exec "{{ minio_podname_cmd.stdout }}"
        -- bash -c 'mkdir -p /artifacts/to_export && mc --config-dir /tmp cp minio/mybucket/ /artifacts/to_export --recursive'
   when: 'rhods_test_jupyterlab_artifacts_collected != "none"'
+  ignore_errors: yes
 
 - name: Extract the ODS-CI test artifacts from the Minio S3 container
   shell: |
@@ -297,6 +304,7 @@
        -- tar cvzf - -C /artifacts/to_export/ . \
        | tar xzf - -C "{{ artifact_extra_logs_dir }}"
   when: 'rhods_test_jupyterlab_artifacts_collected != "none"'
+  ignore_errors: yes
 
 - name: Generate MatrixBenchmark files
   shell: |
@@ -306,6 +314,7 @@
     test={{ rhods_test_jupyterlab_ods_ci_test_case }}
     user_count={{ rhods_test_jupyterlab_user_count }}
     EOF
+  ignore_errors: yes
 
 - name: Show the artifacts directory
   debug: msg="The test artifacts have been stored in {{ artifact_extra_logs_dir }}"
@@ -314,19 +323,19 @@
   shell:
     set -o pipefail;
     cat "{{ artifact_extra_logs_dir }}"/ods-ci/ods-ci-*/test.exit_code | grep '^0$' | wc -l
-  failed_when: false
   register: success_count_cmd
+  ignore_errors: yes
 
 - name: Count failed tests
   shell:
     set -o pipefail;
     cat "{{ artifact_extra_logs_dir }}"/ods-ci/ods-ci-*/test.exit_code | grep -v '^0$' | wc -l
-  failed_when: false
+  ignore_errors: yes
 
 - name: Show failed tests
   shell:
     grep  -v '^0$' "{{ artifact_extra_logs_dir }}"/ods-ci/ods-ci-*/test.exit_code
-  failed_when: false
+  ignore_errors: yes
   register: failed_tests_cmd
 
 - name: Save the success count and failed tests
@@ -335,7 +344,7 @@
          > "{{ artifact_extra_logs_dir }}/success_count"
     echo "{{ failed_tests_cmd.stdout }}" \
          > "{{ artifact_extra_logs_dir }}/failed_tests"
-  failed_when: false
+  ignore_errors: yes
 
 - name: Test if the RHODS test job crashed
   command:

--- a/roles/rhods_test_jupyterlab/templates/rhods-ci.yaml
+++ b/roles/rhods_test_jupyterlab/templates/rhods-ci.yaml
@@ -44,7 +44,7 @@ spec:
         - name: ARTIFACTS_DIR
           value: /mnt/shared-dir/ods-ci
         - name: RUN_ROBOT_EXCLUDE_TAGS
-          value: "{{ rhods_test_jupyterlab_artifacts_exclude_tags }}"
+          value: "{{ rhods_test_jupyterlab_ods_ci_exclude_tags }}"
         volumeMounts:
         - name: shared-dir
           mountPath: /mnt/shared-dir

--- a/testing/ods/common.sh
+++ b/testing/ods/common.sh
@@ -46,7 +46,6 @@ OCP_REGION=us-west-2
 OCP_MASTER_MACHINE_TYPE=m5.xlarge
 OCP_WORKER_MACHINE_TYPE=m5.xlarge
 
-OCP_WORKER_NODES=7
 OCP_BASE_DOMAIN=psap.aws.rhperfscale.org
 
 # Shouldn't be the same than OCP worker nodes.

--- a/testing/ods/common.sh
+++ b/testing/ods/common.sh
@@ -53,7 +53,8 @@ OCP_BASE_DOMAIN=psap.aws.rhperfscale.org
 SUTEST_COMPUTE_MACHINE_TYPE=m5.2xlarge
 DRIVER_COMPUTE_MACHINE_TYPE=m5.2xlarge
 
-FORCE_COMPUTE_NODES_COUNT= # if empty, uses ods/sizing/sizing to determine the right number of machines
+SUTEST_FORCE_COMPUTE_NODES_COUNT= # if empty, uses ods/sizing/sizing to determine the right number of machines
+DRIVER_FORCE_COMPUTE_NODES_COUNT= # if empty, uses ods/sizing/sizing to determine the right number of machines
 
 ocm_login() {
     export OCM_ENV
@@ -115,6 +116,14 @@ get_compute_node_count() {
     shift
     instance_type=$1
     shift
+
+    if [[ "$cluster_role" == "sutest" && "$SUTEST_FORCE_COMPUTE_NODES_COUNT" ]]; then
+        echo "$SUTEST_FORCE_COMPUTE_NODES_COUNT"
+        return
+    elif [[ "$cluster_role" == "driver" && "$DRIVER_FORCE_COMPUTE_NODES_COUNT" ]]; then
+        echo "$DRIVER_FORCE_COMPUTE_NODES_COUNT"
+        return
+    fi
 
     notebook_size_name=$(get_notebook_size "$cluster_role")
     size=$(bash -c "python3 $THIS_DIR/sizing/sizing '$notebook_size_name' '$instance_type' '$ODS_CI_NB_USERS' >&2; echo \$?")

--- a/toolbox/rhods.py
+++ b/toolbox/rhods.py
@@ -89,7 +89,7 @@ class RHODS:
             "rhods_test_jupyterlab_sut_cluster_kubeconfig": sut_cluster_kubeconfig,
             "rhods_test_jupyterlab_artifacts_collected": artifacts_collected,
             "rhods_test_jupyterlab_ods_ci_test_case": ods_ci_test_case,
-            "rhods_test_jupyterlab_ods_ci_exclude_tags": ods_ci_exclude_tags
+            "rhods_test_jupyterlab_ods_ci_exclude_tags": ods_ci_exclude_tags,
         }
 
         ARTIFACTS_COLLECTED_VALUES = ("all", "none", "no-image", "no-image-except-if-failed")


### PR DESCRIPTION
* `testing: ods: common: removed OCP_WORKER_NODES unused variable`


---

* `testing: ods: common: allow manual setting of the sutest/driver node count`


---

* `rhods_test_jupyterlab: ignore errors occuring after the test`

(so that as many artifacts as possible are collected)

---

* `rhods_test_jupyterlab: fix the --ods-ci-exclude flag`


---

* `rhods_test_jupyterlab: entrypoint.sh: retry 5 times to 'oc login'`


---

* `rhods_test_jupyterlab: entrypoint: store how many tries were required for 'oc login'`


---

* `cluster_capture_environment: capture the cluster's nodes and machines`


---

/cc @kpouget 