### PR TITLE
RHODS: update the robot test

### DIFF
--- a/roles/rhods_test_jupyterlab/files/ods-ci/test-jupyterlab-psap-simplenotebook.robot
+++ b/roles/rhods_test_jupyterlab/files/ods-ci/test-jupyterlab-psap-simplenotebook.robot
@@ -75,13 +75,6 @@ Run the PSAP jh-at-scale Simple Notebook
   Should Not Match  ${output}  ERROR*
   Capture Page Screenshot
 
-Can Close Notebook when done
-  [Tags]  Notebook  End Sequence
-  Stop JupyterLab Notebook Server
-  # Capture Page Screenshot
-  # Go To  ${ODH_DASHBOARD_URL}
-  Capture Page Screenshot
-
 *** Keywords ***
 
 Begin and Authenticate

--- a/roles/rhods_test_jupyterlab/tasks/main.yml
+++ b/roles/rhods_test_jupyterlab/tasks/main.yml
@@ -301,6 +301,8 @@
     oc -n minio -c ubi8 exec "{{ minio_podname_cmd.stdout }}" \
        -- tar czf - -C /artifacts/to_export/ . \
        | tar xzf - -C "{{ artifact_extra_logs_dir }}"
+
+    rm -f "{{ artifact_extra_logs_dir }}/os-release"
   when: 'rhods_test_jupyterlab_artifacts_collected != "none"'
   ignore_errors: yes
 

--- a/testing/ods/generate_matrix-benchmarking.sh
+++ b/testing/ods/generate_matrix-benchmarking.sh
@@ -137,7 +137,7 @@ if [[ "$JOB_NAME_SAFE" == "plot-jh-on-"* ]]; then
     set -o nounset
     set -x
 
-    cluster_type=$1
+    cluster_type=${1:-ocp}
 
     results_dir="$MATBENCH_RESULTS_DIR/$MATBENCH_EXPE_NAME"
     mkdir -p "$results_dir"

--- a/toolbox/_common.py
+++ b/toolbox/_common.py
@@ -142,9 +142,6 @@ def run_ansible_role(role_name, opts: dict = dict()):
         except FileNotFoundError:
             pass # play file was removed, ignore
 
-        with open(artifact_extra_logs_dir / "exit_code", "w") as f:
-            print(f"{ret}", file=f)
-
         if ret != 0:
             with open(artifact_extra_logs_dir / "FAILURE", "w") as f:
                 print(f"{ret}", file=f)


### PR DESCRIPTION
* `toolbox: _common.py: do not generate artifact_extra_logs_dir/exit_code`

This file is redundant with FAILURE generated in case of failure.

---

* `rhods_test_jupyterlab: do not keep our canary file 'os-release' in the artifacts`

This file is added to the bucket to avoid it being empty and making
some copy fail because of it.

We do not want to keep it in the artifacts.

---

* `rhods_test_jupyterlab: robot test: refactor to use variables and do not call 'Begin/End Web Test'`

- Variables make a cleaner separation between configuration and
execution
- Being/End Web Test ROBOT keywords were doing things out of our view,
like connecting to RHODS/JupyterHub, and deleting the Notebook.

---

* `rhods_test_jupyterlab: robot test: remove the call to 'Can Close Notebook when done'`

We want to keep the notebook running after the robot test.
They are deleted by the rhods_test_jupyterlab ansible tasks.

---

/cc @fcami 