### PR TITLE
testing: ods: jh-at-scale: mute cluster_undeploy_ldap

### DIFF
--- a/testing/ods/jh-at-scale.sh
+++ b/testing/ods/jh-at-scale.sh
@@ -242,7 +242,7 @@ sutest_cleanup() {
     else
         ./run_toolbox.py cluster undeploy_ldap \
                          "$LDAP_IDP_NAME" \
-                         --use_ocm="$osd_cluster_name"
+                         --use_ocm="$osd_cluster_name" > /dev/null
     fi
 }
 


### PR DESCRIPTION
The execution of this command is logged in the artifacts. Muting it
from stdout makes the logs (and its failure) easier/quicker to read.

/cc @kpouget 