### PR TITLE
testing: pr_args: new script to fetch the PR test arguments

### DIFF
--- a/testing/pr_args.sh
+++ b/testing/pr_args.sh
@@ -1,0 +1,48 @@
+#! /bin/bash -xe
+
+set -o errexit
+set -o pipefail
+set -o nounset
+set -o errtrace
+
+DEST=${1:-}
+
+if [[ -z "$DEST" ]]; then
+    echo "ERROR: expected a destination file as parameter ..."
+    exit 1
+fi
+
+if [[ -z "${PULL_NUMBER:-}" ]]; then
+    echo "ERROR: no PR_NUMBER available ..."
+    exit 1
+fi
+
+PR_URL="https://api.github.com/repos/openshift-psap/ci-artifacts/pulls/$PULL_NUMBER"
+PR_COMMENTS_URL="https://api.github.com/repos/openshift-psap/ci-artifacts/issues/$PULL_NUMBER/comments"
+
+author=kpouget #;$(echo "$JOB_SPEC" | jq -r .refs.pulls[0].author)
+
+JOB_NAME_PREFIX=pull-ci-openshift-psap-ci-artifacts-master
+test_name=test-pr-no-cluster #$(echo "$JOB_NAME" | sed "s/$JOB_NAME_PREFIX-//")
+
+last_user_test_comment=$(curl -sSf "$PR_COMMENTS_URL" \
+                             | jq '.[] | select(.user.login == "'$author'") | .body' \
+                             | grep "$test_name" \
+                             | tail -1 | jq -r)
+pr_body=$(curl -sSf $PR_URL | jq -r .body)
+
+pos_args=$(echo "$last_user_test_comment" |
+               grep "$test_name" | cut -d" " -f3- | tr -d '\n' | tr -d '\r')
+if [[ "$pos_args" ]]; then
+    echo "PR_POSITIONAL_ARGS='$pos_args'" >> "$DEST"
+fi
+
+while read line; do
+    [[ $line != "/env "* ]] && continue
+    [[ $line != *=* ]] && continue
+
+    key=$(echo "$line" | cut -d" " -f2- | cut -d= -f1)
+    value=$(echo "$line" | cut -d= -f2 | tr -d '\n' | tr -d '\r')
+
+    echo "$key='$value'" >> "$DEST"
+done <<< $(echo "$pr_body"; echo "$last_user_test_comment")

--- a/testing/run
+++ b/testing/run
@@ -39,6 +39,16 @@ prechecks() {
         echo "Using ARTIFACT_DIR=$ARTIFACT_DIR."
     fi
 
+    if [[ "${PULL_NUMBER:-}" ]]; then
+        DEST="${ARTIFACT_DIR}/variable_overrides"
+        "$THIS_DIR/pr_args.sh" "$DEST"
+        if [[ -f "$DEST" ]]; then
+            echo "Variables overriden from PR:"
+            cat "$DEST"
+            echo "---"
+        fi
+    fi
+
     if ! oc version; then
         if [[ -z "${KUBECONFIG}" ]]
         then


### PR DESCRIPTION
This PR fetches extra configuration settings from the PR body and test trigger comment.
The syntax is: `/env key=value` or `/test <prow_test> <inline settings>`, example:
```
/test test-pr-no-cluster hello world
/env hello=world
/env toto=yes
```
which generates the [following file](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/openshift-psap_ci-artifacts/491/pull-ci-openshift-psap-ci-artifacts-master-test-pr-no-cluster/1565963447680634880/artifacts/test-pr-no-cluster/test-pr/artifacts/variable_overrides) in `${ARTIFACT_DIR}/variable_overrides`
```
PR_POSITIONAL_ARGS='hello world'
test_path='recipes test'
hello='world'
toto='yes'
```
This file can then be sourced or parsed from the test.