### PR TITLE
rhods_test_jupyterlab: fix call to 'Suite Teardown  Tear Down'

### DIFF
--- a/roles/rhods_test_jupyterlab/files/ods-ci/test-jupyterlab-run-notebook.robot
+++ b/roles/rhods_test_jupyterlab/files/ods-ci/test-jupyterlab-run-notebook.robot
@@ -7,7 +7,7 @@ Library             DebugLibrary
 Library             JupyterLibrary
 Library             libs/Helpers.py
 
-Suite Teardown Tear Down
+Suite Teardown  Tear Down
 
 *** Variables ***
 


### PR DESCRIPTION
Testing was broken because of the missing (double) space ...

/cc @kpouget 