### PR TITLE
RHODS: test 1.19

### DIFF
--- a/testing/ods/clusters.sh
+++ b/testing/ods/clusters.sh
@@ -17,8 +17,8 @@ source "$TESTING_ODS_DIR/cluster_helpers.sh"
 
 prepare_args_from_pr() {
 
-    set_config_from_pr_arg 0 "clusters.create.type"
-    set_config_from_pr_arg 1 "clusters.create.keep" --optional
+    set_config_from_pr_arg 1 "clusters.create.type"
+    set_config_from_pr_arg 2 "clusters.create.keep" --optional
 
     if [[ "$(get_config clusters.create.keep)" == keep ]]; then
         set_config clusters.create.keep true

--- a/testing/ods/clusters.sh
+++ b/testing/ods/clusters.sh
@@ -128,7 +128,7 @@ create_clusters() {
 
             local pr_author=$(echo "$JOB_SPEC" | jq -r .refs.pulls[0].author)
             local keep_cluster_password_file="$PSAP_ODS_SECRET_PATH/$(get_config secrets.keep_cluster_password_file)"
-            ./run_toolbox.py cluster create_htpasswd_adminuser "$pr_author" "$password_file"
+            ./run_toolbox.py cluster create_htpasswd_adminuser "$pr_author" "$keep_cluster_password_file"
 
             oc whoami --show-console > "$ARTIFACT_DIR/${cluster_role}_console.link"
             cat <<EOF > "$ARTIFACT_DIR/${cluster_role}_oc-login.cmd"

--- a/testing/ods/generate_matrix-benchmarking.sh
+++ b/testing/ods/generate_matrix-benchmarking.sh
@@ -21,7 +21,11 @@ fi
 
 matbench_preset=$(get_config matbench.preset)
 
-if [[ "$matbench_preset" == "https://"* ]]; then
+if [[ "$matbench_preset" == null ]]; then
+    # no preset defined
+    true
+
+elif [[ "$matbench_preset" == "https://"* ]]; then
     set_config matbench.download.url "$matbench_preset"
 else
     set_config matbench.config_file "${matbench_preset}.yaml"

--- a/testing/ods/generate_matrix-benchmarking.sh
+++ b/testing/ods/generate_matrix-benchmarking.sh
@@ -15,7 +15,9 @@ ARTIFACT_DIR=${ARTIFACT_DIR:-/tmp/ci-artifacts_$(date +%Y%m%d)}
 export MATBENCH_WORKLOAD=$(get_config matbench.workload)
 WORKLOAD_STORAGE_DIR="$TESTING_ODS_DIR/../../subprojects/matrix-benchmarking-workloads/$MATBENCH_WORKLOAD"
 
-set_config_from_pr_arg 1 "matbench.preset"
+if [[ "$(get_config PR_POSITIONAL_ARG_0)" == ods-plot-* ]]; then
+    set_config_from_pr_arg 1 "matbench.preset"
+fi
 
 matbench_preset=$(get_config matbench.preset)
 

--- a/testing/ods/generate_matrix-benchmarking.sh
+++ b/testing/ods/generate_matrix-benchmarking.sh
@@ -15,7 +15,7 @@ ARTIFACT_DIR=${ARTIFACT_DIR:-/tmp/ci-artifacts_$(date +%Y%m%d)}
 export MATBENCH_WORKLOAD=$(get_config matbench.workload)
 WORKLOAD_STORAGE_DIR="$TESTING_ODS_DIR/../../subprojects/matrix-benchmarking-workloads/$MATBENCH_WORKLOAD"
 
-set_config_from_pr_arg 0 "matbench.preset"
+set_config_from_pr_arg 1 "matbench.preset"
 
 matbench_preset=$(get_config matbench.preset)
 

--- a/testing/ods/run_notebook_scale_test_on_private.sh
+++ b/testing/ods/run_notebook_scale_test_on_private.sh
@@ -22,8 +22,8 @@ export KUBECONFIG_SUTEST=/tmp/sutest_kubeconfig
 HOSTNAME_KEY=clusters.create.sutest.already_exists.hostname
 USERNAME_KEY=clusters.create.sutest_already_exists.username
 
-set_config_from_pr_arg 0 "$HOSTNAME_KEY"
-set_config_from_pr_arg 1 "$USERNAME_KEY"
+set_config_from_pr_arg 1 "$HOSTNAME_KEY"
+set_config_from_pr_arg 2 "$USERNAME_KEY"
 
 cluster_hostname=$(get_config "$HOSTNAME_KEY")
 if [[ -z "$cluster_hostname" ]]; then

--- a/testing/pr_args.sh
+++ b/testing/pr_args.sh
@@ -47,12 +47,13 @@ pos_args=$(echo "$last_user_test_comment" |
                (grep "$test_name" || true) | cut -d" " -f3- | tr -d '\n' | tr -d '\r')
 if [[ "$pos_args" ]]; then
     echo "PR_POSITIONAL_ARGS='$pos_args'" >> "$DEST"
-    i=0
+    i=1
     for pos_arg in $pos_args; do
         echo "PR_POSITIONAL_ARG_$i='$pos_arg'" >> "$DEST"
         i=$((i + 1))
     done
 fi
+echo "PR_POSITIONAL_ARG_0='$test_name'" >> "$DEST"
 
 while read line; do
     [[ $line != "/var "* ]] && continue


### PR DESCRIPTION

/var clusters.create.ocp.control_plan.type=m6i.2xlarge
/var clusters.create.ocp.compute.type=m6i.2xlarge

/var rhods.catalog.image=quay.io/modh/qe-catalog-source
/var rhods.catalog.tag=v1190-7

/var tests.notebooks.users.count=5
/var test.notebooks.users.sleep_factor=2
