### PR TITLE
cluster_destroy_ocp: allow passing no option to delete the local cluster

### DIFF
--- a/roles/cluster_destroy_ocp/defaults/main/config.yml
+++ b/roles/cluster_destroy_ocp/defaults/main/config.yml
@@ -1,4 +1,5 @@
 cluster_destroy_ocp_openshift_install: openshift-install
 cluster_destroy_ocp_region:
 cluster_destroy_ocp_tag:
+cluster_destroy_ocp_confirm: false
 cluster_destroy_ocp_tag_value: owned

--- a/roles/cluster_destroy_ocp/tasks/main.yml
+++ b/roles/cluster_destroy_ocp/tasks/main.yml
@@ -1,15 +1,37 @@
 ---
 - name: Fail if the tag key is empty
-  fail: msg="Tag key is empty"
-  when: not cluster_destroy_ocp_tag
+  fail: msg="Tag cannot be empty, or pass the --confirm flag."
+  when:
+  - not cluster_destroy_ocp_tag
+  - not cluster_destroy_ocp_confirm|bool
 
 - name: Fail if the tag value is empty
   fail: msg="Tag value is empty"
   when: not cluster_destroy_ocp_tag_value
 
 - name: Fail if the region is empty
-  fail: msg="region is empty"
+  fail: msg="region cannot be empty, or pass the --confirm flag."
+  when:
+  - not cluster_destroy_ocp_region
+  - not cluster_destroy_ocp_confirm|bool
+
+- name: Get the cluster region
   when: not cluster_destroy_ocp_region
+  command: oc get machines -n openshift-machine-api -ojsonpath={.items[0].spec.providerSpec.value.placement.region}
+  register: cluster_region_cmd
+
+- name: Get the cluster tag
+  when: not cluster_destroy_ocp_tag
+  shell:
+    set -o pipefail;
+    oc get machines -n openshift-machine-api -ojsonpath={.items[0].spec.providerSpec.value.tags[0].name} \
+        | cut -d/ -f3
+  register: cluster_tag_cmd
+
+- name: Set the cluster tag and region
+  set_fact:
+    cluster_tag: "{{ cluster_destroy_ocp_tag | default(cluster_tag_cmd.stdout, true) }}"
+    cluster_region: "{{ cluster_destroy_ocp_region | default(cluster_region_cmd.stdout, true) }}"
 
 - name: Create openshift-install metadata.json
   template:

--- a/roles/cluster_destroy_ocp/templates/metadata.json.j2
+++ b/roles/cluster_destroy_ocp/templates/metadata.json.j2
@@ -3,10 +3,10 @@
   "clusterID": "clusterId",
   "infraID": "infraID",
   "aws": {
-    "region": "{{ cluster_destroy_ocp_region }}",
+    "region": "{{ cluster_region }}",
     "identifier": [
       {
-        "kubernetes.io/cluster/{{ cluster_destroy_ocp_tag }}": "{{ cluster_destroy_ocp_tag_value }}"
+        "kubernetes.io/cluster/{{ cluster_tag }}": "{{ cluster_destroy_ocp_tag_value }}"
       }
     ],
     "clusterDomain": "clusterDomain"

--- a/toolbox/cluster.py
+++ b/toolbox/cluster.py
@@ -220,20 +220,23 @@ class Cluster:
         return RunAnsibleRole("cluster_prometheus_db", opts)
 
     @staticmethod
-    def destroy_ocp(region, tag, tag_value="owned", openshift_install="openshift-install"):
+    def destroy_ocp(region="", tag="", confirm=False, tag_value="owned", openshift_install="openshift-install"):
         """
         Destroy an OpenShift cluster
 
         Args:
-          region: The AWS region where the cluster lives.
-          label: The resource tag key.
+          region: Optional. The AWS region where the cluster lives. If empty and --confirm is passed, look up from the cluster.
+          label: Optional. The resource tag key. If empty and --confirm is passed, look up from the cluster.
+          confirm: If the region/label are not set, and --confirm is passed, destroy the current cluster.
           tag_value: Optional. The resource tag value. Default: 'owned'.
           openshift_install: Optional. The path to the `openshift-install` to use to destroy the cluster. If empty, pick it up from the `deploy-cluster` subproject. Default: 'openshift-installer'
         """
 
+
         opt = {
             "cluster_destroy_ocp_region": region,
             "cluster_destroy_ocp_tag": tag,
+            "cluster_destroy_ocp_confirm": confirm,
             "cluster_destroy_ocp_tag_value": tag_value,
             "cluster_destroy_ocp_openshift_install": openshift_install,
         }


### PR DESCRIPTION
This commit updates the `cluster_destroy_ocp` to look up the cluster's
REGION and TAG_ID with `oc` (from the `machine` AWS specs).

These two values are then passed to `openshift-install` to destroy the
cluster.

This version of the toolbox can only run if the `--confirm` flag is
passed.

---

Tested locally.

/cc @fcami 