### PR TITLE
testing: ods: {ocp,osd}_cluster: add auto-scaling support

### DIFF
--- a/testing/ods/autoscaling/clusterautoscaler.yaml
+++ b/testing/ods/autoscaling/clusterautoscaler.yaml
@@ -1,0 +1,20 @@
+apiVersion: autoscaling.openshift.io/v1
+kind: ClusterAutoscaler
+metadata:
+  name: default
+spec:
+  podPriorityThreshold: -10
+  resourceLimits:
+    maxNodesTotal: 200
+    cores:
+      min: 0
+      max: 10000
+    memory:
+      min: 0
+      max: 10000
+  scaleDown:
+    enabled: true
+    delayAfterAdd: 10m
+    delayAfterDelete: 5m
+    delayAfterFailure: 30s
+    unneededTime: 10m

--- a/testing/ods/autoscaling/machineautoscaler.yaml
+++ b/testing/ods/autoscaling/machineautoscaler.yaml
@@ -1,0 +1,13 @@
+apiVersion: autoscaling.openshift.io/v1beta1
+kind: MachineAutoscaler
+metadata:
+  name: kpouget-20220701-5g2b7-worker-eu-central-1a--m5-2xlarge
+  namespace: openshift-machine-api
+spec:
+  minReplicas: 0
+  maxReplicas: 1000
+  scaleTargetRef:
+    apiVersion: machine.openshift.io/v1beta1
+    kind: MachineSet
+    name: MACHINESET_NAME
+

--- a/testing/ods/common.sh
+++ b/testing/ods/common.sh
@@ -48,6 +48,8 @@ OCP_WORKER_MACHINE_TYPE=m5.xlarge
 
 OCP_BASE_DOMAIN=psap.aws.rhperfscale.org
 
+ENABLE_AUTOSCALER=0
+
 # Shouldn't be the same than OCP worker nodes.
 
 SUTEST_COMPUTE_MACHINE_TYPE=m5.2xlarge
@@ -120,8 +122,13 @@ get_compute_node_count() {
     if [[ "$cluster_role" == "sutest" && "$SUTEST_FORCE_COMPUTE_NODES_COUNT" ]]; then
         echo "$SUTEST_FORCE_COMPUTE_NODES_COUNT"
         return
+
     elif [[ "$cluster_role" == "driver" && "$DRIVER_FORCE_COMPUTE_NODES_COUNT" ]]; then
         echo "$DRIVER_FORCE_COMPUTE_NODES_COUNT"
+        return
+
+    elif [[ "$cluster_role" == "sutest" && "$ENABLE_AUTOSCALER" ]]; then
+        echo 2
         return
     fi
 

--- a/testing/ods/osd_cluster.sh
+++ b/testing/ods/osd_cluster.sh
@@ -41,6 +41,13 @@ create_cluster() {
                      --compute_nodes="$compute_nodes_count" \
                      --version="$OSD_VERSION" \
                      --region="$OSD_REGION"
+
+    if [[ "$cluster_role" == "sutest" && "$ENABLE_AUTOSCALER" ]]; then
+        MACHINEPOOL_NAME=default
+
+        ocm edit machinepool "$MACHINEPOOL_NAME" --cluster "$cluster_name" \
+            --enable-autoscaling --min-replicas=2 --max-replicas=150
+    fi
 }
 
 destroy_cluster() {


### PR DESCRIPTION
Tested in https://github.com/openshift-psap/ci-artifacts/pull/406, but OSD scaling not working yet because of missing capabilities.

> Failed to create cluster: unable to create cluster: status is 400, identifier is '400', code is 'CLUSTERS-MGMT-400' and operation identifier is '917fc84f-bdd8-42b7-883a-c96858134146': Autoscaling is only allowed for clusters with the 'autoscale_clusters' capability

/cc @kpouget 