### PR TITLE
RHODS: Fail on notebook errors and define the notebook image in a single location

### DIFF
--- a/roles/rhods_test_jupyterlab/files/ods-ci/test-jupyterlab-run-notebook.robot
+++ b/roles/rhods_test_jupyterlab/files/ods-ci/test-jupyterlab-run-notebook.robot
@@ -101,6 +101,13 @@ Run the Notebook
 
   Wait Until JupyterLab Code Cell Is Not Active  timeout=${NOTEBOOK_EXEC_WAIT_TIME}
   Capture Page Screenshot
+  ${has_errors}  ${error}=  Run Keyword And Ignore Error  Get JupyterLab Code Cell Error Text
+
+  IF  '${has_errors}' == 'PASS'
+      Log  ${error}
+      Fail  "Error detected during the execution of the notebook:\n${error}"
+  END
+
 
 *** Keywords ***
 Get Browser Console Log Entries

--- a/roles/rhods_test_jupyterlab/files/ods-ci/test-jupyterlab-run-notebook.robot
+++ b/roles/rhods_test_jupyterlab/files/ods-ci/test-jupyterlab-run-notebook.robot
@@ -12,7 +12,7 @@ Suite Teardown  Tear Down
 
 *** Variables ***
 
-${NOTEBOOK_IMAGE_NAME}         s2i-generic-data-science-notebook
+${NOTEBOOK_IMAGE_NAME}         %{NOTEBOOK_IMAGE_NAME}
 ${NOTEBOOK_IMAGE_SIZE}         Default
 ${NOTEBOOK_SPAWN_WAIT_TIME}    15 minutes
 ${NOTEBOOK_SPAWN_RETRIES}      45

--- a/roles/rhods_test_jupyterlab/templates/rhods-ci.yaml
+++ b/roles/rhods_test_jupyterlab/templates/rhods-ci.yaml
@@ -49,6 +49,8 @@ spec:
           value: "{{ rhods_test_jupyterlab_ods_sleep_factor }}"
         - name: NOTEBOOK_URL
           value: "{{ rhods_test_jupyterlab_notebook_url }}"
+        - name: NOTEBOOK_IMAGE_NAME
+          value: "{{ rhods_test_jupyterlab_ods_ci_notebook_image_name }}"
         volumeMounts:
         - name: shared-dir
           mountPath: /mnt/shared-dir

--- a/testing/ods/common.sh
+++ b/testing/ods/common.sh
@@ -33,6 +33,7 @@ ODS_CI_USER_PREFIX=psapuser
 ODS_NOTEBOOK_SIZE=default # needs to match what the ROBOT test-case requests
 ODS_NOTEBOOK_SIZE_TEST_POD="test_pod" # shouldn't change
 ODS_SLEEP_FACTOR=1.0 # how long to wait between users.
+ODS_CI_ARTIFACTS_COLLECTED=no-image-except-failed-and-zero
 
 NGINX_NOTEBOOK_NAMESPACE=loadtest-notebooks
 ODS_NOTEBOOK_NAME=simple-notebook.ipynb

--- a/testing/ods/images/Containerfile.s3_artifacts_exporter
+++ b/testing/ods/images/Containerfile.s3_artifacts_exporter
@@ -6,3 +6,4 @@ RUN dnf -y --quiet install https://dl.fedoraproject.org/pub/epel/epel-release-la
 
 RUN curl --silent -L https://github.com/mikefarah/yq/releases/download/v4.25.1/yq_linux_amd64 -o /usr/bin/yq \
  && chmod +x /usr/bin/yq
+

--- a/testing/ods/jh-at-scale.sh
+++ b/testing/ods/jh-at-scale.sh
@@ -229,15 +229,13 @@ run_jupyterlab_test() {
     nginx_server_dir=$(ls -d "$ARTIFACT_DIR"/*_"${NGINX_SERVER_DIRNAME}" | tail -1)
     nginx_server=$(cat "${nginx_server_dir}/hostname")
 
-    ARTIFACTS_COLLECTED=no-image-except-failed-and-zero
-
     ./run_toolbox.py rhods test_jupyterlab \
                      "$LDAP_IDP_NAME" \
                      "$ODS_CI_USER_PREFIX" "$ODS_CI_NB_USERS" \
                      "$S3_LDAP_PROPS" \
                      "http://$nginx_server/$ODS_NOTEBOOK_NAME" \
                      --sut_cluster_kubeconfig="$KUBECONFIG_SUTEST" \
-                     --artifacts-collected="$ARTIFACTS_COLLECTED" \
+                     --artifacts-collected="$ODS_CI_ARTIFACTS_COLLECTED" \
                      --ods_sleep_factor="$ODS_SLEEP_FACTOR" \
                      --ods_ci_exclude_tags="$ODS_EXCLUDE_TAGS" \
                      --ods_ci_artifacts_exporter_istag="$ODS_CI_IMAGESTREAM:$ODS_CI_ARTIFACTS_EXPORTER_TAG" \

--- a/testing/ods/jh-at-scale.sh
+++ b/testing/ods/jh-at-scale.sh
@@ -240,7 +240,8 @@ run_jupyterlab_test() {
                      --artifacts-collected="$ARTIFACTS_COLLECTED" \
                      --ods_sleep_factor="$ODS_SLEEP_FACTOR" \
                      --ods_ci_exclude_tags="$ODS_EXCLUDE_TAGS" \
-                     --ods_ci_artifacts_exporter_istag="$ODS_CI_IMAGESTREAM:$ODS_CI_ARTIFACTS_EXPORTER_TAG"
+                     --ods_ci_artifacts_exporter_istag="$ODS_CI_IMAGESTREAM:$ODS_CI_ARTIFACTS_EXPORTER_TAG" \
+                     --ods_ci_notebook_image_name="$RHODS_NOTEBOOK_IMAGE_NAME"
 
     # quick access to these files
     cp "$ARTIFACT_DIR"/*__driver_rhods__test_jupyterlab/{failed_tests,success_count} "$ARTIFACT_DIR" || true

--- a/toolbox/rhods.py
+++ b/toolbox/rhods.py
@@ -68,7 +68,9 @@ class RHODS:
                         ods_ci_exclude_tags="None",
                         ods_ci_test_case="test-jupyterlab-run-notebook.robot",
                         ods_ci_artifacts_exporter_istag="ods-ci:artifacts_exporter",
+                        ods_ci_notebook_image_name="s2i-generic-data-science-notebook",
                         ):
+
         """
         Test RHODS JupyterLab notebooks
 
@@ -88,6 +90,7 @@ class RHODS:
           ods_ci_test_case: Optional. ODS-CI test case to execute.
           ods_ci_exclude_tags: Optional. Tags to exclude in the ODS-CI test case.
           ods_ci_artifacts_exporter_istag: Optional. Imagestream tag of the ODS-CI artifacts exporter side-car container.
+          ods_ci_notebook_image_name: Optional. Name of the RHODS image to use when launching the notebooks.
         """
 
         opts = {
@@ -102,7 +105,7 @@ class RHODS:
             "rhods_test_jupyterlab_ods_ci_test_case": ods_ci_test_case,
             "rhods_test_jupyterlab_ods_ci_exclude_tags": ods_ci_exclude_tags,
             "rhods_test_jupyterlab_ods_ci_artifacts_exporter_istag": ods_ci_artifacts_exporter_istag,
-
+            "rhods_test_jupyterlab_ods_ci_notebook_image_name": ods_ci_notebook_image_name,
         }
 
         ARTIFACTS_COLLECTED_VALUES = ("all", "none", "no-image", "no-image-except-failed", "no-image-except-failed-and-zero")


### PR DESCRIPTION
* `rhods_test_jupyterlab: receive the notebok image name from a CLI parameter`

This commit allows the `rhods_test_jupyterlab` to receive an image
name, and passes it to the ODS-CI Pods.

This avoid the duplication of the image name (image preloading vs
notebook creation), and allows the definition of the image name from
the `common.sh` property file.

---

* `testing: ods: move ODS_CI_ARTIFACTS_COLLECTED to common.sh`

This commit moves ODS_CI_ARTIFACTS_COLLECTED to common.sh, as it's not
anymore a dynamic value as it used to be.

---

* `rhods_test_jupyterlab: test-jupyterlab-run-notebook.robot: catch notebook execution errors`

This commit ensures that errors in the notebook execution are not
silently ignored.

---