### PR TITLE
WIP: rhods_test_jupyterlab: set default notebook ram&cpu

### DIFF
--- a/roles/rhods_test_jupyterlab/defaults/main/config.yml
+++ b/roles/rhods_test_jupyterlab/defaults/main/config.yml
@@ -5,6 +5,8 @@ rhods_test_jupyterlab_secret_properties:
 rhods_test_jupyterlab_idp_name:
 rhods_test_jupyterlab_sut_cluster_kubeconfig:
 rhods_test_jupyterlab_artifacts_collected: all
+rhods_test_jupyterlab_notebook_memory:
+rhods_test_jupyterlab_notebook_cpu:
 rhods_test_jupyterlab_ods_sleep_factor: 1.0
 rhods_test_jupyterlab_ods_ci_exclude_tags: None
 rhods_test_jupyterlab_ods_ci_test_case: test-jupyterlab-run-notebook.robot

--- a/roles/rhods_test_jupyterlab/tasks/main.yml
+++ b/roles/rhods_test_jupyterlab/tasks/main.yml
@@ -168,6 +168,53 @@
     oc delete ev -n {{ rhods_test_namespace }} --all > /dev/null
   failed_when: false
 
+- name: Conditionally update the default notebook size
+  environment:
+    KUBECONFIG: '{{ sut_cluster_kubeconfig }}'
+  # AND logic is a design choice: allowing the test user to choose either
+  # RAM or CPU is a source of iterative errors (override CPU, then 2 days
+  # later override RAM thinking CPU is default, etc). 
+  when: (rhods_test_jupyterlab_notebook_cpu | length > 0 and
+            rhods_test_jupyterlab_notebook_memory | length > 0 )
+  block:
+    - name: Retrieve the configmap containing the default notebook size
+      shell:
+        oc get configmap -ojson -n redhat-ods-applications odh-jupyterhub-global-profile 
+          > {{ artifact_extra_logs_dir }}/jh_global_profile.json
+
+    - name: Update default config to ours
+      command:
+        cp {{ artifact_extra_logs_dir }}/jh_global_profile.json
+          {{ artifact_extra_logs_dir }}/jh_global_profile-ours.json
+
+    - name: Update default notebook cpu size in the cm file
+      command:
+        jq -i '.cpu="{{ rhods_test_jupyterlab_notebook_cpu }}"' 
+          {{ artifact_extra_logs_dir }}/jh_global_profile-ours.json
+
+    - name: Update default notebook memory size in the cm file
+      command:
+        jq -i '.memory="{{ rhods_test_jupyterlab_notebook_memory }}Gi"' 
+          {{ artifact_extra_logs_dir }}/jh_global_profile-ours.json
+
+    - name: Check if the cm backup already exists
+      command:
+        oc get cm -n redhat-ods-applications odh-jupyterhub-global-profile-orig
+      failed_when: false
+      register: has_backup_cmd
+  
+    - name: Create a new config map with orig values for backup purposes
+      when: has_backup_cmd.rc != 0
+      shell:
+        cat {{ artifact_extra_logs_dir }}/jh_global_profile.json |
+          jq '.metadata.name="odh-jupyterhub-global-profile-orig"' |
+          oc apply -f-
+      failed_when: false
+
+    - name: Upload the updated cm to change the default notebook size
+      command:
+        oc apply -f {{ artifact_extra_logs_dir }}/jh_global_profile-ours.json
+
 - name: Delete the events, pods and PVC of the notebook namespace
   environment:
     KUBECONFIG: '{{ sut_cluster_kubeconfig }}'

--- a/testing/ods/common.sh
+++ b/testing/ods/common.sh
@@ -31,8 +31,8 @@ ODS_CI_USER_PREFIX=psapuser
 ODS_NOTEBOOK_SIZE=default # needs to match what the ROBOT test-case requests
 ODS_NOTEBOOK_SIZE_TEST_POD="test_pod" # shouldn't change
 ODS_SLEEP_FACTOR=1.0 # how long to wait between users.
-ODS_NOTEBOOK_RAM= # how much default RAM notebooks should have. Syntax: 4.0
-ODS_NOTEBOOK_CPU= # how many CPU cores notebooks should have. Syntax: 1.0
+ODS_NOTEBOOK_RAM=4.0 # how much default RAM notebooks should have. Syntax: 4.0
+ODS_NOTEBOOK_CPU=1.0 # how many CPU cores notebooks should have. Syntax: 1.0
 
 [ "$ODS_NOTEBOOK_CPU" ] && sed -i '/^default,/s/cpu=[^,]*/cpu=${ODS_NOTEBOOK_CPU}/g' testing/ods/sizing/notebook_sizes
 [ "$ODS_NOTEBOOK_RAM" ] && sed -i '/^default,/s/memory=[^,]*/memory=${ODS_NOTEBOOK_RAM}/g' testing/ods/sizing/notebook_sizes

--- a/testing/ods/common.sh
+++ b/testing/ods/common.sh
@@ -31,6 +31,9 @@ ODS_CI_USER_PREFIX=psapuser
 ODS_NOTEBOOK_SIZE=default # needs to match what the ROBOT test-case requests
 ODS_NOTEBOOK_SIZE_TEST_POD="test_pod" # shouldn't change
 ODS_SLEEP_FACTOR=1.0 # how long to wait between users.
+ODS_NOTEBOOK_RAM=4.0 # how much default RAM notebooks should have
+ODS_NOTEBOOK_CPU=1.0 # how many CPU cores notebooks should have
+
 
 NGINX_NOTEBOOK_NAMESPACE=loadtest-notebooks
 ODS_NOTEBOOK_NAME=simple-notebook.ipynb

--- a/testing/ods/common.sh
+++ b/testing/ods/common.sh
@@ -34,6 +34,8 @@ ODS_SLEEP_FACTOR=1.0 # how long to wait between users.
 ODS_NOTEBOOK_RAM= # how much default RAM notebooks should have. Syntax: 4.0
 ODS_NOTEBOOK_CPU= # how many CPU cores notebooks should have. Syntax: 1.0
 
+[ "$ODS_NOTEBOOK_CPU" ] && sed -i '/^default,/s/cpu=[^,]*/cpu=${ODS_NOTEBOOK_CPU}/g' testing/ods/sizing/notebook_sizes
+[ "$ODS_NOTEBOOK_RAM" ] && sed -i '/^default,/s/memory=[^,]*/memory=${ODS_NOTEBOOK_RAM}/g' testing/ods/sizing/notebook_sizes
 
 NGINX_NOTEBOOK_NAMESPACE=loadtest-notebooks
 ODS_NOTEBOOK_NAME=simple-notebook.ipynb

--- a/testing/ods/common.sh
+++ b/testing/ods/common.sh
@@ -31,8 +31,8 @@ ODS_CI_USER_PREFIX=psapuser
 ODS_NOTEBOOK_SIZE=default # needs to match what the ROBOT test-case requests
 ODS_NOTEBOOK_SIZE_TEST_POD="test_pod" # shouldn't change
 ODS_SLEEP_FACTOR=1.0 # how long to wait between users.
-ODS_NOTEBOOK_RAM=4.0 # how much default RAM notebooks should have
-ODS_NOTEBOOK_CPU=1.0 # how many CPU cores notebooks should have
+ODS_NOTEBOOK_RAM= # how much default RAM notebooks should have. Syntax: 4.0
+ODS_NOTEBOOK_CPU= # how many CPU cores notebooks should have. Syntax: 1.0
 
 
 NGINX_NOTEBOOK_NAMESPACE=loadtest-notebooks

--- a/testing/ods/jh-at-scale.sh
+++ b/testing/ods/jh-at-scale.sh
@@ -226,7 +226,8 @@ run_jupyterlab_test() {
                      --sut_cluster_kubeconfig="$KUBECONFIG_SUTEST" \
                      --artifacts-collected="$ARTIFACTS_COLLECTED" \
                      --ods_sleep_factor="$ODS_SLEEP_FACTOR" \
-                     --ods_ci_exclude_tags="$ODS_EXCLUDE_TAGS"
+                     --notebook_memory="$ODS_NOTEBOOK_RAM" \
+                     --notebook_cpu="$ODS_NOTEBOOK_CPU"
 
     # quick access to these files
     cp "$ARTIFACT_DIR"/*__driver_rhods__test_jupyterlab/{failed_tests,success_count} "$ARTIFACT_DIR" || true

--- a/toolbox/rhods.py
+++ b/toolbox/rhods.py
@@ -66,7 +66,9 @@ class RHODS:
                         artifacts_collected="all",
                         ods_sleep_factor="1.0",
                         ods_ci_exclude_tags="None",
-                        ods_ci_test_case="test-jupyterlab-run-notebook.robot"):
+                        ods_ci_test_case="test-jupyterlab-run-notebook.robot",
+                        notebook_cpu="",
+                        notebook_memory=""):
         """
         Test RHODS JupyterLab notebooks
 
@@ -85,6 +87,8 @@ class RHODS:
           ods_sleep_factor: Optional. Delay to sleep between users. Default 1.0.
           ods_ci_test_case: Optional. ODS-CI test case to execute.
           ods_ci_exclude_tags: Optional. Tags to exclude in the ODS-CI test case.
+          notebook_cpu: Optional. Number of cores to request for the notebook. The default is in odh-jupyterhub-global-profile.
+          notebook_memory: Optional. Amount of memory to request for the notebook. The default is in odh-jupyterhub-global-profile.
         """
 
         opts = {
@@ -98,6 +102,8 @@ class RHODS:
             "rhods_test_jupyterlab_ods_sleep_factor": ods_sleep_factor,
             "rhods_test_jupyterlab_ods_ci_test_case": ods_ci_test_case,
             "rhods_test_jupyterlab_ods_ci_exclude_tags": ods_ci_exclude_tags,
+            "rhods_test_jupyterlab_notebook_cpu": notebook_cpu,
+            "rhods_test_jupyterlab_notebook_memory": notebook_memory
         }
 
         ARTIFACTS_COLLECTED_VALUES = ("all", "none", "no-image", "no-image-except-failed", "no-image-except-failed-and-zero")
@@ -105,6 +111,9 @@ class RHODS:
             print(f"ERROR: invalid value '{artifacts_collected}' for 'artifacts_collected'. Must be one of {', '.join(ARTIFACTS_COLLECTED_VALUES)}")
             sys.exit(1)
 
+        if (notebook_memory and not notebook_cpu) or (notebook_cpu and not notebook_memory):
+            print(f"ERROR: either specify notebook_cpu ({notebook_cpu}) and notebook_memory ({notebook_memory}) or neither of these.")
+            sys.exit(1)
 
         return RunAnsibleRole("rhods_test_jupyterlab", opts)
 


### PR DESCRIPTION
RHODS has a default profile (odh-jupyterhub-global-profile)
which sets the default notebook size to use.
Due to a [RHODS bug](https://issues.redhat.com/browse/RHODS-1882), it is more reliable to set CPU & RAM request
by changing the default profile rather than selecting another
profile.
