### PR TITLE
RHODS: test 1.18

### DIFF
--- a/subprojects/matrix-benchmarking-workloads/rhods-notebooks-ux/plotting/error_report.py
+++ b/subprojects/matrix-benchmarking-workloads/rhods-notebooks-ux/plotting/error_report.py
@@ -208,7 +208,10 @@ class ErrorReport():
                 robot_log_path = user_dir / "log.html"
 
                 images = list(user_dir.glob("*.png"))
-                images.sort(key=lambda f: int(re.findall(r"selenium-screenshot-([0-9]*).png", f.name)[0]))
+                try:
+                    images.sort(key=lambda f: int(re.findall(r"selenium-screenshot-([0-9]*).png", f.name)[0]))
+                except IndexError: pass # no sorting if no image is available
+
                 last_screenshot_path = images[-1] if images else None
 
                 content.append(html.Ul([

--- a/testing/ods/config_clusters.sh
+++ b/testing/ods/config_clusters.sh
@@ -37,6 +37,12 @@ SUTEST_TAINT_VALUE=yes
 SUTEST_TAINT_EFFECT=NoSchedule
 SUTEST_NODE_SELECTOR="$SUTEST_TAINT_KEY=$SUTEST_TAINT_VALUE"
 
+OSD_SUTEST_COMPUTE_MACHINE_TYPE=m5.2xlarge
+OCP_SUTEST_COMPUTE_MACHINE_TYPE=m5a.2xlarge
+
+SUTEST_FORCE_COMPUTE_NODES_COUNT= # if empty, uses ods/sizing/sizing to determine the right number of machines
+
+
 DRIVER_MACHINESET_NAME=test-pods
 DRIVER_TAINT_KEY=only-$DRIVER_MACHINESET_NAME
 DRIVER_TAINT_VALUE=yes
@@ -44,10 +50,7 @@ DRIVER_TAINT_EFFECT=NoSchedule
 DRIVER_NODE_SELECTOR="$DRIVER_TAINT_KEY=$DRIVER_TAINT_VALUE"
 
 DRIVER_COMPUTE_MACHINE_TYPE=m5a.2xlarge
-OSD_SUTEST_COMPUTE_MACHINE_TYPE=m5.2xlarge
-OCP_SUTEST_COMPUTE_MACHINE_TYPE=m5a.2xlarge
 
-SUTEST_FORCE_COMPUTE_NODES_COUNT= # if empty, uses ods/sizing/sizing to determine the right number of machines
 DRIVER_FORCE_COMPUTE_NODES_COUNT= # if empty, uses ods/sizing/sizing to determine the right number of machines
 
 # cluster that will be available right away when going to the debug tab of the test pod in the CI cluster

--- a/testing/ods/sizing/machines
+++ b/testing/ods/sizing/machines
@@ -51,4 +51,5 @@ g4dn.12xlarge, 48 vCPU, 192 GiB RAM, $3.912, 4 GPU
 # Not an OSD machine
 m6a.xlarge, 4 vcpu, 16 Gib RAM, $0.173
 m6a.2xlarge, 8 vcpu, 32 Gib RAM, $0.345
+m6i.2xlarge, 8 vcpu, 32 Gib RAM, $0.384
 m5a.2xlarge, 8 vcpu, 32 Gib RAM, $0.344

--- a/testing/ods/sizing/sizing
+++ b/testing/ods/sizing/sizing
@@ -71,4 +71,8 @@ def main():
     return machine_count
 
 if __name__ == "__main__":
-    sys.exit(main())
+    try:
+        sys.exit(main()) # returns the number of nodes required
+    except Exception as e:
+        print(f"ERROR: '{' '.join(sys.argv)}' failed: {e.__class__.__name__}: {e}")
+        sys.exit(0) # 0 means that an error occured


### PR DESCRIPTION
/var CI_DEFAULT_CLUSTER_TYPE=ocp

/var OCP_VERSION=4.11.9
/var OCP_SUTEST_COMPUTE_MACHINE_TYPE=m6i.2xlarge
/var OCP_MASTER_MACHINE_TYPE=m6i.2xlarge

/var ODS_CATALOG_IMAGE=quay.io/llasmith/rhods-operator-live-catalog
/var ODS_CATALOG_IMAGE_TAG=1.18.0-7

/var ODS_CI_NB_USERS=200
/var ODS_SLEEP_FACTOR=5

/cc @kpouget 