### PR TITLE
testing: run: do not crash when the pull request data cannot be fetched

### DIFF
--- a/testing/run
+++ b/testing/run
@@ -79,8 +79,11 @@ prechecks() {
     (git describe HEAD --long --always || echo "git missing") > ${ARTIFACT_DIR}/ci_artifact.git_version
 
     if [[ "${PULL_NUMBER:-}" ]]; then
-        curl -sSf "https://api.github.com/repos/openshift-psap/ci-artifacts/pulls/$PULL_NUMBER" -o "${ARTIFACT_DIR}/pull_request.json"
-        curl -sSf "https://api.github.com/repos/openshift-psap/ci-artifacts/issues/420/comments" -o "${ARTIFACT_DIR}/pull_request-comments.json"
+        PR_URL="https://api.github.com/repos/openshift-psap/ci-artifacts/pulls/$PULL_NUMBER"
+        PR_COMMENTS_URL="https://api.github.com/repos/openshift-psap/ci-artifacts/issues/$PULL_NUMBER/comments"
+
+        curl -sSf "$PR_URL" -o "${ARTIFACT_DIR}/pull_request.json" || echo "WARNING: Failed to download the PR from $PR_URL"
+        curl -sSf "$PR_COMMENTS_URL" -o "${ARTIFACT_DIR}/pull_request-comments.json" || echo "WARNING: Failed to download the PR comments from $PR_COMMENTS_URL"
     fi
 
     # check that the OCP cluster can be reached


### PR DESCRIPTION
This breaks the rehearsals from openshift/release.