### PR TITLE
RHODS: minor updates

### DIFF
--- a/subprojects/matrix-benchmarking-workloads/rhods-ci/store.py
+++ b/subprojects/matrix-benchmarking-workloads/rhods-ci/store.py
@@ -260,7 +260,7 @@ def _parse_pod_times(filename, is_notebook=False):
                     pod["status"]["containerStatuses"][0]["state"]["terminated"]["finishedAt"],
                     K8S_TIME_FMT)
 
-        elif pod["status"]["containerStatuses"][0]["state"]["running"]:
+        elif pod["status"]["containerStatuses"][0]["state"].get("running"):
             pod_times[podname].container_running_since = \
                 datetime.datetime.strptime(
                     pod["status"]["containerStatuses"][0]["state"]["running"]["startedAt"],
@@ -268,7 +268,6 @@ def _parse_pod_times(filename, is_notebook=False):
 
         else:
             print("Unknown containerStatuses ...")
-            import pdb;pdb.set_trace()
             pass
 
     return pod_times

--- a/testing/ods/private_cluster.sh
+++ b/testing/ods/private_cluster.sh
@@ -68,7 +68,7 @@ prepare_sutest_cluster() {
     ./run_toolbox.py cluster set-scale "$compute_nodes_type" "$compute_nodes_count"
 }
 
-prepare_sutest_cluster() {
+unprepare_sutest_cluster() {
     cluster_role=sutest
 
     export ARTIFACT_TOOLBOX_NAME_PREFIX="${cluster_role}_"

--- a/testing/pr_args.sh
+++ b/testing/pr_args.sh
@@ -1,4 +1,4 @@
-#! /bin/bash -xe
+#! /bin/bash
 
 set -o errexit
 set -o pipefail


### PR DESCRIPTION
* `testing: ods: generate_matrix-benchmarking: use overwrittable variable MATBENCH_DATA_URL`

instead of PR body anchor

---

* `testing: pr_args: remove '-x'`


---

* `[matrix-benchmarking-workloads/rhods-ci] Do not crash if no state is available`


---

* `testing: ods: private_cluster: fix function name`


---