### PR TITLE
RHODS: rhods_wait_ods: default: also wait for tensorflow and pytorch images

### DIFF
--- a/roles/rhods_wait_ods/defaults/main/config.yml
+++ b/roles/rhods_wait_ods/defaults/main/config.yml
@@ -1,3 +1,3 @@
 ---
 # comma separated list of RHODS images to wait for
-rhods_wait_ods_images: "s2i-minimal-notebook,s2i-generic-data-science-notebook"
+rhods_wait_ods_images: "s2i-minimal-notebook,s2i-generic-data-science-notebook,tensorflow,pytorch"


### PR DESCRIPTION
Without this, the automation may try to spawn notebooks before these
images are built, and RHODS dashboard refuses to go to JupyterLab when
these images are missing.

Fixes: PSAP-806

/cc @fcami 