### PR TITLE
testing: run: disable PR rehearsal

### DIFF
--- a/testing/run
+++ b/testing/run
@@ -19,6 +19,12 @@ ci_banner() {
 }
 
 prechecks() {
+    if [ "${INSIDE_CI_IMAGE:-}" == "y" ]; then
+        if [ "$JOB_NAME" == rehearse-* ]; then
+            echo "FATAL: rehearsal disabled. Please merge the commit for testing."
+            exit 1
+        fi
+    fi
     if [ -z "${ARTIFACT_DIR:-}" ]; then
         if [[ "${INSIDE_CI_IMAGE:-}" == "y" ]]; then
             echo "ARTIFACT_DIR not set, cannot proceed without inside the image."


### PR DESCRIPTION
This PR disables the rehearsal of `ci-artifacts` tests (from
`openshift/release`).

Rehearsal (and testing) creates clusters, we don't want to waste
resources by automatically creating multiple clusters. Better merge
the `openshift/release` PR and test on demand on ci-artifacts.