### PR TITLE
testing: run: download the PR and its comment into the artifacts

### DIFF
--- a/testing/run
+++ b/testing/run
@@ -78,6 +78,11 @@ prechecks() {
     # store `ci-artifacts` version in use
     (git describe HEAD --long --always || echo "git missing") > ${ARTIFACT_DIR}/ci_artifact.git_version
 
+    if [[ "${PULL_NUMBER:-}" ]]; then
+        curl -sSf "https://api.github.com/repos/openshift-psap/ci-artifacts/pulls/$PULL_NUMBER" -o "${ARTIFACT_DIR}/pull_request.json"
+        curl -sSf "https://api.github.com/repos/openshift-psap/ci-artifacts/issues/420/comments" -o "${ARTIFACT_DIR}/pull_request-comments.json"
+    fi
+
     # check that the OCP cluster can be reached
     ocp_version=$(oc version -o json | jq --raw-output '.openshiftVersion' || true)
     if [[ -z "$ocp_version" ]]; then


### PR DESCRIPTION
The PR json file contains the title, description, commit and base
commit, which are useful information about the version of code being
tested.

The comments of the PR contain, among other things, the `/test`
command that was used to trigger the testing. Soon we'll use this to run
different configurations of the test, eg:
```
/test ods-jh-on-ocp TEST=1 VALUE=2
```

---

Tested in #450: https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/openshift-psap_ci-artifacts/450/pull-ci-openshift-psap-ci-artifacts-master-ods-get-cluster/1550354756239626240/artifacts/get-cluster/test/artifacts/