### PR TITLE
testing: ods: cleanup/zombies.sh: do not expose AWS_PROFILE

### DIFF
--- a/testing/ods/cleanup/zombies.sh
+++ b/testing/ods/cleanup/zombies.sh
@@ -6,7 +6,6 @@ set -o nounset
 set -o errtrace
 set -x
 
-export AWS_PROFILE=${AWS_PROFILE:-ci-artifact}
 export AWS_DEFAULT_PROFILE=${AWS_DEFAULT_PROFILE:-ci-artifact}
 
 THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"


### PR DESCRIPTION
only `AWS_DEFAULT_PROFILE` must be exposed for the boto3 scripts to run :/

/cc @kpouget 