### PR TITLE
RHODS: test RHODS

### DIFF
--- a/roles/rhods_notebook_ux_e2e_scale_test/tasks/main.yml
+++ b/roles/rhods_notebook_ux_e2e_scale_test/tasks/main.yml
@@ -272,8 +272,8 @@
       xargs --no-run-if-empty --replace
             oc annotate {} --overwrite
                kubeflow-resource-stopped=stopped-by-ci-artifacts
-               -oname
                -n {{ rhods_notebook_namespace }}
+               -oname > /dev/null
 
 - name: Capture the driver cluster artifacts
   include_tasks: artifacts_driver.yml

--- a/testing/ods/config.yaml
+++ b/testing/ods/config.yaml
@@ -98,7 +98,7 @@ tests:
     users:
       count: 5 # number of users to simulate
       start_offset: 0 # offset to add to the Pod user index
-      sleep_factor: 1.0 # how long to wait between user starts, multiplied by the user index
+      sleep_factor: 5.0 # how long to wait between user starts, multiplied by the user index
     flavor_to_run: user-level
     namespace: notebooks-scale-test
     imagestream_name: scale-test


### PR DESCRIPTION
/var clusters.create.ocp.control_plane.type=m6i.2xlarge
/var clusters.create.ocp.compute.type=m6i.2xlarge

/var rhods.catalog.image=quay.io/modh/qe-catalog-source
/var rhods.catalog.tag=v1180-8 

/var tests.notebooks.users.count=300
/var tests.notebooks.users.sleep_factor=2

