### PR TITLE
testing: pr_args: use /var instead of /env

### DIFF
--- a/testing/pr_args.sh
+++ b/testing/pr_args.sh
@@ -38,7 +38,7 @@ if [[ "$pos_args" ]]; then
 fi
 
 while read line; do
-    [[ $line != "/env "* ]] && continue
+    [[ $line != "/var "* ]] && continue
     [[ $line != *=* ]] && continue
 
     key=$(echo "$line" | cut -d" " -f2- | cut -d= -f1)


### PR DESCRIPTION
As the variable is not exposed in the environment variables.

/cc @kpouget 