### PR TITLE
[matrix-benchmarking-workloads/rhods-ci] Improve plots

### DIFF
--- a/subprojects/matrix-benchmarking-workloads/rhods-ci/plotting/advanced_timeline.py
+++ b/subprojects/matrix-benchmarking-workloads/rhods-ci/plotting/advanced_timeline.py
@@ -60,7 +60,7 @@ class Timeline():
             text = []
             for row in range(len(rows)):
                 line_idx = ordered_lines.index(rows["LineName"].values[row])
-                txt = rows["Text"].values[row]
+                txt = rows["LineName"].values[row] + "<br>" + rows["Text"].values[row]
                 get_ts = lambda name: datetime.datetime.fromtimestamp(int(rows[name].values[row].astype(datetime.datetime))/1000000000)
                 try:
                     get_ts("Finish")
@@ -114,7 +114,7 @@ class Timeline():
         fig.update_layout(xaxis_range=[min_date[0] - x_shift, max_date[0] + x_shift])
         fig.update_layout(yaxis_range=[len(ordered_lines) - 1 + y_shift, 0 - y_shift]) # range reverted here
         fig.update_layout(xaxis_title="Timeline (by date)")
-        fig.update_yaxes(tickmode='array', ticktext=ordered_lines, tickvals=list(range(len(ordered_lines))))
+        fig.update_layout(yaxis_title="User Index")
 
         fig.update_xaxes(showspikes=True, spikecolor="green", spikesnap="cursor", spikemode="across")
 

--- a/subprojects/matrix-benchmarking-workloads/rhods-ci/plotting/error_report.py
+++ b/subprojects/matrix-benchmarking-workloads/rhods-ci/plotting/error_report.py
@@ -34,6 +34,19 @@ class ErrorReport():
         header += [html.P("This report shows the list of users who failed the test, with a link to their execution report and the last screenshot taken by the Robot.")]
         header += [html.H1("Error Report")]
 
+        info = []
+        if entry.results.from_env.pr:
+            pr = entry.results.from_env.pr
+            info += [html.Li(["PR ", html.A(pr.name, href=pr.link, target="_blank")])]
+            info += [html.Li(["Diff against ", html.A(pr.base_ref, href=pr.diff_link, target="_blank"), " (when this test ran)"])]
+
+        if entry.results.from_env.link_flag == "running-with-the-test":
+            info += [html.Li(html.A("Results artifacts",
+                                    href="..", target="_blank"))]
+        elif entry.results.from_env.link_flag == "running-without-the-test":
+            info += [html.Li(html.A("Results artifacts",
+                                    href=entry.results.source_url, target="_blank"))]
+
         if entry.results.from_env.link_flag == "interactive" :
             # running in interactive mode
             def link(path):
@@ -55,9 +68,6 @@ class ErrorReport():
 
             elif entry.results.from_env.link_flag == "running-without-the-test":
                 # running independently of the test
-                # we need to know where the test artifacts are stored
-                if entry.results.source_url is None:
-                    raise ValueError(f"'source_url' value not available for {entry.results.location} ...")
 
                 link = lambda path: f"{entry.results.source_url}/{path.relative_to(entry.results.location.parent)}"
             else:
@@ -132,7 +142,8 @@ class ErrorReport():
 
         )
         header += [html.Ul(
-            [html.Li(f"{failed_users}/{total_users} users failed:" if failed_users else "No user failed.")]
+            info
+            + [html.Li(f"{failed_users}/{total_users} users failed:" if failed_users else "No user failed.")]
             + [steps]
         )]
 

--- a/subprojects/matrix-benchmarking-workloads/rhods-ci/plotting/error_report.py
+++ b/subprojects/matrix-benchmarking-workloads/rhods-ci/plotting/error_report.py
@@ -113,7 +113,7 @@ class ErrorReport():
                 if last_screenshot_path:
                     content += [html.A(html.Img(src=link(last_screenshot_path),
                                                 width=1024,
-                                                style="border: 2px solid #555; border-radius: 25px;"),
+                                                style={"border": "2px solid #555", "border-radius": "25px"}),
                                        target="_blank", href=link(last_screenshot_path))]
                 else:
                     content += [html.I("No screenshot available.")]

--- a/subprojects/matrix-benchmarking-workloads/rhods-ci/plotting/mapping.py
+++ b/subprojects/matrix-benchmarking-workloads/rhods-ci/plotting/mapping.py
@@ -35,8 +35,11 @@ def generate_data(entry, cfg, is_notebook):
         else:
             user_idx = int(pod_name.split("-")[2])
 
+        try: pod_times = entry_results.pod_times[pod_name]
+        except KeyError: continue
+
         event_times = entry_results.event_times[pod_name]
-        pod_times = entry_results.pod_times[pod_name]
+
         try:
             hostname = hostnames[pod_name]
         except KeyError:

--- a/subprojects/matrix-benchmarking-workloads/rhods-ci/store.py
+++ b/subprojects/matrix-benchmarking-workloads/rhods-ci/store.py
@@ -206,6 +206,9 @@ def _parse_ods_ci_output_xml(filename):
     if not isinstance(tests, list): tests = [tests]
 
     for test in tests:
+        if test["status"].get("#text") == 'Failure occurred and exit-on-failure mode is in use.':
+            continue
+
         ods_ci_times[test["@name"]] = test_times = types.SimpleNamespace()
 
         test_times.start = datetime.datetime.strptime(test["status"]["@starttime"], ROBOT_TIME_FMT)


### PR DESCRIPTION
* `[matrix-benchmarking-workloads/rhods-ci] mapping: do not crash when a Notebook pod wasn't created`


---

* `[matrix-benchmarking-workloads/rhods-ci] store: ignore tests skipped with exit-on-failure`

With the robot --exit-on-failure recently enabled, when a test-case
fails, the following ones won't be executed, but directly marked as
failed.

This commit skips these skipped tests from our parsing.

---

* `[matrix-benchmarking-workloads/rhods-ci] advanced_timeline: user integer index for Y axis`


---

* `[matrix-benchmarking-workloads/rhods-ci] error_report: fix images when running interactively`


---

* `[matrix-benchmarking-workloads/rhods-ci] error_report: fix style (use a dict instead of str)`

Dash doesn't like the str ...

---

* `[matrix-benchmarking-workloads/rhods-ci] error_report: group errors by failed task`


---

/cc @kpouget 

```
matbench-data-url: https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/openshift-psap_ci-artifacts/420/pull-ci-openshift-psap-ci-artifacts-master-ods-jh-on-ocp/1548174089028374528/artifacts/jh-on-ocp/test/artifacts/
```