### PR TITLE
RHODS: minor updates

### DIFF
--- a/config/ansible.cfg
+++ b/config/ansible.cfg
@@ -15,8 +15,6 @@ nocows = True
 remote_user = root
 roles_path = roles/
 gathering = smart
-fact_caching = yaml
-fact_caching_timeout = 0
 callbacks_enabled = json_to_logfile, timer, profile_roles
 inventory_ignore_extensions = secrets.py, .pyc, .cfg, .crt, .ini
 # work around privilege escalation timeouts in ansible:

--- a/roles/rhods_test_jupyterlab/tasks/main.yml
+++ b/roles/rhods_test_jupyterlab/tasks/main.yml
@@ -244,12 +244,10 @@
 
 - name: Get the logs of the tester Pod
   shell: |
-    for container in artifacts-exporter ods-ci; do
-      oc logs {{ item }} \
-         -c "$container" \
+    oc logs {{ item }} \
+         -c ods-ci \
          -n {{ rhods_test_namespace }} \
-         > "{{ artifact_extra_logs_dir }}/tester_pod__$(basename "{{ item }}")__${container}.log";
-    done
+         > "{{ artifact_extra_logs_dir }}/tester_pod__$(basename "{{ item }}").log";
 
   loop: "{{ pod_names_cmd.stdout_lines }}"
   ignore_errors: yes

--- a/testing/ods/generate_matrix-benchmarking.sh
+++ b/testing/ods/generate_matrix-benchmarking.sh
@@ -55,8 +55,8 @@ _get_data_from_pr() {
         base_url="https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/openshift-psap_ci-artifacts/$PULL_NUMBER/pull-ci-openshift-psap-ci-artifacts-master-ods-jh-on-${cluster_type}"
 
         build=$(get_anchor_value "$MATBENCH_BUILD_ANCHOR")
-        if [[ -z "$matbench_build" ]]; then
-            build=$(curl --quiet -Ssf "${base_url}/latest-build.txt")
+        if [[ -z "$build" ]]; then
+            build=$(curl --silent -Ssf "${base_url}/latest-build.txt")
         fi
 
         matbench_url="${base_url}/${build}/artifacts/jh-on-${cluster_type}/test/artifacts/"
@@ -131,7 +131,7 @@ EOF
 }
 
 
-if [[ "$JOB_NAME_SAFE" == "ods-plot-jh-on-"* ]]; then
+if [[ "$JOB_NAME_SAFE" == "plot-jh-on-"* ]]; then
     set -o errexit
     set -o pipefail
     set -o nounset


### PR DESCRIPTION
* `config: ansible.cfg: disable Inventory caching`

See https://github.com/ansible/ansible/issues/78178#issuecomment-1175212485

This commit should avoid random crashes caused by running Ansible in
parallel, with a file-based cache plugin.

---

* `rhods_test_jupyterlab: capture only the ods-ci container logs`

This commit removes the collection of the 'artifacts-exporter'
container of the test Pod. The logs of this file are not so useful,
and they are available in the artifacts collected by the gather-extra
script of the cluster destruction post test step.

---
* `testing: ods: generate_matrix-benchmarking: fix crashes`

This commit fixes various code mistakes introduced by
https://github.com/openshift-psap/ci-artifacts/pull/373.

These two test commands are now functional:

* `/test ods-plot-jh-on-ocp` plots the last results of `/test ods-jh-on-ocp`
* `/test ods-plot-jh-on-osd` plots the last results of `/test ods-jh-on-osd`

---

Commits tested as part of https://github.com/openshift-psap/ci-artifacts/pull/404

/cc @fcami 