### PR TITLE
testing: ods: common: use sizing script by default for the node count

### DIFF
--- a/testing/ods/common.sh
+++ b/testing/ods/common.sh
@@ -61,8 +61,8 @@ ENABLE_AUTOSCALER=
 SUTEST_COMPUTE_MACHINE_TYPE=m5.2xlarge
 DRIVER_COMPUTE_MACHINE_TYPE=m5.2xlarge
 
-SUTEST_FORCE_COMPUTE_NODES_COUNT=2 # if empty, uses ods/sizing/sizing to determine the right number of machines
-DRIVER_FORCE_COMPUTE_NODES_COUNT=0 # if empty, uses ods/sizing/sizing to determine the right number of machines
+SUTEST_FORCE_COMPUTE_NODES_COUNT= # if empty, uses ods/sizing/sizing to determine the right number of machines
+DRIVER_FORCE_COMPUTE_NODES_COUNT= # if empty, uses ods/sizing/sizing to determine the right number of machines
 
 # OSP/OSD cluster naming is handled differently in this job
 JOB_NAME_SAFE_GET_CLUSTER="get-cluster"


### PR DESCRIPTION
The regression was introduced in this commit: https://github.com/openshift-psap/ci-artifacts/pull/425/commits/3d58f3241c15fdd00a030187a7309a9994442122

/cc @kpouget 