### PR TITLE
testing: ods: common: properly disable ENABLE_AUTOSCALER

### DIFF
--- a/testing/ods/common.sh
+++ b/testing/ods/common.sh
@@ -48,7 +48,8 @@ OCP_WORKER_MACHINE_TYPE=m5.xlarge
 
 OCP_BASE_DOMAIN=psap.aws.rhperfscale.org
 
-ENABLE_AUTOSCALER=0
+# if not empty, enables auto-scaling in the sutest cluster
+ENABLE_AUTOSCALER=
 
 # Shouldn't be the same than OCP worker nodes.
 


### PR DESCRIPTION
This PR properly disables the auto-scaler enablement.

The previous value (`0`) enabled the auto-scaling, so I added a
comment to make it clear that not-empty is enabled.

/cc @fcami 
/approve