### PR TITLE
testing: ods: jh-at-scale: reorganize run_multi_cluster to ease reuse

### DIFF
--- a/testing/ods/common.sh
+++ b/testing/ods/common.sh
@@ -104,7 +104,7 @@ ocm_cluster_is_ready() {
 get_osd_cluster_name() {
     cluster_role=$1
 
-    cat "$SHARED_DIR/osd_${cluster_role}_cluster_name" 2>/dev/null || true
+    cat "${SHARED_DIR:-}/osd_${cluster_role}_cluster_name" 2>/dev/null || true
 }
 
 get_notebook_size() {


### PR DESCRIPTION
* `testing: ods: jh-at-scale: reorganize run_multi_cluster to ease reuse`


---

* `rhods_test_jupyterlab: better catch errors in 'Spawn a Notebook'`

Avoid false-positives in this test, by trying to run something in the
notebook after the spawn.

---

/cc @kpouget 