### PR TITLE
RHODS: minor updates

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -21,26 +21,28 @@ RUN virtualenv -p /usr/bin/python3.9 $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 RUN pip install --upgrade pip
 
+ARG CURL_OPTIONS="--silent --location --fail --show-error"
+
 # Install dependencies: `oc`
 ARG OCP_CLI_VERSION=latest
 ARG OCP_CLI_URL=https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/${OCP_CLI_VERSION}/openshift-client-linux.tar.gz
-RUN curl --silent --location --fail --show-error ${OCP_CLI_URL} | tar xfz - -C /usr/local/bin oc
+RUN curl ${CURL_OPTIONS} ${OCP_CLI_URL} | tar xfz - -C /usr/local/bin oc
 
 # Install dependencies: `ocm`
 ARG OCM_CLI_VERSION=v0.1.63
 ARG OCM_CLI_URL=https://github.com/openshift-online/ocm-cli/releases/download/${OCM_CLI_VERSION}/ocm-linux-amd64
-RUN curl --silent -L ${OCM_CLI_URL} --output /usr/local/bin/ocm
+RUN curl ${CURL_OPTIONS} ${OCM_CLI_URL} --output /usr/local/bin/ocm
 RUN chmod +x /usr/local/bin/ocm
 
 # Install dependencies: `helm`
 ARG HELM_VERSION=v3.5.1
 ARG HELM_URL=https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz
-RUN curl --silent ${HELM_URL} | tar xfz - -C /usr/local/bin --strip-components 1 linux-amd64/helm
+RUN curl ${CURL_OPTIONS} ${HELM_URL} | tar xfz - -C /usr/local/bin --strip-components 1 linux-amd64/helm
 
 # Install dependencies: `rosa`
 ARG ROSA_VERSION=latest
 ARG ROSA_URL=https://mirror.openshift.com/pub/openshift-v4/clients/rosa/${ROSA_VERSION}/rosa-linux.tar.gz
-RUN curl --silent ${ROSA_URL} | tar xfz - -C /usr/local/bin
+RUN curl ${CURL_OPTIONS} ${ROSA_URL} | tar xfz - -C /usr/local/bin
 
 # Install dependencies: `operator-sdk`
 ARG OPERATOR_SDK_VERSION=v1.6.2

--- a/testing/ods/common.sh
+++ b/testing/ods/common.sh
@@ -38,17 +38,17 @@ ODS_CI_ARTIFACTS_EXPORTER_DOCKERFILE="testing/ods/images/Containerfile.s3_artifa
 LDAP_IDP_NAME=RHODS_CI_LDAP
 LDAP_NB_USERS=1000
 
-ODS_CI_NB_USERS=5
+ODS_CI_NB_USERS=${ODS_CI_NB_USERS:-5} # number of users to simulate
 ODS_CI_USER_PREFIX=psapuser
 ODS_NOTEBOOK_SIZE=default # needs to match what the ROBOT test-case requests
 ODS_NOTEBOOK_SIZE_TEST_POD="test_pod" # shouldn't change
-ODS_SLEEP_FACTOR=1.0 # how long to wait between users.
+ODS_SLEEP_FACTOR=${ODS_SLEEP_FACTOR:-1.0} # how long to wait between user starts.
 ODS_CI_ARTIFACTS_COLLECTED=no-image-except-failed-and-zero
 
 NGINX_NOTEBOOK_NAMESPACE=loadtest-notebooks
 ODS_NOTEBOOK_NAME=simple-notebook.ipynb
 ODS_NOTEBOOK_DIR=${THIS_DIR}/notebooks
-ODS_EXCLUDE_TAGS=None
+ODS_EXCLUDE_TAGS=${ODS_EXCLUDE_TAGS:-None} # tags to exclude when running the robot test case
 
 if [[ "$OSD_USE_ODS_CATALOG" == "0" ]]; then
     # deploying from the addon. Get the email address from the secret vault.

--- a/testing/ods/common.sh
+++ b/testing/ods/common.sh
@@ -35,6 +35,9 @@ ODS_CI_TAG="latest"
 ODS_CI_ARTIFACTS_EXPORTER_TAG="artifacts-exporter"
 ODS_CI_ARTIFACTS_EXPORTER_DOCKERFILE="testing/ods/images/Containerfile.s3_artifacts_exporter"
 
+LDAP_IDP_NAME=RHODS_CI_LDAP
+LDAP_NB_USERS=1000
+
 ODS_CI_NB_USERS=5
 ODS_CI_USER_PREFIX=psapuser
 ODS_NOTEBOOK_SIZE=default # needs to match what the ROBOT test-case requests
@@ -51,8 +54,6 @@ if [[ "$OSD_USE_ODS_CATALOG" == "0" ]]; then
     # deploying from the addon. Get the email address from the secret vault.
     ODS_ADDON_EMAIL_ADDRESS=$(cat "$PSAP_ODS_SECRET_PATH/addon.email")
 fi
-
-LDAP_IDP_NAME=RHODS_CI_LDAP
 
 CLUSTER_NAME_PREFIX=odsci
 

--- a/testing/ods/jh-at-scale.sh
+++ b/testing/ods/jh-at-scale.sh
@@ -128,7 +128,7 @@ prepare_sutest_install_ldap() {
     osd_cluster_name=$(get_osd_cluster_name "sutest")
 
     process_ctrl::run_in_bg ./run_toolbox.py cluster deploy_ldap \
-              "$LDAP_IDP_NAME" "$ODS_CI_USER_PREFIX" "$ODS_CI_NB_USERS" "$S3_LDAP_PROPS" \
+              "$LDAP_IDP_NAME" "$ODS_CI_USER_PREFIX" "$LDAP_NB_USERS" "$S3_LDAP_PROPS" \
               --use_ocm="$osd_cluster_name" \
               --wait
 }

--- a/testing/ods/ocp_cluster.sh
+++ b/testing/ods/ocp_cluster.sh
@@ -40,6 +40,7 @@ create_cluster() {
         author=$(echo "$JOB_SPEC" | jq -r .refs.pulls[0].author)
         cluster_name="${author}-${cluster_role}-$(date +%Y%m%d-%Hh%M)"
 
+        export AWS_DEFAULT_PROFILE="${author}_ci-artifact"
     elif [[ "${PULL_NUMBER:-}" ]]; then
         cluster_name="${cluster_name}-pr${PULL_NUMBER}-${cluster_role}-${BUILD_ID}"
     else

--- a/testing/ods/ocp_cluster.sh
+++ b/testing/ods/ocp_cluster.sh
@@ -30,7 +30,7 @@ prepare_deploy_cluster_subproject() {
 create_cluster() {
     cluster_role=$1
     export ARTIFACT_TOOLBOX_NAME_PREFIX="ocp_${cluster_role}_"
-
+    export AWS_DEFAULT_PROFILE=${AWS_DEFAULT_PROFILE:-ci-artifact}
     # ---
 
     cd subprojects/deploy-cluster/
@@ -45,6 +45,9 @@ create_cluster() {
     else
         cluster_name="${cluster_name}-${cluster_role}-$(date +%Hh%M)"
     fi
+
+    export AWS_PROFILE=$AWS_DEFAULT_PROFILE
+    echo "Using AWS_[DEFAULT_]PROFILE=$AWS_DEFAULT_PROFILE"
 
     install_dir="/tmp/ocp_${cluster_role}_installer"
     rm -rf "$install_dir"


### PR DESCRIPTION
* `testing: ods: create LDAP users independently of ODS_CI_NB_USERS`

This allows creating first a large number of LDAP users, then running
the test multiple times with different user counts.

---

* `testing: ods: common: allows receving ODS_CI_NB_USERS ODS_SLEEP_FACTOR and ODS_EXCLUDE_TAGS values from env`

This makes it easier to override the value of these variables without
modifying the source files.

---

* `testing: ods: ocp_cluster.sh: use the AWS profile 'ci-artifact' by default`


---

* `testing: ods: ocp_cluster.sh: use the AWS profile '${author}_ci-artifact' for get-cluster`


---

* `build: use the same options for all the curl calls`


---