### PR TITLE
rhods_notebook_api_scale_test: disable REUSE_COOKIES by default when running on the cluster

### DIFF
--- a/roles/rhods_notebook_api_scale_test/files/entrypoint/locustfile.py
+++ b/roles/rhods_notebook_api_scale_test/files/entrypoint/locustfile.py
@@ -31,7 +31,7 @@ env.NAMESPACE = "rhods-notebooks"
 env.NOTEBOOK_IMAGE_NAME = os.getenv("NOTEBOOK_IMAGE_NAME")
 env.NOTEBOOK_SIZE_NAME = os.getenv("NOTEBOOK_SIZE_NAME")
 env.USER_INDEX_OFFSET = int(os.getenv("USER_INDEX_OFFSET", 0))
-env.SAVE_COOKIES = True
+env.REUSE_COOKIES = os.getenv("REUSE_COOKIES", False) == "1"
 env.DO_NOT_STOP_NOTEBOOK = False
 
 # Other env variables:
@@ -73,7 +73,7 @@ class NotebookUser(HttpUser):
     def on_start(self):
         print(f"Running user #{self.user_name}")
 
-        if env.SAVE_COOKIES:
+        if env.REUSE_COOKIES:
             try:
                 with open(f"cookies.{self.user_id}.pickle", "rb") as f:
                     self.client.cookies.update(pickle.load(f))
@@ -84,7 +84,7 @@ class NotebookUser(HttpUser):
             print("Failed to go to RHODS dashboard")
             return False
 
-        if env.SAVE_COOKIES:
+        if env.REUSE_COOKIES:
             with open(f"cookies.{self.user_id}.pickle", "wb") as f:
                 pickle.dump(self.client.cookies, f)
 

--- a/roles/rhods_notebook_api_scale_test/files/entrypoint/run_locust_on_laptop.sh
+++ b/roles/rhods_notebook_api_scale_test/files/entrypoint/run_locust_on_laptop.sh
@@ -26,6 +26,7 @@ export LOCUST_RUN_TIME=5m
 #export LOCUST_ITERATIONS=1
 
 export LOCUST_LOCUSTFILE=$PWD/locustfile.py
+export REUSE_COOKIES=1
 
 DEBUG_MODE=${DEBUG_MODE:-1}
 if [[ "$DEBUG_MODE" == 1 ]]; then

--- a/testing/ods/clusters.sh
+++ b/testing/ods/clusters.sh
@@ -151,14 +151,18 @@ fi
 action="${1:-}"
 shift
 
-cluster_type="${PR_POSITIONAL_ARG1:-$CI_DEFAULT_CLUSTER_TYPE}"
-create_flag="${PR_POSITIONAL_ARG2:-}"
+cluster_type="${PR_POSITIONAL_ARG_0:-$CI_DEFAULT_CLUSTER_TYPE}"
+create_flag="${PR_POSITIONAL_ARG_1:-}"
 
 if [[ -z "cluster_type" ]]; then
     echo "ERROR: cluster type not found in ODS_CLUSTER_TYPE or PR_POSITIONAL_ARGS"
     exit 1
+elif [[ "$cluster_type" == "keep" ]]; then
+    cluster_type="$CI_DEFAULT_CLUSTER_TYPE"
+    create_flag="keep"
 elif [[ "$cluster_type" == "customer" ]]; then
     cluster_type="single"
+
 fi
 
 set -x


### PR DESCRIPTION
/var NOTEBOOK_TEST_FLAVOR=api-level
/var ODS_CATALOG_IMAGE=quay.io/llasmith/rhods-operator-live-catalog
/var ODS_CATALOG_IMAGE_TAG=1.18.0-6