### PR TITLE
rhods_test_jupyterlab: Add test Pod startup delay

### DIFF
--- a/roles/rhods_test_jupyterlab/defaults/main/config.yml
+++ b/roles/rhods_test_jupyterlab/defaults/main/config.yml
@@ -5,6 +5,7 @@ rhods_test_jupyterlab_secret_properties:
 rhods_test_jupyterlab_idp_name:
 rhods_test_jupyterlab_sut_cluster_kubeconfig:
 rhods_test_jupyterlab_artifacts_collected: all
+rhods_test_jupyterlab_ods_sleep_factor: 1.0
 rhods_test_jupyterlab_ods_ci_exclude_tags: None
 rhods_test_jupyterlab_ods_ci_test_case: test-jupyterlab-psap-simplenotebook.robot
 

--- a/roles/rhods_test_jupyterlab/files/entrypoint.sh
+++ b/roles/rhods_test_jupyterlab/files/entrypoint.sh
@@ -46,6 +46,7 @@ cp "/mnt/rhods-jupyterlab-entrypoint/$RUN_ROBOT_TEST_CASE" .
 sleep_delay=$(python3 -c "print($JOB_COMPLETION_INDEX * $SLEEP_FACTOR)")
 
 echo "Waiting $sleep_delay seconds before starting (job index: $JOB_COMPLETION_INDEX, sleep factor: $SLEEP_FACTOR)"
+echo "$sleep_delay" > "${ARTIFACTS_DIR}/sleep_delay"
 sleep "$sleep_delay"
 
 # This isn't necessary for the testing, Keep it until

--- a/roles/rhods_test_jupyterlab/files/entrypoint.sh
+++ b/roles/rhods_test_jupyterlab/files/entrypoint.sh
@@ -5,6 +5,9 @@ set -o pipefail
 set -o nounset
 set -x
 
+JOB_COMPLETION_INDEX=${JOB_COMPLETION_INDEX:-1}
+SLEEP_WAIT_FACTOR=${SLEEP_WAIT_FACTOR:-1}
+
 do_oc_login() {
     export KUBECONFIG=/tmp/kube
 
@@ -35,9 +38,16 @@ mkdir -p "${ARTIFACTS_DIR}"
 
 trap "touch $ARTIFACTS_DIR/test.exit_code" EXIT
 
-sed "s/#{JOB_COMPLETION_INDEX}/${JOB_COMPLETION_INDEX:-1}/g" /mnt/ods-ci-test-variables/test-variables.yml > /tmp/test-variables.yml
+sed "s/#{JOB_COMPLETION_INDEX}/${JOB_COMPLETION_INDEX}/g" /mnt/ods-ci-test-variables/test-variables.yml > /tmp/test-variables.yml
 
 cp "/mnt/rhods-jupyterlab-entrypoint/$RUN_ROBOT_TEST_CASE" .
+
+# Sleep for a while to avoid DDoSing OAuth
+
+sleep_delay=$(python3 -c "print($JOB_COMPLETION_INDEX / $SLEEP_WAIT_FACTOR)")
+
+echo "Waiting $sleep_delay seconds before starting (job index: $JOB_COMPLETION_INDEX, sleep wait factor: $SLEEP_WAIT_FACTOR)"
+sleep "$sleep_delay"
 
 # This isn't necessary for the testing, Keep it until
 # `run_robot_test.sh` initialization stops complaining when we provide

--- a/roles/rhods_test_jupyterlab/files/entrypoint.sh
+++ b/roles/rhods_test_jupyterlab/files/entrypoint.sh
@@ -6,7 +6,6 @@ set -o nounset
 set -x
 
 JOB_COMPLETION_INDEX=${JOB_COMPLETION_INDEX:-1}
-SLEEP_WAIT_FACTOR=${SLEEP_WAIT_FACTOR:-1}
 
 do_oc_login() {
     export KUBECONFIG=/tmp/kube
@@ -44,9 +43,9 @@ cp "/mnt/rhods-jupyterlab-entrypoint/$RUN_ROBOT_TEST_CASE" .
 
 # Sleep for a while to avoid DDoSing OAuth
 
-sleep_delay=$(python3 -c "print($JOB_COMPLETION_INDEX / $SLEEP_WAIT_FACTOR)")
+sleep_delay=$(python3 -c "print($JOB_COMPLETION_INDEX * $SLEEP_FACTOR)")
 
-echo "Waiting $sleep_delay seconds before starting (job index: $JOB_COMPLETION_INDEX, sleep wait factor: $SLEEP_WAIT_FACTOR)"
+echo "Waiting $sleep_delay seconds before starting (job index: $JOB_COMPLETION_INDEX, sleep factor: $SLEEP_FACTOR)"
 sleep "$sleep_delay"
 
 # This isn't necessary for the testing, Keep it until

--- a/roles/rhods_test_jupyterlab/templates/rhods-ci.yaml
+++ b/roles/rhods_test_jupyterlab/templates/rhods-ci.yaml
@@ -45,6 +45,8 @@ spec:
           value: /mnt/shared-dir/ods-ci
         - name: RUN_ROBOT_EXCLUDE_TAGS
           value: "{{ rhods_test_jupyterlab_ods_ci_exclude_tags }}"
+        - name: SLEEP_FACTOR
+          value: "{{ rhods_test_jupyterlab_ods_sleep_factor }}"
         volumeMounts:
         - name: shared-dir
           mountPath: /mnt/shared-dir

--- a/testing/ods/common.sh
+++ b/testing/ods/common.sh
@@ -28,6 +28,7 @@ ODS_CI_NB_USERS=15
 ODS_CI_USER_PREFIX=testuser
 ODS_NOTEBOOK_SIZE=default # needs to match what the ROBOT test-case requests
 ODS_NOTEBOOK_SIZE_TEST_POD="test_pod" # shouldn't change
+ODS_SLEEP_FACTOR=1.0 # how long to wait between users.
 
 if [[ "$OSD_USE_ODS_CATALOG" == "0" ]]; then
     # deploying from the addon. Get the email address from the secret vault.

--- a/testing/ods/jh-at-scale.sh
+++ b/testing/ods/jh-at-scale.sh
@@ -211,7 +211,8 @@ run_multi_cluster() {
                      "$ODS_CI_USER_PREFIX" "$ODS_CI_NB_USERS" \
                      "$S3_LDAP_PROPS" \
                      --sut_cluster_kubeconfig="$KUBECONFIG_SUTEST" \
-                     --artifacts-collected=$collect
+                     --artifacts-collected=$collect \
+                     --ods_sleep_factor="$ODS_SLEEP_FACTOR"
 
     set +e # we do not wait to fail passed this point
 

--- a/toolbox/rhods.py
+++ b/toolbox/rhods.py
@@ -62,6 +62,7 @@ class RHODS:
     def test_jupyterlab(idp_name, username_prefix, user_count: int,
                         secret_properties_file, sut_cluster_kubeconfig="",
                         artifacts_collected="all",
+                        ods_sleep_factor="1.0",
                         ods_ci_exclude_tags="None",
                         ods_ci_test_case="test-jupyterlab-psap-simplenotebook.robot"):
         """
@@ -77,6 +78,7 @@ class RHODS:
            - 'no-image': exclude the images (.png) from the artifacts collected.
            - 'no-image-except-if-failed': exclude the images, except if the test failed.
            - 'none': do not collect any ODS-CI artifact.
+          ods_sleep_factor: Optional. Delay to sleep between users. Default 1.0.
           ods_ci_test_case: Optional. ODS-CI test case to execute.
           ods_ci_exclude_tags: Optional. Tags to exclude in the ODS-CI test case.
         """
@@ -88,6 +90,7 @@ class RHODS:
             "rhods_test_jupyterlab_secret_properties": secret_properties_file,
             "rhods_test_jupyterlab_sut_cluster_kubeconfig": sut_cluster_kubeconfig,
             "rhods_test_jupyterlab_artifacts_collected": artifacts_collected,
+            "rhods_test_jupyterlab_ods_sleep_factor": ods_sleep_factor,
             "rhods_test_jupyterlab_ods_ci_test_case": ods_ci_test_case,
             "rhods_test_jupyterlab_ods_ci_exclude_tags": ods_ci_exclude_tags,
         }


### PR DESCRIPTION
- Sleep for JOB_COMPLETION_INDEX*SLEEP_FACTOR seconds to avoid DDoSing Oauth.
- Un-hardcode SLEEP_FACTOR (time to wait in between users).
- Define rhods_test_jupyterlab_ods_sleep_factor from SLEEP_FACTOR.


- & sleepfactor: test 0.2