### PR TITLE
RHODS: various updates

### DIFF
--- a/roles/cluster_create_osd/tasks/main.yml
+++ b/roles/cluster_create_osd/tasks/main.yml
@@ -121,7 +121,7 @@
     ocm edit machinepool
              {{ cluster_create_osd_machinepool_name }}
              --cluster={{ cluster_create_osd_cluster_name }}
-             --replicas={{ cluster_create_osd_compute_nodes }}
+             --replicas={{ [2, cluster_create_osd_compute_nodes|int] |max }}
 
 - name: Wait for the desired worker node count
   shell: |
@@ -130,7 +130,7 @@
     echo "$nodes" | nl 1>&2 # for observation
     node_count=$(echo "$nodes" | grep "Ready" | wc -l)
     echo "$node_count nodes are ready"
-    test "$node_count" == "{{ cluster_create_osd_compute_nodes }}"
+    test "$node_count" -ge "{{ cluster_create_osd_compute_nodes }}"
   register: osd_node_count
   delay: 30
   retries: 40

--- a/roles/rhods_test_jupyterlab/files/entrypoint.sh
+++ b/roles/rhods_test_jupyterlab/files/entrypoint.sh
@@ -35,6 +35,7 @@ test_exit_code=0
     --test-artifact-dir "$ARTIFACTS_DIR" \
     --test-case "$RUN_ROBOT_TEST_CASE" \
     --exclude "$RUN_ROBOT_EXCLUDE_TAGS" \
+    --extra-robot-args "--exitonfailure" \
     |& tee "${ARTIFACTS_DIR}/test.log") || test_exit_code=$?
 
 # /!\ the creation of this file triggers the export of the logs

--- a/roles/rhods_test_jupyterlab/files/entrypoint.sh
+++ b/roles/rhods_test_jupyterlab/files/entrypoint.sh
@@ -7,13 +7,13 @@ set -x
 
 JOB_COMPLETION_INDEX=${JOB_COMPLETION_INDEX:-1}
 
-if [[ -z "{ARTIFACTS_DIR:-}" ]]; then
-    ARTIFACTS_DIR=/tmp/ods-ci
+if [[ -z "{ARTIFACT_DIR:-}" ]]; then
+    ARTIFACT_DIR=/tmp/ods-ci
 fi
 
-mkdir -p "${ARTIFACTS_DIR}"
+mkdir -p "${ARTIFACT_DIR}"
 
-trap "touch $ARTIFACTS_DIR/test.exit_code" EXIT
+trap "touch $ARTIFACT_DIR/test.exit_code" EXIT
 
 sed "s/#{JOB_COMPLETION_INDEX}/${JOB_COMPLETION_INDEX}/g" /mnt/ods-ci-test-variables/test-variables.yml > /tmp/test-variables.yml
 
@@ -24,7 +24,7 @@ cp "/mnt/rhods-jupyterlab-entrypoint/$RUN_ROBOT_TEST_CASE" .
 sleep_delay=$(python3 -c "print($JOB_COMPLETION_INDEX * $SLEEP_FACTOR)")
 
 echo "Waiting $sleep_delay seconds before starting (job index: $JOB_COMPLETION_INDEX, sleep factor: $SLEEP_FACTOR)"
-echo "$sleep_delay" > "${ARTIFACTS_DIR}/sleep_delay"
+echo "$sleep_delay" > "${ARTIFACT_DIR}/sleep_delay"
 sleep "$sleep_delay"
 
 test_exit_code=0
@@ -32,14 +32,14 @@ test_exit_code=0
     --skip-pip-install \
     --test-variables-file /tmp/test-variables.yml \
     --skip-oclogin true \
-    --test-artifact-dir "$ARTIFACTS_DIR" \
+    --test-artifact-dir "$ARTIFACT_DIR" \
     --test-case "$RUN_ROBOT_TEST_CASE" \
     --exclude "$RUN_ROBOT_EXCLUDE_TAGS" \
     --extra-robot-args "--exitonfailure" \
-    |& tee "${ARTIFACTS_DIR}/test.log") || test_exit_code=$?
+    |& tee "${ARTIFACT_DIR}/test.log") || test_exit_code=$?
 
 # /!\ the creation of this file triggers the export of the logs
-echo "$test_exit_code" > "${ARTIFACTS_DIR}/test.exit_code"
+echo "$test_exit_code" > "${ARTIFACT_DIR}/test.exit_code"
 
 echo "Test finished with $test_exit_code errors."
 

--- a/roles/rhods_test_jupyterlab/files/ods-ci/test-jupyterlab-run-notebook.robot
+++ b/roles/rhods_test_jupyterlab/files/ods-ci/test-jupyterlab-run-notebook.robot
@@ -13,7 +13,7 @@ Suite Teardown  Tear Down
 
 ${NOTEBOOK_IMAGE_NAME}         s2i-minimal-notebook
 ${NOTEBOOK_IMAGE_SIZE}         Default
-${NOTEBOOK_SPAWN_WAIT_TIME}    5 minutes
+${NOTEBOOK_SPAWN_WAIT_TIME}    15 minutes
 ${NOTEBOOK_SPAWN_RETRIES}      15
 
 ${NOTEBOOK_URL}                %{NOTEBOOK_URL}

--- a/roles/rhods_test_jupyterlab/files/ods-ci/test-jupyterlab-run-notebook.robot
+++ b/roles/rhods_test_jupyterlab/files/ods-ci/test-jupyterlab-run-notebook.robot
@@ -14,6 +14,7 @@ Suite Teardown  Tear Down
 ${NOTEBOOK_IMAGE_NAME}         s2i-minimal-notebook
 ${NOTEBOOK_IMAGE_SIZE}         Default
 ${NOTEBOOK_SPAWN_WAIT_TIME}    5 minutes
+${NOTEBOOK_SPAWN_RETRIES}      15
 
 ${NOTEBOOK_URL}                %{NOTEBOOK_URL}
 ${NOTEBOOK_NAME}               notebook.ipynb
@@ -59,7 +60,7 @@ Spawn a Notebook
   [Tags]  Spawn  Notebook
 
   Fix Spawner Status
-  Spawn Notebook With Arguments  image=${NOTEBOOK_IMAGE_NAME}  size=${NOTEBOOK_IMAGE_SIZE}  spawner_timeout=${NOTEBOOK_SPAWN_WAIT_TIME}
+  Spawn Notebook With Arguments  image=${NOTEBOOK_IMAGE_NAME}  size=${NOTEBOOK_IMAGE_SIZE}  spawner_timeout=${NOTEBOOK_SPAWN_WAIT_TIME}  retries=${NOTEBOOK_SPAWN_RETRIES}
   Capture Page Screenshot
 
   ${is_launcher_selected} =  Run Keyword And Return Status  JupyterLab Launcher Tab Is Selected

--- a/roles/rhods_test_jupyterlab/files/s3-artifacts-exporter.sh
+++ b/roles/rhods_test_jupyterlab/files/s3-artifacts-exporter.sh
@@ -35,17 +35,17 @@ chmod +x /usr/bin/yq
 
 set +x
 
-echo "$(date) Waiting for '${ARTIFACTS_DIR}/test.exit_code' to appear ..."
+echo "$(date) Waiting for '${ARTIFACT_DIR}/test.exit_code' to appear ..."
 
-while ! [[ -f "${ARTIFACTS_DIR}/test.exit_code" ]]; do
+while ! [[ -f "${ARTIFACT_DIR}/test.exit_code" ]]; do
     sleep 15
 done
 
-echo "$(date) '${ARTIFACTS_DIR}/test.exit_code' appeared."
+echo "$(date) '${ARTIFACT_DIR}/test.exit_code' appeared."
 
 set -x
 
-test_failed=$(cat ${ARTIFACTS_DIR}/test.exit_code)
+test_failed=$(cat ${ARTIFACT_DIR}/test.exit_code)
 
 delete_image=0
 [[ "$ARTIFACTS_COLLECTED" == "no-image" ]] && delete_image=1
@@ -53,15 +53,15 @@ delete_image=0
 [[ "$ARTIFACTS_COLLECTED" == "no-image-except-failed-and-zero" && "${JOB_COMPLETION_INDEX:-0}" == 0 ]] && delete_image=0
 
 if [[ "$delete_image" == 1 ]]; then
-    find "${ARTIFACTS_DIR}" -name '*.png' -delete > dev/null
+    find "${ARTIFACT_DIR}" -name '*.png' -delete > dev/null
 fi
 
 configure_s3
 
 s3cmd put \
-      "${ARTIFACTS_DIR}/test.exit_code" \
-      "${ARTIFACTS_DIR}/test.log" \
-      "${ARTIFACTS_DIR}"/ods-ci-*/* \
+      "${ARTIFACT_DIR}/test.exit_code" \
+      "${ARTIFACT_DIR}/test.log" \
+      "${ARTIFACT_DIR}"/ods-ci-*/* \
       "s3://$S3_BUCKET_NAME/ods-ci/$HOSTNAME/" \
       --recursive --no-preserve --no-progress --stats
 

--- a/roles/rhods_test_jupyterlab/templates/rhods-ci.yaml
+++ b/roles/rhods_test_jupyterlab/templates/rhods-ci.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: RUN_ROBOT_TEST_CASE
           value: "{{ rhods_test_jupyterlab_ods_ci_test_case }}"
-        - name: ARTIFACTS_DIR
+        - name: ARTIFACT_DIR
           value: /mnt/shared-dir/ods-ci
         - name: RUN_ROBOT_EXCLUDE_TAGS
           value: "{{ rhods_test_jupyterlab_ods_ci_exclude_tags }}"
@@ -69,7 +69,7 @@ spec:
         env:
         - name: ARTIFACTS_COLLECTED
           value: "{{ rhods_test_jupyterlab_artifacts_collected }}"
-        - name: ARTIFACTS_DIR
+        - name: ARTIFACT_DIR
           value: /mnt/shared-dir/ods-ci
         securityContext:
           privileged: true

--- a/testing/ods/generate_matrix-benchmarking.sh
+++ b/testing/ods/generate_matrix-benchmarking.sh
@@ -86,8 +86,15 @@ _download_data_from_url() {
 }
 
 _prepare_data_from_artifacts_dir() {
+    artifact_dir=$1
+
+    if ! ls "$artifact_dir"/*__driver_rhods__test_jupyterlab -d >/dev/null 2>&1; then
+        echo "FATAL: No result available, aborting."
+        exit 1
+    fi
+
     mkdir -p "$MATBENCH_RESULTS_DIR"
-    ln -s "$ARTIFACT_DIR" "$MATBENCH_RESULTS_DIR/$MATBENCH_EXPE_NAME"
+    ln -s "$artifact_dir" "$MATBENCH_RESULTS_DIR/$MATBENCH_EXPE_NAME"
 }
 
 generate_matbench::get_prometheus() {
@@ -150,11 +157,7 @@ if [[ "$JOB_NAME_SAFE" == "jh-on-"* ]]; then
 
     cluster_type=$(echo "$JOB_NAME_SAFE" | cut -d- -f3 )
 
-    if ! ls "$ARTIFACT_DIR"/*__driver_rhods__test_jupyterlab -d >/dev/null 2>&1; then
-        echo "WARNING: No result available, aborting."
-        exit 1
-    fi
-    _prepare_data_from_artifacts_dir
+    _prepare_data_from_artifacts_dir "$ARTIFACT_DIR/.."
 
     generate_matbench::get_prometheus
     generate_matbench::get_matrix_benchmarking

--- a/toolbox/cluster.py
+++ b/toolbox/cluster.py
@@ -263,6 +263,7 @@ class Cluster:
           cluster_name: The name to give to the cluster.
           secret_file: The file containing the cluster creation credentials.
           kubeconfig: The KUBECONFIG file to populate with the access to the cluster.
+          compute_nodes: The number of compute nodes to create. A minimum of 2 is required by OSD.
         """
 
         opts = dict(


### PR DESCRIPTION
* `testing: ods: generate_matrix-benchmarking: use the right ARTIFACTS_DIR`


---

* `rhods_test_jupyterlab: retry 15 times to spawn the notebook`


---

* `cluster_create_osd: set a minimum of 2 replicas for the machinepool`

With 1, OCM will complain.

---

* `rhods_test_jupyterlab: set NOTEBOOK_SPAWN_WAIT_TIME = 15 minutes`


---

* `rhods_test_jupyterlab: entrypoint: pass --exitonfailure to the Robot`

With this flag, no more test cases are executed after one failed.

---

* `rhods_test_jupyterlab: s/ARTIFACT_DIR/ARTIFACTS_DIR/ to be consistent with OpenShift CI env variable`


---