### PR TITLE
RHODS: various updates

### DIFF
--- a/subprojects/matrix-benchmarking-workloads/rhods-notebooks-ux/store_thresholds.py
+++ b/subprojects/matrix-benchmarking-workloads/rhods-notebooks-ux/store_thresholds.py
@@ -22,6 +22,10 @@ def _parse_thresholds():
     with open(fname) as f:
         data = yaml.safe_load(f)
 
+    if not data.get("visualize") or not data["visualize"].get("thresholds"):
+        logging.info(f"No threshold found in {filename}")
+        return
+
     for entry in data["visualize"]["thresholds"]:
         thresholds_cache.append([entry["settings_selector"], entry["thresholds"]])
 

--- a/testing/ods/clusters.sh
+++ b/testing/ods/clusters.sh
@@ -17,8 +17,8 @@ source "$TESTING_ODS_DIR/cluster_helpers.sh"
 
 prepare_args_from_pr() {
 
-    set_config_from_pr_arg 0 "clusters.create.type"
-    set_config_from_pr_arg 1 "clusters.create.keep" --optional
+    set_config_from_pr_arg 1 "clusters.create.type"
+    set_config_from_pr_arg 2 "clusters.create.keep" --optional
 
     if [[ "$(get_config clusters.create.keep)" == keep ]]; then
         set_config clusters.create.keep true

--- a/testing/ods/clusters.sh
+++ b/testing/ods/clusters.sh
@@ -128,7 +128,7 @@ create_clusters() {
 
             local pr_author=$(echo "$JOB_SPEC" | jq -r .refs.pulls[0].author)
             local keep_cluster_password_file="$PSAP_ODS_SECRET_PATH/$(get_config secrets.keep_cluster_password_file)"
-            ./run_toolbox.py cluster create_htpasswd_adminuser "$pr_author" "$password_file"
+            ./run_toolbox.py cluster create_htpasswd_adminuser "$pr_author" "$keep_cluster_password_file"
 
             oc whoami --show-console > "$ARTIFACT_DIR/${cluster_role}_console.link"
             cat <<EOF > "$ARTIFACT_DIR/${cluster_role}_oc-login.cmd"

--- a/testing/ods/configure.sh
+++ b/testing/ods/configure.sh
@@ -25,8 +25,12 @@ get_config() {
 }
 
 set_config() {
-    key=$1
-    value=$2
+    key=${1:-}
+    value=${2:-}
+
+    if [[ -z "$key" || -z "$value" ]]; then
+        error "set_config key value are both mandatory"
+    fi
 
     yq --yaml-roundtrip --in-place --argjson value "$(echo "$value" | yq)" ".$key = \$value" "$CI_ARTIFACTS_FROM_CONFIG_FILE"
 
@@ -47,14 +51,14 @@ set_config_from_pr_arg() {
 
     if [[ -z "$arg_idx" ]]; then
         if [[ "$warn_missing" == 1 ]]; then
-            _warning "set_config_from_pr_ar '$arg_idx' '$config_key': arg_idx missing"
+            _error "set_config_from_pr_ar '$arg_idx' '$config_key': arg_idx missing"
         fi
 
         return
     fi
 
     if [[ -z "$config_key" ]]; then
-        _warning "set_config_from_pr_ar '$arg_idx' '$config_key': config_key missing"
+        _error "set_config_from_pr_ar '$arg_idx' '$config_key': config_key missing"
         return
     fi
 

--- a/testing/ods/generate_matrix-benchmarking.sh
+++ b/testing/ods/generate_matrix-benchmarking.sh
@@ -21,7 +21,11 @@ fi
 
 matbench_preset=$(get_config matbench.preset)
 
-if [[ "$matbench_preset" == "https://"* ]]; then
+if [[ "$matbench_preset" == null ]]; then
+    # no preset defined
+    true
+
+elif [[ "$matbench_preset" == "https://"* ]]; then
     set_config matbench.download.url "$matbench_preset"
 else
     set_config matbench.config_file "${matbench_preset}.yaml"

--- a/testing/ods/generate_matrix-benchmarking.sh
+++ b/testing/ods/generate_matrix-benchmarking.sh
@@ -15,7 +15,9 @@ ARTIFACT_DIR=${ARTIFACT_DIR:-/tmp/ci-artifacts_$(date +%Y%m%d)}
 export MATBENCH_WORKLOAD=$(get_config matbench.workload)
 WORKLOAD_STORAGE_DIR="$TESTING_ODS_DIR/../../subprojects/matrix-benchmarking-workloads/$MATBENCH_WORKLOAD"
 
-set_config_from_pr_arg 1 "matbench.preset"
+if [[ "$(get_config PR_POSITIONAL_ARG_0)" == ods-plot-* ]]; then
+    set_config_from_pr_arg 1 "matbench.preset"
+fi
 
 matbench_preset=$(get_config matbench.preset)
 

--- a/testing/ods/generate_matrix-benchmarking.sh
+++ b/testing/ods/generate_matrix-benchmarking.sh
@@ -15,7 +15,7 @@ ARTIFACT_DIR=${ARTIFACT_DIR:-/tmp/ci-artifacts_$(date +%Y%m%d)}
 export MATBENCH_WORKLOAD=$(get_config matbench.workload)
 WORKLOAD_STORAGE_DIR="$TESTING_ODS_DIR/../../subprojects/matrix-benchmarking-workloads/$MATBENCH_WORKLOAD"
 
-set_config_from_pr_arg 0 "matbench.preset"
+set_config_from_pr_arg 1 "matbench.preset"
 
 matbench_preset=$(get_config matbench.preset)
 

--- a/testing/ods/private_cluster.sh
+++ b/testing/ods/private_cluster.sh
@@ -8,11 +8,8 @@ set -x
 
 TESTING_ODS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 source "$TESTING_ODS_DIR/../_logging.sh"
-source "$TESTING_ODS_DIR/process_ctrl.sh"
-source "$TESTING_ODS_DIR/config_common.sh"
-source "$TESTING_ODS_DIR/config_clusters.sh"
-source "$TESTING_ODS_DIR/config_load_overrides.sh"
-
+source "$TESTING_ODS_DIR/../process_ctrl.sh"
+source "$TESTING_ODS_DIR/configure.sh"
 source "$TESTING_ODS_DIR/cluster_helpers.sh"
 
 HOSTNAME_KEY=clusters.create.sutest.already_exists.hostname
@@ -29,13 +26,13 @@ prepare_driver_cluster() {
 
 connect_sutest_cluster() {
     local cluster_hostname=$(get_config "$HOSTNAME_KEY")
-    if [[ -z "$cluster_hostname" ]]; then
-        _error "$HOSTNAME_KEY must be set with the hostname of the private cluster, or with the PR argument 0"
+    if [[ "$cluster_hostname" == null ]]; then
+        _error "$HOSTNAME_KEY must be set with the hostname of the private cluster, or with the PR argument 1."
     fi
 
     local cluster_username=$(get_config "$USERNAME_KEY")
-    if [[ -z "$cluster_username" ]]; then
-        _error "$USERNAME_KEY must be set with the username to use to log into the private cluster, or with the PR argument 1"
+    if [[ "$cluster_username" == null ]]; then
+        _error "$USERNAME_KEY must be set with the username to use to log into the private cluster, or with the PR argument 2."
     fi
 
     rm -f "$KUBECONFIG_SUTEST"
@@ -79,46 +76,50 @@ unprepare_driver_cluster() {
     # nothing to do at the moment
 }
 
-if [[ -z "${KUBECONFIG_DRIVER:-}" ]]; then
-    _error "KUBECONFIG_DRIVER must be set"
-fi
+main() {
+    if [[ -z "${KUBECONFIG_DRIVER:-}" ]]; then
+        _error "KUBECONFIG_DRIVER must be set"
+    fi
 
-if [[ -z "${KUBECONFIG_SUTEST:-}" ]]; then
-    _error "KUBECONFIG_SUTEST must be set"
-fi
+    if [[ -z "${KUBECONFIG_SUTEST:-}" ]]; then
+        _error "KUBECONFIG_SUTEST must be set"
+    fi
 
-if [[ -z "${ARTIFACT_DIR:-}" ]]; then
-    _error "artifacts storage directory ARTIFACT_DIR not set ..."
-    exit 1
-fi
-
-action="${1:-}"
-
-set -x
-
-case ${action} in
-    "connect_sutest_cluster")
-        connect_sutest_cluster
-        exit 0
-        ;;
-    "prepare_sutest_cluster")
-        prepare_sutest_cluster
-        exit 0
-        ;;
-    "prepare_driver_cluster")
-        prepare_driver_cluster
-        exit 0
-        ;;
-    "unprepare_sutest_cluster")
-        unprepare_sutest_cluster
-        exit 0
-        ;;
-    "unprepare_driver_cluster")
-        unprepare_driver_cluster
-        exit 0
-        ;;
-    *)
-        echo "FATAL: Unknown action: ${action}"
+    if [[ -z "${ARTIFACT_DIR:-}" ]]; then
+        _error "artifacts storage directory ARTIFACT_DIR not set ..."
         exit 1
-        ;;
-esac
+    fi
+
+    local action="${1:-}"
+
+    set -x
+
+    case ${action} in
+        "connect_sutest_cluster")
+            connect_sutest_cluster
+            exit 0
+            ;;
+        "prepare_sutest_cluster")
+            prepare_sutest_cluster
+            exit 0
+            ;;
+        "prepare_driver_cluster")
+            prepare_driver_cluster
+            exit 0
+            ;;
+        "unprepare_sutest_cluster")
+            unprepare_sutest_cluster
+            exit 0
+            ;;
+        "unprepare_driver_cluster")
+            unprepare_driver_cluster
+            exit 0
+            ;;
+        *)
+            echo "FATAL: Unknown action: ${action}"
+            exit 1
+            ;;
+    esac
+}
+
+main "$@"

--- a/testing/ods/run_notebook_scale_test_on_private.sh
+++ b/testing/ods/run_notebook_scale_test_on_private.sh
@@ -8,12 +8,9 @@ set -x
 
 TESTING_ODS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
-source "$TESTING_ODS_DIR/process_ctrl.sh"
+source "$TESTING_ODS_DIR/../process_ctrl.sh"
 source "$TESTING_ODS_DIR/../_logging.sh"
-source "$TESTING_ODS_DIR/config_common.sh"
-source "$TESTING_ODS_DIR/config_clusters.sh"
-source "$TESTING_ODS_DIR/config_load_overrides.sh"
-
+source "$TESTING_ODS_DIR/configure.sh"
 source "$TESTING_ODS_DIR/cluster_helpers.sh"
 
 export KUBECONFIG_DRIVER=$KUBECONFIG
@@ -22,38 +19,46 @@ export KUBECONFIG_SUTEST=/tmp/sutest_kubeconfig
 HOSTNAME_KEY=clusters.create.sutest.already_exists.hostname
 USERNAME_KEY=clusters.create.sutest_already_exists.username
 
-set_config_from_pr_arg 1 "$HOSTNAME_KEY"
-set_config_from_pr_arg 2 "$USERNAME_KEY"
 
-cluster_hostname=$(get_config "$HOSTNAME_KEY")
-if [[ -z "$cluster_hostname" ]]; then
-    _error "$HOSTNAME_KEY must be set with the hostname of the private cluster, or with the PR argument 0"
-fi
+main() {
+    "$TESTING_ODS_DIR/ci_init_configure.sh"
 
-cluster_username=$(get_config "$USERNAME_KEY")
-if [[ -z "$cluster_username" ]]; then
-    _error "$USERNAME_KEY must be set with the username to use to log into the private cluster, or with the PR argument 1"
-fi
+    set_config_from_pr_arg 1 "$HOSTNAME_KEY"
+    set_config_from_pr_arg 2 "$USERNAME_KEY"
 
-prepare_driver_cluster() {
-    process_ctrl::run_in_bg "$TESTING_ODS_DIR/private_cluster.sh" prepare_driver_cluster
-    "$TESTING_ODS_DIR/notebook_scale_test.sh" prepare_driver_cluster
+    cluster_hostname=$(get_config "$HOSTNAME_KEY")
+    if [[ "$cluster_hostname" == null ]]; then
+        _error "$HOSTNAME_KEY must be set with the hostname of the private cluster, or with the PR argument 0"
+    fi
+
+    cluster_username=$(get_config "$USERNAME_KEY")
+    if [[ "$cluster_username" == null ]]; then
+        local pr_author=$(echo "$JOB_SPEC" | jq -r .refs.pulls[0].author)
+        set_config "$USERNAME_KEY" "$pr_author"
+    fi
+
+    prepare_driver_cluster() {
+        process_ctrl::run_in_bg "$TESTING_ODS_DIR/private_cluster.sh" prepare_driver_cluster
+        "$TESTING_ODS_DIR/notebook_scale_test.sh" prepare_driver_cluster
+    }
+
+    action=${1:-}
+
+    "$TESTING_ODS_DIR/private_cluster.sh" connect_sutest_cluster
+
+    if [[ "$action" == "prepare" ]]; then
+        process_ctrl::run_in_bg "$TESTING_ODS_DIR/private_cluster.sh" prepare_sutest_cluster
+        process_ctrl::run_in_bg prepare_driver_cluster
+
+        process_ctrl::wait_bg_processes
+    else
+        "$TESTING_ODS_DIR/notebook_scale_test.sh" run_test_and_plot
+
+        if [[ "$action" != "run" ]]; then
+            process_ctrl::run_in_bg "$TESTING_ODS_DIR/private_cluster.sh" unprepare_sutest_cluster
+            process_ctrl::run_in_bg "$TESTING_ODS_DIR/private_cluster.sh" unprepare_driver_cluster
+        fi
+    fi
 }
 
-action=${1:-}
-
-"$TESTING_ODS_DIR/private_cluster.sh" connect_sutest_cluster
-
-if [[ "$action" == "prepare" ]]; then
-    process_ctrl::run_in_bg "$TESTING_ODS_DIR/private_cluster.sh" prepare_sutest_cluster
-    process_ctrl::run_in_bg prepare_driver_cluster
-
-    process_ctrl::wait_bg_processes
-else
-    "$TESTING_ODS_DIR/notebook_scale_test.sh" run_test_and_plot
-
-    if [[ "$action" != "run" ]]; then
-        process_ctrl::run_in_bg "$TESTING_ODS_DIR/private_cluster.sh" unprepare_sutest_cluster
-        process_ctrl::run_in_bg "$TESTING_ODS_DIR/private_cluster.sh" unprepare_driver_cluster
-    fi
-fi
+main "$@"

--- a/testing/ods/run_notebook_scale_test_on_private.sh
+++ b/testing/ods/run_notebook_scale_test_on_private.sh
@@ -22,8 +22,8 @@ export KUBECONFIG_SUTEST=/tmp/sutest_kubeconfig
 HOSTNAME_KEY=clusters.create.sutest.already_exists.hostname
 USERNAME_KEY=clusters.create.sutest_already_exists.username
 
-set_config_from_pr_arg 0 "$HOSTNAME_KEY"
-set_config_from_pr_arg 1 "$USERNAME_KEY"
+set_config_from_pr_arg 1 "$HOSTNAME_KEY"
+set_config_from_pr_arg 2 "$USERNAME_KEY"
 
 cluster_hostname=$(get_config "$HOSTNAME_KEY")
 if [[ -z "$cluster_hostname" ]]; then

--- a/testing/pr_args.sh
+++ b/testing/pr_args.sh
@@ -47,12 +47,13 @@ pos_args=$(echo "$last_user_test_comment" |
                (grep "$test_name" || true) | cut -d" " -f3- | tr -d '\n' | tr -d '\r')
 if [[ "$pos_args" ]]; then
     echo "PR_POSITIONAL_ARGS='$pos_args'" >> "$DEST"
-    i=0
+    i=1
     for pos_arg in $pos_args; do
         echo "PR_POSITIONAL_ARG_$i='$pos_arg'" >> "$DEST"
         i=$((i + 1))
     done
 fi
+echo "PR_POSITIONAL_ARG_0='$test_name'" >> "$DEST"
 
 while read line; do
     [[ $line != "/var "* ]] && continue


### PR DESCRIPTION
* `testing: ods: clusters: fix keep cluster`


---

* `testing: pr_args: add the 'test_name' as PR_POSITIONAL_ARG_0`


---

* `testing: ods: use pr_args n+1`


---

* `testing: ods: generate_matrix-benchmarking: only read 'pr_arg 1' in the ods-plot-* test`


---

* `testing: ods: generate_matrix-benchmarking: do nothing if matbench.preset isn't set`


---

* `testing: ods: run_notebook_scale_test_on_private: fix following the configuration refactoring`


---

* `testing: ods: private_cluster: fix following the configuration refactoring`


---

* `testing: ods: configure: set_config: ensure that both arguments are passed`


---

* `[matrix-benchmarking-workloads/rhods-notebooks-ux] store_thresholds: do not crash if the config file doesn't define any threshold`


---

/cc @kpouget 