### PR TITLE
RHODS: wait for RHODS images to be loaded and look up in the cluster the image tag to preload

### DIFF
--- a/roles/rhods_wait_ods/defaults/main/config.yml
+++ b/roles/rhods_wait_ods/defaults/main/config.yml
@@ -1,0 +1,3 @@
+---
+# comma separated list of RHODS images to wait for
+rhods_wait_ods_images: "s2i-minimal-notebook,s2i-generic-data-science-notebook"

--- a/roles/rhods_wait_ods/tasks/main.yml
+++ b/roles/rhods_wait_ods/tasks/main.yml
@@ -13,7 +13,6 @@
   retries: 40
   delay: 60
 
-
 - name: Get JupyterLab route host
   command: oc get route/jupyterhub -n redhat-ods-applications -ojsonpath={.spec.host}
   register: jupyterlab_hostname_cmd
@@ -36,4 +35,15 @@
     args:
       warn: false # don't warn about using curl here
   - name: fail
-    fail: msg="JupiterHub didn't get ready"
+    fail: msg="JupyterHub didn't get ready"
+
+- name: Wait for RHODS images to be loaded
+  shell:
+    set -o pipefail;
+    oc get istag -n redhat-ods-applications -oname
+       | cut -d/ -f2 | grep "{{ item }}"
+  register: has_rhods_image
+  until: has_rhods_image.rc == 0
+  retries: 40
+  delay: 60
+  loop: "{{ rhods_wait_ods_images.split(',') }}"

--- a/testing/ods/common.sh
+++ b/testing/ods/common.sh
@@ -18,7 +18,6 @@ ODS_QE_CATALOG_IMAGE="quay.io/modh/qe-catalog-source"
 ODS_QE_CATALOG_IMAGE_TAG="v1121-1"
 
 RHODS_NOTEBOOK_IMAGE_NAME=s2i-minimal-notebook
-RHODS_NOTEBOOK_IMAGE_TAG=py3.8-v1.12.1-1
 
 ODS_CI_TEST_NAMESPACE=loadtest
 ODS_CI_REPO="https://github.com/openshift-psap/ods-ci.git"

--- a/testing/ods/jh-at-scale.sh
+++ b/testing/ods/jh-at-scale.sh
@@ -162,9 +162,11 @@ wait_rhods_launch() {
 
     ./run_toolbox.py rhods wait_ods
 
-    NOTEBOOK_IMAGE="image-registry.openshift-image-registry.svc:5000/redhat-ods-applications/$RHODS_NOTEBOOK_IMAGE_NAME:$RHODS_NOTEBOOK_IMAGE_TAG"
-
     if [[ -z "$ENABLE_AUTOSCALER" ]]; then
+        rhods_notebook_image_tag=$(oc get istag -n redhat-ods-applications -oname \
+                                       | cut -d/ -f2 | grep "$RHODS_NOTEBOOK_IMAGE_NAME" | cut -d: -f2)
+
+        NOTEBOOK_IMAGE="image-registry.openshift-image-registry.svc:5000/redhat-ods-applications/$RHODS_NOTEBOOK_IMAGE_NAME:$rhods_notebook_image_tag"
         # preload the image only if auto-scaling is disabled
         ./run_toolbox.py cluster preload_image "$RHODS_NOTEBOOK_IMAGE_NAME" "$NOTEBOOK_IMAGE" \
                          --namespace=rhods-notebooks


### PR DESCRIPTION
* `testing: ods: jh-at-scale: look up in the cluster the image tag to preload`

This part was failing on OSD, as the addon is installing the "latest"
version of RHODS and not a specific one as we do in OCP.

---

* `rhods_wait_ods: wait for RHODS images to be loaded`


---

/cc @kpouget 