### PR TITLE
build: Follow redirects for mirror.openshift.com

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -24,7 +24,7 @@ RUN pip install --upgrade pip
 # Install dependencies: `oc`
 ARG OCP_CLI_VERSION=latest
 ARG OCP_CLI_URL=https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/${OCP_CLI_VERSION}/openshift-client-linux.tar.gz
-RUN curl --silent ${OCP_CLI_URL} | tar xfz - -C /usr/local/bin oc
+RUN curl --silent --location --fail --show-error ${OCP_CLI_URL} | tar xfz - -C /usr/local/bin oc
 
 # Install dependencies: `ocm`
 ARG OCM_CLI_VERSION=v0.1.63


### PR DESCRIPTION
Original commit cherry-picked from https://github.com/rh-ecosystem-edge/ci-artifacts/pull/45
```
Requests to mirror.openshift.com originating from the CI worker IP
pool are now redirected to S3 buckets for cost saving.
```
`curl`'s `--location` (long for `-L`) follows this redirection.

Also add `--fail` and `--show-error` to fail explicitly on HTTP
errors.
