### PR TITLE
RHODS: minor updates

### DIFF
--- a/roles/cluster_capture_environment/tasks/main.yml
+++ b/roles/cluster_capture_environment/tasks/main.yml
@@ -31,6 +31,22 @@
 
 # ---
 
+- name: Store the OpenShift nodes
+  shell:
+    oc get nodes
+       > {{ artifact_extra_logs_dir }}/nodes.status;
+    oc get nodes -oyaml
+       > {{ artifact_extra_logs_dir }}/nodes.yaml;
+
+- name: Store the OpenShift machines
+  shell:
+    oc get machines -n openshift-machine-api
+       > {{ artifact_extra_logs_dir }}/machines.status;
+    oc get machines -n openshift-machine-api -oyaml
+       > {{ artifact_extra_logs_dir }}/machines.yaml;
+
+# ---
+
 - name: Fetch ci-artifact version from Git
   command:
     git describe HEAD --long --always

--- a/roles/cluster_destroy_osd/defaults/main/config.yml
+++ b/roles/cluster_destroy_osd/defaults/main/config.yml
@@ -1,1 +1,2 @@
 cluster_destroy_osd_cluster_name:
+cluster_create_osd_machinepool_name: default

--- a/roles/cluster_destroy_osd/tasks/main.yml
+++ b/roles/cluster_destroy_osd/tasks/main.yml
@@ -6,6 +6,13 @@
 - name: Check ocm whoami
   command: ocm whoami
 
+- name: Set the worker node count to 2
+  command:
+    ocm edit machinepool
+             {{ cluster_create_osd_machinepool_name }}
+             --cluster={{ cluster_create_osd_cluster_name }}
+             --replicas=2
+
 - name: Get the cluster ID
   shell:
     set -o pipefail;

--- a/roles/rhods_test_jupyterlab/tasks/main.yml
+++ b/roles/rhods_test_jupyterlab/tasks/main.yml
@@ -301,7 +301,7 @@
     set -o pipefail
 
     oc -n minio -c ubi8 exec "{{ minio_podname_cmd.stdout }}" \
-       -- tar cvzf - -C /artifacts/to_export/ . \
+       -- tar czf - -C /artifacts/to_export/ . \
        | tar xzf - -C "{{ artifact_extra_logs_dir }}"
   when: 'rhods_test_jupyterlab_artifacts_collected != "none"'
   ignore_errors: yes

--- a/roles/rhods_test_jupyterlab/tasks/main.yml
+++ b/roles/rhods_test_jupyterlab/tasks/main.yml
@@ -333,18 +333,19 @@
   ignore_errors: yes
 
 - name: Show failed tests
-  shell:
-    grep  -v '^0$' "{{ artifact_extra_logs_dir }}"/ods-ci/ods-ci-*/test.exit_code
+  shell: |
+    for f in "{{ artifact_extra_logs_dir }}"/ods-ci/ods-ci-*/test.log; do
+      echo -e "\n===\n$f\n---"
+      egrep 'FAIL|WARN' $f | grep -v "^| FAIL|"
+      echo "--> $(cat $(dirname "$f")/test.exit_code)"
+      echo "==="
+    done > "{{ artifact_extra_logs_dir }}"/failed_tests
   ignore_errors: yes
-  register: failed_tests_cmd
 
 - name: Save the success count and failed tests
-  shell: |
-    echo "{{ success_count_cmd.stdout }}/{{ rhods_test_jupyterlab_user_count }}" \
+  shell:
+    echo "{{ success_count_cmd.stdout }}/{{ rhods_test_jupyterlab_user_count }}"
          > "{{ artifact_extra_logs_dir }}/success_count"
-    echo "{{ failed_tests_cmd.stdout }}" \
-         > "{{ artifact_extra_logs_dir }}/failed_tests"
-  ignore_errors: yes
 
 - name: Test if the RHODS test job crashed
   command:

--- a/roles/rhods_test_jupyterlab/tasks/main.yml
+++ b/roles/rhods_test_jupyterlab/tasks/main.yml
@@ -311,8 +311,9 @@
     (test -z "$(oc get jobs/ods-ci -ojsonpath={.status.failed} -n {{ rhods_test_namespace }})" && echo 0 || echo 1) >  "{{ artifact_extra_logs_dir }}/exit_code"
     cat <<EOF > "{{ artifact_extra_logs_dir }}/settings"
     date=$(date +%Y-%m-%d_%H:%M:%S)
-    test={{ rhods_test_jupyterlab_ods_ci_test_case }}
-    user_count={{ rhods_test_jupyterlab_user_count }}
+    test-case={{ rhods_test_jupyterlab_ods_ci_test_case }}
+    exclude-tags={{ rhods_test_jupyterlab_ods_ci_exclude_tags }}
+    user-count={{ rhods_test_jupyterlab_user_count }}
     EOF
   ignore_errors: yes
 

--- a/roles/rhods_test_jupyterlab/tasks/main.yml
+++ b/roles/rhods_test_jupyterlab/tasks/main.yml
@@ -153,7 +153,7 @@
     oc -c mc -n minio rsh $(oc get pod -lapp=minio -n minio -oname) \
        mc --config-dir /tmp rm minio/mybucket/ods-ci --recursive --force;
     oc -c mc -n minio rsh $(oc get pod -lapp=minio -n minio -oname) \
-       rm -rf /artifacts/to_export
+       rm -rf /artifacts/to_export  > /dev/null
     oc -c mc -n minio rsh $(oc get pod -lapp=minio -n minio -oname) \
        mc --config-dir /tmp cp /etc/os-release minio/mybucket; # without it, cp may fail if the bucket is empty
   failed_when: false
@@ -166,8 +166,8 @@
        -n {{ rhods_test_namespace }}
 
 - name: Delete the events of the tester namespace
-  command:
-    oc delete ev -n {{ rhods_test_namespace }} --all
+  shell:
+    oc delete ev -n {{ rhods_test_namespace }} --all > /dev/null
   failed_when: false
 
 - name: Delete the events, pods and PVC of the notebook namespace

--- a/testing/ods/ocp_cluster.sh
+++ b/testing/ods/ocp_cluster.sh
@@ -29,6 +29,7 @@ prepare_deploy_cluster_subproject() {
 
 create_cluster() {
     cluster_role=$1
+    export ARTIFACT_TOOLBOX_NAME_PREFIX="ocp_${cluster_role}_"
 
     # ---
 
@@ -113,6 +114,8 @@ create_cluster() {
 
 destroy_cluster() {
     cluster_role=$1
+
+    export ARTIFACT_TOOLBOX_NAME_PREFIX="ocp_${cluster_role}_"
 
     destroy_dir="/tmp/ocp_${cluster_role}_destroy"
     mkdir "$destroy_dir"

--- a/testing/ods/osd_cluster.sh
+++ b/testing/ods/osd_cluster.sh
@@ -13,6 +13,8 @@ source "$THIS_DIR/common.sh"
 create_cluster() {
     cluster_role=$1
 
+    export ARTIFACT_TOOLBOX_NAME_PREFIX="osd_${cluster_role}_"
+
     cluster_name="${CLUSTER_NAME_PREFIX}"
     if [[ "${PULL_NUMBER:-}" ]]; then
         cluster_name="${cluster_name}${PULL_NUMBER}-$(date +%Hh%M)"
@@ -43,6 +45,8 @@ create_cluster() {
 
 destroy_cluster() {
     cluster_role=$1
+
+    export ARTIFACT_TOOLBOX_NAME_PREFIX="osd_${cluster_role}_"
 
     cluster_name=$(get_osd_cluster_name "$cluster_role")
     if [[ -z "$cluster_name" ]]; then

--- a/testing/ods/process_ctrl.sh
+++ b/testing/ods/process_ctrl.sh
@@ -24,7 +24,7 @@ process_ctrl::wait_bg_processes() {
 process_ctrl::kill_bg_processes() {
     echo "Killing the background processes '${process_ctrl__wait_list[@]}' still running ..."
     for pid in ${process_ctrl__wait_list[@]}; do
-        kill -9 $pid 2>/dev/null || true
+        kill -TERM $pid 2>/dev/null || true
     done
     echo "All the processes have been terminated."
     process_ctrl__wait_list=()


### PR DESCRIPTION
* `rhods_test_jupyterlab: improve 'Show failed tests'`


---

* `rhods_test_jupyterlab: store the test-case and exclude-tags in Matbench's settings`


---

* `rhods_test_jupyterlab: mute old ev/artifacts cleanup`


---

* `rhods_test_jupyterlab: mute artifacts extraction`


---

* `cluster_destroy_osd: downscale the cluster before destroying it`


---

* `cluster_capture_environment: capture the cluster's nodes and machines`


---

* `testing: ods: process_ctrl: use sigTERM instead of sigKILL to terminate bg processes`


---

* `testing: ods: ocp_cluster: better call save_install_artifacts on failure`


---

* `testing: ods: ocp/osd clusters: add prefix to toolbox command artifacts`


---