### PR TITLE
RHODS: use a dedicated image for the artifacts exporter side-car

### DIFF
--- a/roles/rhods_test_jupyterlab/defaults/main/config.yml
+++ b/roles/rhods_test_jupyterlab/defaults/main/config.yml
@@ -9,6 +9,7 @@ rhods_test_jupyterlab_ods_sleep_factor: 1.0
 rhods_test_jupyterlab_ods_ci_exclude_tags: None
 rhods_test_jupyterlab_ods_ci_test_case: test-jupyterlab-run-notebook.robot
 rhods_test_jupyterlab_notebook_url:
+rhods_test_jupyterlab_ods_ci_artifacts_exporter_istag: ods-ci:artifacts_exporter
 
 rhods_test_namespace: loadtest
 rhods_test_istag: ods-ci:latest

--- a/roles/rhods_test_jupyterlab/files/s3-artifacts-exporter.sh
+++ b/roles/rhods_test_jupyterlab/files/s3-artifacts-exporter.sh
@@ -13,7 +13,8 @@ configure_s3() {
 
     export S3_ACCESS_KEY=minio
     # S3_SECRET_KEY: set below
-
+    export HOME=/tmp/s3cmd
+    mkdir -p "$HOME"
     # run this in a subshell to avoid printing the password in clear because of 'set -x'
     bash -ec "eval \$(yq e .TEST_USER.PASSWORD /mnt/ods-ci-test-variables/test-variables.yml | awk '{ print \"export S3_SECRET_KEY=\" \$1 }'); cat /mnt/s3-config/s3cfg | envsubst > ~/.s3cfg"
 }
@@ -25,13 +26,6 @@ retcode=0 # always exit 0, we'll decide later if this is a success or a failure
 if [[ "$ARTIFACTS_COLLECTED" == "none" ]]; then
     exit $retcode
 fi
-
-dnf -y --quiet install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
-dnf install -y --quiet s3cmd gettext
-dnf clean all
-
-curl --silent -L https://github.com/mikefarah/yq/releases/download/v4.25.1/yq_linux_amd64 -o /usr/bin/yq
-chmod +x /usr/bin/yq
 
 set +x
 

--- a/roles/rhods_test_jupyterlab/tasks/main.yml
+++ b/roles/rhods_test_jupyterlab/tasks/main.yml
@@ -18,6 +18,7 @@
 - name: Define the test environments
   set_fact:
     rhods_test_image: image-registry.openshift-image-registry.svc:5000/{{ rhods_test_namespace }}/{{ rhods_test_istag }}
+    rhods_artifacts_exporter_image: image-registry.openshift-image-registry.svc:5000/{{ rhods_test_namespace }}/{{ rhods_test_jupyterlab_ods_ci_artifacts_exporter_istag }}
     rhods_notebook_namespace: rhods-notebooks
 
 - name: Set system-under-test == driver-cluster if no system-under-test (SUT) is provided

--- a/roles/rhods_test_jupyterlab/templates/rhods-ci.yaml
+++ b/roles/rhods_test_jupyterlab/templates/rhods-ci.yaml
@@ -63,7 +63,7 @@ spec:
           limits:
             memory: 750M
             cpu: 0.2
-      - image: "quay.io/centos/centos:stream8"
+      - image: "{{ rhods_artifacts_exporter_image }}"
         name: artifacts-exporter
         command: ['bash', '/mnt/rhods-jupyterlab-entrypoint/artifacts-exporter.sh']
         env:
@@ -71,9 +71,6 @@ spec:
           value: "{{ rhods_test_jupyterlab_artifacts_collected }}"
         - name: ARTIFACT_DIR
           value: /mnt/shared-dir/ods-ci
-        securityContext:
-          privileged: true
-          runAsUser: 0
         volumeMounts:
         - name: s3cmd-config
           mountPath: /mnt/s3-config

--- a/roles/utils_build_push_image/tasks/build_image.yml
+++ b/roles/utils_build_push_image/tasks/build_image.yml
@@ -22,13 +22,13 @@
     oc apply
        -f "{{ artifact_extra_logs_dir }}/002_image_buildconfig.yml"
        -n "{{ utils_build_push_image_namespace }}"
-       -oname
+       -ojsonpath={.metadata.name}
   register: builconfig_name_cmd
 
 - name: Get the name of the build
   command:
     oc get builds
-       "-lbuildconfig={{ utils_build_push_image_local_name }}"
+       "-lbuildconfig={{ builconfig_name_cmd.stdout }}"
        -oname
        -n "{{ utils_build_push_image_namespace }}"
   register: build_name_cmd
@@ -71,7 +71,7 @@
     shell:
       oc describe
          -n "{{ utils_build_push_image_namespace }}"
-         {{ builconfig_name_cmd.stdout }}
+         buildconfig/{{ builconfig_name_cmd.stdout }}
          > {{ artifact_extra_logs_dir }}/image-build.descr
     failed_when: false
 

--- a/roles/utils_build_push_image/tasks/main.yml
+++ b/roles/utils_build_push_image/tasks/main.yml
@@ -14,7 +14,13 @@
        --dry-run=client
        -oyaml
     | tee "{{ artifact_extra_logs_dir }}/001_imagestream.yml"
-    | oc apply -f- -n "{{ utils_build_push_image_namespace }}"
+    | oc create
+         -f-
+         -n "{{ utils_build_push_image_namespace }}"
+  # Will fail if the imagestream already exists. Ignore it.  Cannot
+  # use 'oc apply' above, as we don't want to erase the imagestream
+  # content.
+  failed_when: false
 
 - name: Check if the image is already built
   command:

--- a/roles/utils_build_push_image/templates/image_buildconfig.yml.j2
+++ b/roles/utils_build_push_image/templates/image_buildconfig.yml.j2
@@ -26,10 +26,12 @@ spec:
     type: Docker
     dockerStrategy:
       dockerfilePath: {{ utils_build_push_image_dockerfile_path }}
-{% elif dockerfile.stdout|length %}
+{% elif dockerfile_content_cmd.stdout|length %}
   source:
     dockerfile: |
-{{ dockerfile.stdout | indent(6, True) }}
+{{ dockerfile_content_cmd.stdout | indent(6, True) }}
+  strategy:
+    type: Docker
 {% endif %}
   triggers:
     - type: ConfigChange

--- a/roles/utils_build_push_image/templates/image_buildconfig.yml.j2
+++ b/roles/utils_build_push_image/templates/image_buildconfig.yml.j2
@@ -4,7 +4,7 @@ kind: BuildConfig
 metadata:
   labels:
     app: ci-artifacts
-  name: {{ utils_build_push_image_local_name }}
+  name: {{ utils_build_push_image_local_name }}-{{ utils_build_push_image_tag }}
 spec:
   output:
     to:

--- a/testing/ods/common.sh
+++ b/testing/ods/common.sh
@@ -25,6 +25,8 @@ ODS_CI_REF="jh-at-scale"
 
 ODS_CI_IMAGESTREAM="ods-ci"
 ODS_CI_TAG="latest"
+ODS_CI_ARTIFACTS_EXPORTER_TAG="artifacts-exporter"
+ODS_CI_ARTIFACTS_EXPORTER_DOCKERFILE="testing/ods/images/Containerfile.s3_artifacts_exporter"
 
 ODS_CI_NB_USERS=5
 ODS_CI_USER_PREFIX=psapuser

--- a/testing/ods/images/Containerfile.s3_artifacts_exporter
+++ b/testing/ods/images/Containerfile.s3_artifacts_exporter
@@ -1,0 +1,8 @@
+FROM quay.io/centos/centos:stream8
+
+RUN dnf -y --quiet install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm \
+ && dnf install -y --quiet s3cmd gettext \
+ && dnf clean all
+
+RUN curl --silent -L https://github.com/mikefarah/yq/releases/download/v4.25.1/yq_linux_amd64 -o /usr/bin/yq \
+ && chmod +x /usr/bin/yq

--- a/testing/ods/jh-at-scale.sh
+++ b/testing/ods/jh-at-scale.sh
@@ -239,7 +239,8 @@ run_jupyterlab_test() {
                      --sut_cluster_kubeconfig="$KUBECONFIG_SUTEST" \
                      --artifacts-collected="$ARTIFACTS_COLLECTED" \
                      --ods_sleep_factor="$ODS_SLEEP_FACTOR" \
-                     --ods_ci_exclude_tags="$ODS_EXCLUDE_TAGS"
+                     --ods_ci_exclude_tags="$ODS_EXCLUDE_TAGS" \
+                     --ods_ci_artifacts_exporter_istag="$ODS_CI_IMAGESTREAM:$ODS_CI_ARTIFACTS_EXPORTER_TAG"
 
     # quick access to these files
     cp "$ARTIFACT_DIR"/*__driver_rhods__test_jupyterlab/{failed_tests,success_count} "$ARTIFACT_DIR" || true

--- a/testing/ods/jh-at-scale.sh
+++ b/testing/ods/jh-at-scale.sh
@@ -85,12 +85,25 @@ prepare_driver_cluster() {
                          --context-dir="/" \
                          --dockerfile-path="build/Dockerfile"
 
-        IMAGE="image-registry.openshift-image-registry.svc:5000/$ODS_CI_TEST_NAMESPACE/$ODS_CI_IMAGESTREAM:$ODS_CI_TAG"
-        ./run_toolbox.py cluster preload_image "ods-ci-image" "$IMAGE" \
+        ods_ci_image="image-registry.openshift-image-registry.svc:5000/$ODS_CI_TEST_NAMESPACE/$ODS_CI_IMAGESTREAM:$ODS_CI_TAG"
+        ./run_toolbox.py cluster preload_image "ods-ci-image" "$ods_ci_image" \
+                         --namespace="$ODS_CI_TEST_NAMESPACE"
+    }
+
+    build_and_preload_artifacts_exporter_image() {
+        ./run_toolbox.py utils build_push_image \
+                         "$ODS_CI_IMAGESTREAM" "$ODS_CI_ARTIFACTS_EXPORTER_TAG" \
+                         --namespace="$ODS_CI_TEST_NAMESPACE" \
+                         --context-dir="/" \
+                         --dockerfile-path="$ODS_CI_ARTIFACTS_EXPORTER_DOCKERFILE"
+
+        artifacts_exporter_image="image-registry.openshift-image-registry.svc:5000/$ODS_CI_TEST_NAMESPACE/$ODS_CI_IMAGESTREAM:$ODS_CI_ARTIFACTS_EXPORTER_TAG"
+        ./run_toolbox.py cluster preload_image "ods-ci-artifacts-exporter-image" "$artifacts_exporter_image" \
                          --namespace="$ODS_CI_TEST_NAMESPACE"
     }
 
     process_ctrl::run_in_bg build_and_preload_odsci_image
+    process_ctrl::run_in_bg build_and_preload_artifacts_exporter_image
 
     process_ctrl::run_in_bg ./run_toolbox.py cluster deploy_minio_s3_server "$S3_LDAP_PROPS"
 

--- a/toolbox/rhods.py
+++ b/toolbox/rhods.py
@@ -66,7 +66,9 @@ class RHODS:
                         artifacts_collected="all",
                         ods_sleep_factor="1.0",
                         ods_ci_exclude_tags="None",
-                        ods_ci_test_case="test-jupyterlab-run-notebook.robot"):
+                        ods_ci_test_case="test-jupyterlab-run-notebook.robot",
+                        ods_ci_artifacts_exporter_istag="ods-ci:artifacts_exporter",
+                        ):
         """
         Test RHODS JupyterLab notebooks
 
@@ -85,6 +87,7 @@ class RHODS:
           ods_sleep_factor: Optional. Delay to sleep between users. Default 1.0.
           ods_ci_test_case: Optional. ODS-CI test case to execute.
           ods_ci_exclude_tags: Optional. Tags to exclude in the ODS-CI test case.
+          ods_ci_artifacts_exporter_istag: Optional. Imagestream tag of the ODS-CI artifacts exporter side-car container.
         """
 
         opts = {
@@ -98,6 +101,8 @@ class RHODS:
             "rhods_test_jupyterlab_ods_sleep_factor": ods_sleep_factor,
             "rhods_test_jupyterlab_ods_ci_test_case": ods_ci_test_case,
             "rhods_test_jupyterlab_ods_ci_exclude_tags": ods_ci_exclude_tags,
+            "rhods_test_jupyterlab_ods_ci_artifacts_exporter_istag": ods_ci_artifacts_exporter_istag,
+
         }
 
         ARTIFACTS_COLLECTED_VALUES = ("all", "none", "no-image", "no-image-except-failed", "no-image-except-failed-and-zero")


### PR DESCRIPTION
This PR creates a dedicated image for artifacts exporter side-car container of the `test_jupyterlab` test.

This is a cleaner design, and it solves the issue that, until now, all the simulated users had to install `s3cmd` package and download `yq` from Github.

/cc @fcami 