### PR TITLE
RHODS: minor updates

### DIFF
--- a/roles/rhods_notebook_ux_e2e_scale_test/tasks/main.yml
+++ b/roles/rhods_notebook_ux_e2e_scale_test/tasks/main.yml
@@ -292,7 +292,9 @@
 - name: Test if all the test jobs failed
   shell:
     set -o pipefail;
-    (cat "{{ artifact_extra_logs_dir }}"/ods-ci/ods-ci-*/test.exit_code | grep '^0$' || true) | wc -l
+    (cat "{{ artifact_extra_logs_dir }}"/ods-ci/ods-ci-*/test.exit_code || true)
+      | (grep '^0$' || true)
+      | wc -l
   register: success_count_cmd
   failed_when: success_count_cmd.stdout == "0"
 

--- a/testing/ods/private_cluster.sh
+++ b/testing/ods/private_cluster.sh
@@ -60,7 +60,11 @@ prepare_sutest_cluster() {
     export ARTIFACT_TOOLBOX_NAME_PREFIX="${cluster_role}_"
     export KUBECONFIG=$KUBECONFIG_SUTEST
 
-    # nothing to do at the moment
+    oc delete events --all --wait=false -n rhods-notebooks || true
+
+    for kind in notebooks secrets cm; do
+        oc get "$kind" -oname -n rhods-notebooks | grep "$ODS_CI_USER_PREFIX" | xargs -r oc delete || true
+    done
 }
 
 unprepare_sutest_cluster() {

--- a/testing/ods/private_cluster.sh
+++ b/testing/ods/private_cluster.sh
@@ -26,7 +26,7 @@ prepare_driver_cluster() {
     export ARTIFACT_TOOLBOX_NAME_PREFIX="${cluster_role}_"
     export KUBECONFIG=$KUBECONFIG_DRIVER
 
-    ./run_toolbox.py cluster set-scale "$OCP_INFRA_MACHINE_TYPE" "$OCP_INFRA_NODES_COUNT"
+    # nothing to do at the moment
 }
 
 connect_sutest_cluster() {


### PR DESCRIPTION
* `testing: ods: private_cluster: do not pre-scale the driver cluster`


---

* `testing: ods: private_cluster: delete notebooks resources when starting the test`


---

* `rhods_notebook_ux_e2e_scale_test: fix 'Test if all the test jobs failed'`


---

/cc @kpouget 