### PR TITLE
testing: prow: _logging: add _flake function

### DIFF
--- a/testing/prow/_logging.sh
+++ b/testing/prow/_logging.sh
@@ -1,5 +1,16 @@
 #! /usr/bin/env bash
 
+_flake() {
+    fname="$1"
+    msg="$2"
+
+    DEST_DIR="${ARTIFACT_DIR}/_FLAKE/"
+    mkdir -p "$DEST_DIR"
+    echo "$msg" > "${DEST_DIR}/$fname"
+
+    echo "FLAKE: $msg"
+}
+
 _info() {
     fname="$1"
     msg="$2"


### PR DESCRIPTION
Already used in testing/benchmarking/run_mlperf_ssd.sh but not implemented.

Function was missing in this nightly test: https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/periodic-ci-openshift-psap-ci-artifacts-master-4.10-e2e-mlperf-ssd/1552066448631795712/artifacts/e2e-mlperf-ssd/nightly/build-log.txt

/cc @kpouget 