### PR TITLE
testing: ods: ocp_cluster.sh: use custom AWS profiles

### DIFF
--- a/testing/ods/ocp_cluster.sh
+++ b/testing/ods/ocp_cluster.sh
@@ -40,6 +40,7 @@ create_cluster() {
         author=$(echo "$JOB_SPEC" | jq -r .refs.pulls[0].author)
         cluster_name="${author}-${cluster_role}-$(date +%Y%m%d-%Hh%M)"
 
+        export AWS_DEFAULT_PROFILE="${author}_ci-artifacts"
     elif [[ "${PULL_NUMBER:-}" ]]; then
         cluster_name="${cluster_name}-pr${PULL_NUMBER}-${cluster_role}-${BUILD_ID}"
     else

--- a/testing/ods/ocp_cluster.sh
+++ b/testing/ods/ocp_cluster.sh
@@ -30,7 +30,7 @@ prepare_deploy_cluster_subproject() {
 create_cluster() {
     cluster_role=$1
     export ARTIFACT_TOOLBOX_NAME_PREFIX="ocp_${cluster_role}_"
-
+    export AWS_DEFAULT_PROFILE=${AWS_DEFAULT_PROFILE:-ci-artifacts}
     # ---
 
     cd subprojects/deploy-cluster/
@@ -45,6 +45,8 @@ create_cluster() {
     else
         cluster_name="${cluster_name}-${cluster_role}-$(date +%Hh%M)"
     fi
+
+    echo "Using AWS_DEFAULT_PROFILE=$AWS_DEFAULT_PROFILE"
 
     install_dir="/tmp/ocp_${cluster_role}_installer"
     rm -rf "$install_dir"


### PR DESCRIPTION
* `testing: ods: ocp_cluster.sh: use the AWS profile 'ci-artifacts' by default`


---

* `testing: ods: ocp_cluster.sh: use the AWS profile '${author}_ci-artifacts' for get-cluster`


---

/cc @fcami 