### PR TITLE
rhods_test_jupyterlab: robot: revert to the s2i-generic-data-science-notebook image

### DIFF
--- a/roles/rhods_test_jupyterlab/files/ods-ci/test-jupyterlab-run-notebook.robot
+++ b/roles/rhods_test_jupyterlab/files/ods-ci/test-jupyterlab-run-notebook.robot
@@ -12,7 +12,7 @@ Suite Teardown  Tear Down
 
 *** Variables ***
 
-${NOTEBOOK_IMAGE_NAME}         s2i-minimal-notebook
+${NOTEBOOK_IMAGE_NAME}         s2i-generic-data-science-notebook
 ${NOTEBOOK_IMAGE_SIZE}         Default
 ${NOTEBOOK_SPAWN_WAIT_TIME}    15 minutes
 ${NOTEBOOK_SPAWN_RETRIES}      45

--- a/testing/ods/common.sh
+++ b/testing/ods/common.sh
@@ -17,7 +17,7 @@ OSD_USE_ODS_CATALOG=${OSD_USE_ODS_CATALOG:-0}
 ODS_QE_CATALOG_IMAGE="quay.io/modh/qe-catalog-source"
 ODS_QE_CATALOG_IMAGE_TAG="latest"
 
-RHODS_NOTEBOOK_IMAGE_NAME=s2i-minimal-notebook
+RHODS_NOTEBOOK_IMAGE_NAME=s2i-generic-data-science-notebook
 
 ODS_CI_TEST_NAMESPACE=loadtest
 ODS_CI_REPO="https://github.com/openshift-psap/ods-ci.git"

--- a/testing/ods/notebooks/simple-notebook.ipynb
+++ b/testing/ods/notebooks/simple-notebook.ipynb
@@ -10,7 +10,6 @@
     "# stress test cpu\n",
     "\n",
     "from multiprocessing import Pool\n",
-    "import psutil\n",
     "import time\n",
     "\n",
     "\n",


### PR DESCRIPTION
Commit 499f2983d8955c279ac70edd0798e5e8a5caed56 switched from
the s2i-generic-data-science-notebook image to the s2i-minimal
notebook image.
Revert the change to be able to run more notebooks.

Signed-off-by: François Cami <fcami@redhat.com>