### PR TITLE
testing: ods: common: use psapuser as username prefix

### DIFF
--- a/testing/ods/common.sh
+++ b/testing/ods/common.sh
@@ -25,7 +25,7 @@ ODS_CI_IMAGESTREAM="ods-ci"
 ODS_CI_TAG="latest"
 
 ODS_CI_NB_USERS=5
-ODS_CI_USER_PREFIX=psap_user
+ODS_CI_USER_PREFIX=psapuser
 ODS_NOTEBOOK_SIZE=default # needs to match what the ROBOT test-case requests
 ODS_NOTEBOOK_SIZE_TEST_POD="test_pod" # shouldn't change
 ODS_SLEEP_FACTOR=1.0 # how long to wait between users.


### PR DESCRIPTION
The `_` is a special character for naming K8s resources, so RHODS
rewrites it into `-5f`. Better stay without special characters.

/cc @fcami FYI