### PR TITLE
testing: ods: cleanup/zombies: properly compute the number of clusters deleted

### DIFF
--- a/testing/ods/cleanup/zombies.sh
+++ b/testing/ods/cleanup/zombies.sh
@@ -31,7 +31,7 @@ do
             --ci-list-file "$DELETE_FILE" |& tee -a "$ARTIFACT_DIR/scan-ec2-instances.$region.log"
 done
 
-cluster_count=$(wc -l "$DELETE_FILE")
+cluster_count=$(cat "$DELETE_FILE" | wc -l)
 echo "Found  $cluster_count clusters to delete:"
 cat "$DELETE_FILE"
 


### PR DESCRIPTION
Before this fix, 'wc -l' outputs the name of the file after the line count

/cc @kpouget 