### PR TITLE
RHODS: minor updates

### DIFF
--- a/testing/ods/common.sh
+++ b/testing/ods/common.sh
@@ -28,7 +28,7 @@ RHODS_NOTEBOOK_IMAGE_NAME=s2i-generic-data-science-notebook
 
 ODS_CI_TEST_NAMESPACE=loadtest
 ODS_CI_REPO="https://github.com/openshift-psap/ods-ci.git"
-ODS_CI_REF="jh-at-scale.v220819-2"
+ODS_CI_REF="jh-at-scale.v220822"
 
 ODS_CI_IMAGESTREAM="ods-ci"
 ODS_CI_TAG="latest"

--- a/toolbox/rhods.py
+++ b/toolbox/rhods.py
@@ -67,7 +67,7 @@ class RHODS:
                         ods_sleep_factor="1.0",
                         ods_ci_exclude_tags="None",
                         ods_ci_test_case="test-jupyterlab-run-notebook.robot",
-                        ods_ci_artifacts_exporter_istag="ods-ci:artifacts_exporter",
+                        ods_ci_artifacts_exporter_istag="ods-ci:artifacts-exporter",
                         ods_ci_notebook_image_name="s2i-generic-data-science-notebook",
                         ):
 


### PR DESCRIPTION
/cc @kpouget 

* `toolbox: rhods: fix typo in ods_ci_artifacts_exporter_istag default value`


---

* `testing: ods: common: update ODS_CI_REF`

The update adds this commit aec8a887cb47fe5d6525a2fbe8de6f9520355431:

```
* `Add optional RHODS_VERSION predefined variable`

so that the call to `oc get csv` can be avoided
```

---