### PR TITLE
[matrix-benchmarking-workloads/rhods-ci] error_report: Improve with further info about the test

### DIFF
--- a/subprojects/matrix-benchmarking-workloads/rhods-ci/plotting/error_report.py
+++ b/subprojects/matrix-benchmarking-workloads/rhods-ci/plotting/error_report.py
@@ -37,8 +37,9 @@ class ErrorReport():
         info = []
         if entry.results.from_env.pr:
             pr = entry.results.from_env.pr
-            info += [html.Li(["PR ", html.A(pr.name, href=pr.link, target="_blank")])]
-            info += [html.Li(["Diff against ", html.A(pr.base_ref, href=pr.diff_link, target="_blank"), " (when this test ran)"])]
+            info += [html.Li(["PR ", html.A(pr.name, href=pr.link, target="_blank"), html.B(entry.results.from_pr["title"])])]
+            info += [html.Ul(html.Li(html.Code(entry.results.from_pr["body"].replace("\n", "<br>"))))]
+            info += [html.Li(["Test diff against ", html.A(html.Code(pr.base_ref), href=pr.diff_link, target="_blank")])]
 
         if entry.results.from_env.link_flag == "running-with-the-test":
             info += [html.Li(html.A("Results artifacts",
@@ -47,6 +48,12 @@ class ErrorReport():
             info += [html.Li(html.A("Results artifacts",
                                     href=entry.results.source_url, target="_blank"))]
 
+        info += [html.Li(["RHODS ", html.Code(entry.results.rhods_info.version)])]
+
+        info += [html.Li(["Test job: ", html.Code(entry.results.from_env.env.get("JOB_NAME_SAFE", "no job defined"))])]
+        managed = list(entry.results.nodes_info.values())[0].managed
+        ocp_version = entry.results.rhods_info.ocp_version
+        info += [html.Li(["Running on ", "OpenShift Dedicated" if managed else "OCP", f" v{ocp_version}"])]
         if entry.results.from_env.link_flag == "interactive" :
             # running in interactive mode
             def link(path):


### PR DESCRIPTION
This PR adds further information in the error report about the test that was executed.

/cc @fcami 
```
matbench-data-url: https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/openshift-psap_ci-artifacts/460/pull-ci-openshift-psap-ci-artifacts-master-ods-get-cluster/1551835589391683584/artifacts/get-cluster/test/artifacts/
```
Example:
---


* PR[ openshift-psap/ci-artifacts #462 ](https://github.com/openshift-psap/ci-artifacts/pull/462)RHODS: use a dedicated image for the artifacts exporter side-car
```
    This PR creates a dedicated image for artifacts exporter side-car container of the `test_jupyterlab` test.

    This is a cleaner design, and it solves the issue that, until now, all the simulated users had to install `s3cmd` package and download `yq` from Github.

    /cc @fcami
```
* Test diff against master
* RHODS v1.14.0-2
* Test job: jh-on-single
* Running on OCP v4.10.15
* No user failed.