### PR TITLE
rhods_deploy_ods: delete the GPU image builds and mock them up

### DIFF
--- a/roles/rhods_deploy_ods/tasks/main.yml
+++ b/roles/rhods_deploy_ods/tasks/main.yml
@@ -64,3 +64,14 @@
     cluster_deploy_operator_namespace: redhat-ods-operator
     cluster_deploy_operator_channel: beta
     cluster_deploy_operator_all_namespaces: "True"
+
+- name: Fill the imagestreams with dummy (ubi) images
+  loop: [minimal-gpu, nvidia-cuda-11.4.2, pytorch, tensorflow]
+  command:
+    oc tag
+       registry.access.redhat.com/ubi8/ubi
+       {{ item }}:ubi
+       -n redhat-ods-applications
+
+- name: Delete the RHODS builds
+  command: oc delete builds --all  -n redhat-ods-applications


### PR DESCRIPTION
This commit mocks up the GPU images of RHODS. They are normally built in the cluster, and this takes more than 1h. We don't use these images at the moment, so no need to build them.

If ever we get to use them, we'll certainly prefer storing them in a _private_ quay repo and populate them from there.

/cc @fcami  