### PR TITLE
testing: ods: testuser => psap_user

### DIFF
--- a/testing/ods/common.sh
+++ b/testing/ods/common.sh
@@ -25,7 +25,7 @@ ODS_CI_IMAGESTREAM="ods-ci"
 ODS_CI_TAG="latest"
 
 ODS_CI_NB_USERS=15
-ODS_CI_USER_PREFIX=testuser
+ODS_CI_USER_PREFIX=psap_user
 ODS_NOTEBOOK_SIZE=default # needs to match what the ROBOT test-case requests
 ODS_NOTEBOOK_SIZE_TEST_POD="test_pod" # shouldn't change
 ODS_SLEEP_FACTOR=1.0 # how long to wait between users.


### PR DESCRIPTION
Change the default user prefix from testuser to psap_user.
testuser is too generic and using it might result in collisions
when scale-testing production or PoC clusters.

Signed-off-by: François Cami <fcami@redhat.com>