### PR TITLE
rhods_test_jupyterlab: only remove our testusers objects

### DIFF
--- a/roles/rhods_test_jupyterlab/tasks/main.yml
+++ b/roles/rhods_test_jupyterlab/tasks/main.yml
@@ -179,19 +179,11 @@
 - name: Delete the events, pods and PVC of the notebook namespace
   environment:
     KUBECONFIG: '{{ sut_cluster_kubeconfig }}'
-  command: |
-    oc get pods -o wide -n {{ rhods_notebook_namespace }} | \
-      grep -i -E {{ rhods_test_jupyterlab_username_prefix }} | \
-      awk '{print $1}' | \
-      xargs oc delete pod
-    oc get pvc -o wide -n {{ rhods_notebook_namespace }} | \
-      grep -i -E {{ rhods_test_jupyterlab_username_prefix }} | \
-      awk '{print $1}' | \
-      xargs oc delete pvc
-    oc get ev -o wide -n {{ rhods_notebook_namespace }} | \
-      grep -i -E {{ rhods_test_jupyterlab_username_prefix }} | \
-      awk '{print $1}' | \
-      xargs oc delete ev
+  shell:
+    set -o pipefail;
+    oc get pods,pvc,ev -oname -n {{ rhods_notebook_namespace }} | \
+      grep {{ rhods_test_jupyterlab_username_prefix }} | \
+      xargs oc delete pod -n {{ rhods_notebook_namespace }}
   failed_when: false
 
 - name: Name the namespace privileged
@@ -255,15 +247,11 @@
 
 - name: Cleanup the notebooks Pods and PVCs
   # (the Pods are destroyed anyway when the ods-ci test succeeds)
-  shell: |
-    oc get pods -o wide -n {{ rhods_notebook_namespace }} | \
-      grep -i -E {{ rhods_test_jupyterlab_username_prefix }} | \
-      awk '{print $1}' | \
-      xargs oc delete pod
-    oc get pvc -o wide -n {{ rhods_notebook_namespace }} | \
-      grep -i -E {{ rhods_test_jupyterlab_username_prefix }} | \
-      awk '{print $1}' | \
-      xargs oc delete pvc
+  shell:
+    set -o pipefail;
+    oc get pods,pvc -oname -n {{ rhods_notebook_namespace }} |
+      grep {{ rhods_test_jupyterlab_username_prefix }} |
+      xargs oc delete -n  {{ rhods_notebook_namespace }}
   environment:
     KUBECONFIG: '{{ sut_cluster_kubeconfig }}'
   ignore_errors: yes

--- a/roles/rhods_test_jupyterlab/tasks/main.yml
+++ b/roles/rhods_test_jupyterlab/tasks/main.yml
@@ -180,9 +180,18 @@
   environment:
     KUBECONFIG: '{{ sut_cluster_kubeconfig }}'
   command: |
-    oc delete pod --all -n  {{ rhods_notebook_namespace }}
-    oc delete pvc --all -n {{ rhods_notebook_namespace }}
-    oc delete ev --all -n {{ rhods_notebook_namespace }}
+    oc get pods -o wide -n {{ rhods_notebook_namespace }} | \
+      grep -i -E {{ rhods_test_jupyterlab_username_prefix }} | \
+      awk '{print $1}' | \
+      xargs oc delete pod
+    oc get pvc -o wide -n {{ rhods_notebook_namespace }} | \
+      grep -i -E {{ rhods_test_jupyterlab_username_prefix }} | \
+      awk '{print $1}' | \
+      xargs oc delete pvc
+    oc get ev -o wide -n {{ rhods_notebook_namespace }} | \
+      grep -i -E {{ rhods_test_jupyterlab_username_prefix }} | \
+      awk '{print $1}' | \
+      xargs oc delete ev
   failed_when: false
 
 - name: Name the namespace privileged
@@ -247,8 +256,14 @@
 - name: Cleanup the notebooks Pods and PVCs
   # (the Pods are destroyed anyway when the ods-ci test succeeds)
   shell: |
-    oc delete pod --all -n {{ rhods_notebook_namespace }}
-    oc delete pvc --all -n {{ rhods_notebook_namespace }}
+    oc get pods -o wide -n {{ rhods_notebook_namespace }} | \
+      grep -i -E {{ rhods_test_jupyterlab_username_prefix }} | \
+      awk '{print $1}' | \
+      xargs oc delete pod
+    oc get pvc -o wide -n {{ rhods_notebook_namespace }} | \
+      grep -i -E {{ rhods_test_jupyterlab_username_prefix }} | \
+      awk '{print $1}' | \
+      xargs oc delete pvc
   environment:
     KUBECONFIG: '{{ sut_cluster_kubeconfig }}'
   ignore_errors: yes


### PR DESCRIPTION
Previously, all pods, pvcs, and events were cleaned from the rhods
notebook namespace.
Attempt to remove only objects created for our test users.

Signed-off-by: François Cami <fcami@redhat.com>