### PR TITLE
RHODS: cluster_undeploy_ldap: also undeploy on osd/rosa 

### DIFF
--- a/roles/cluster_undeploy_ldap/defaults/main/config.yml
+++ b/roles/cluster_undeploy_ldap/defaults/main/config.yml
@@ -1,0 +1,3 @@
+cluster_undeploy_ldap_idp_name: ""
+cluster_undeploy_ldap_use_ocm: ""
+cluster_undeploy_ldap_use_rosa: ""

--- a/roles/cluster_undeploy_ldap/tasks/main.yml
+++ b/roles/cluster_undeploy_ldap/tasks/main.yml
@@ -19,6 +19,9 @@
     mode: 0400
 
 - name: Delete the LDAP Oauth resource
+  when:
+  - not cluster_undeploy_ldap_use_rosa
+  - not cluster_undeploy_ldap_use_ocm
   shell:
     set -o pipefail;
     oc get -f "{{ artifact_extra_logs_dir }}/001_oauth_ldap.yml" -ojson | jq 'del(.spec.identityProviders)' | oc apply -f-
@@ -26,3 +29,19 @@
 - name: Delete the ldap namespace
   command:
     oc delete namespace openldap --ignore-not-found
+
+- name: Undeploy on ROSA
+  when: cluster_undeploy_ldap_use_rosa | length > 0
+  block:
+  - name: Delete the IDP resource
+    command:
+      rosa delete idp "{{ cluster_undeploy_ldap_idp_name }}"
+          --cluster "{{ cluster_undeploy_ldap_use_rosa }}"
+
+- name: Undeploy on OCM
+  when: cluster_undeploy_ldap_use_ocm | length > 0
+  block:
+  - name: Delete the IDP resource
+    command:
+      ocm delete idp "{{ cluster_undeploy_ldap_idp_name }}"
+          --cluster "{{ cluster_undeploy_ldap_use_ocm }}"

--- a/toolbox/cluster.py
+++ b/toolbox/cluster.py
@@ -329,12 +329,23 @@ class Cluster:
         return RunAnsibleRole("cluster_deploy_ldap", opts)
 
     @staticmethod
-    def undeploy_ldap():
+    def undeploy_ldap(idp_name, use_ocm="", use_rosa=""):
         """
         Undeploy OpenLDAP and LDAP Oauth
+
+        Args:
+          idp_name: Name of the LDAP identity provider.
+          use_ocm: Optional. If set with a cluster name, use `ocm delete idp` to delete the LDAP identity provider.
+          use_rosa: Optional. If set with a cluster name, use `rosa delete idp` to delete the LDAP identity provider.
         """
 
-        return RunAnsibleRole("cluster_undeploy_ldap")
+        opts = {
+            "cluster_deploy_ldap_idp_name": idp_name,
+            "cluster_deploy_ldap_use_ocm": use_ocm,
+            "cluster_deploy_ldap_use_rosa": use_rosa,
+        }
+
+        return RunAnsibleRole("cluster_undeploy_ldap", opts)
 
     @staticmethod
     def preload_image(name, image, namespace="default"):


### PR DESCRIPTION
* `cluster_undeploy_ldap: also undeploy on osd/rosa`

The role `cluster_undeploy_ldap` was only undeploying the LDAP setup
in OCP, and not in OSD/ROSA.

This commit fixes this missing point.

---

* `testing: ods: jh-at-scale: undeploy LDAP after testing`

Until now, the LDAP authentication was not undeployed in the CI
testing.

This commit fixes that, so that the SUTest cluster is left in a
cleaner state.

---