### PR TITLE
testing: model-mesh: locust: new entrypoint

### DIFF
--- a/testing/model-mesh/command_args.yaml
+++ b/testing/model-mesh/command_args.yaml
@@ -1,0 +1,49 @@
+{% set scale_test_imagestream = "image-registry.openshift-image-registry.svc:5000/"+ tests.model_mesh.namespace +"/"+ tests.model_mesh.imagestream_name %}
+
+{% set secrets_location = secrets.dir.name | or_env(secrets.dir.env_key) %}
+{% set s3_ldap_password_location = secrets_location + "/" + secrets.s3_ldap_password_file %}
+
+#
+
+utils build_push_image/artifacts-exporter:
+  namespace: {{ tests.model_mesh.namespace }}
+  dockerfile_path: testing/ods/images/Containerfile.s3_artifacts_exporter
+{% set artifacts_exporter_istag = "artifacts-exporter" %}
+  image_tag: {{ artifacts_exporter_istag }}
+  local_image_name: {{ tests.model_mesh.imagestream_name }}
+
+cluster preload_image/artifacts-exporter:
+  namespace: {{ tests.model_mesh.namespace }}
+  name: {{ artifacts_exporter_istag }}
+  image: {{ scale_test_imagestream }}:{{ artifacts_exporter_istag }}
+
+#
+
+utils build_push_image/locust-scale-test:
+  namespace: {{ tests.model_mesh.namespace }}
+  dockerfile_path: testing/ods/images/Containerfile.api_scale_test
+{% set locust_scale_test_istag = "api-scale-test" %}
+  image_tag: {{ locust_scale_test_istag }}
+  local_image_name: {{ tests.model_mesh.imagestream_name }}
+
+cluster preload_image/locust-scale-test:
+  namespace: {{ tests.model_mesh.namespace }}
+  name: {{ locust_scale_test_istag }}
+  image: {{ scale_test_imagestream }}:{{ locust_scale_test_istag }}
+
+#
+
+cluster deploy_minio_s3_server:
+  secret_properties_file: {{ s3_ldap_password_location }}
+
+#
+
+rhods notebook_api_scale_test:
+  namespace: {{ tests.model_mesh.namespace }}
+  idp_name: NO_IDP
+  secret_properties_file: {{ s3_ldap_password_location }}
+  username_prefix: NO_USER
+  test_name: NO_TEST
+  user_count: 100
+  artifacts_exporter_istag: "{{ tests.model_mesh.imagestream_name }}:{{ artifacts_exporter_istag }}"
+  api_scale_test_istag: "{{ tests.model_mesh.imagestream_name }}:{{ locust_scale_test_istag }}"

--- a/testing/model-mesh/config.yaml
+++ b/testing/model-mesh/config.yaml
@@ -1,0 +1,20 @@
+secrets:
+  dir:
+    name: null
+    env_key: PSAP_ODS_SECRET_PATH
+  s3_ldap_password_file: s3_ldap.passwords
+tests:
+  model_mesh:
+    namespace: model-mesh-scale-test
+    imagestream_name: scale-test
+matbench:
+  preset: null
+  workload: rhods-notebooks-ux
+  config_file: notebooks_scale_test.yaml # subprojects/matrix-benchmarking-workloads/rhods-notebooks-ux/data
+  download:
+    mode: prefer_cache
+    url:
+    url_file:
+    # if true, copy the results downloaded by `matbench download` into the artifacts directory
+    save_to_artifacts: false
+  ignore_exit_code: true

--- a/testing/model-mesh/locust.sh
+++ b/testing/model-mesh/locust.sh
@@ -1,0 +1,229 @@
+#! /bin/bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
+set -o errtrace
+set -x
+
+TESTING_MM_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+TESTING_ODS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )/../ods"
+
+if [ -z "${ARTIFACT_DIR:-}" ]; then
+    if [[ "${INSIDE_CI_IMAGE:-}" == "y" ]]; then
+        echo "ARTIFACT_DIR not set, cannot proceed without inside the image."
+        false
+    fi
+
+    export ARTIFACT_DIR="/tmp/ci-artifacts_$(date +%Y%m%d)"
+    mkdir -p "$ARTIFACT_DIR"
+
+    echo "Using ARTIFACT_DIR=$ARTIFACT_DIR as default artifacts directory."
+else
+    echo "Using ARTIFACT_DIR=$ARTIFACT_DIR."
+fi
+
+source "$TESTING_MM_DIR/config.sh"
+source "$TESTING_MM_DIR/../_logging.sh"
+source "$TESTING_MM_DIR/../process_ctrl.sh"
+source "$TESTING_ODS_DIR/configure.sh"
+source "$TESTING_ODS_DIR/cluster_helpers.sh"
+export CI_ARTIFACTS_FROM_CONFIG_FILE=${TESTING_MM_DIR}/config.yaml
+export CI_ARTIFACTS_FROM_COMMAND_ARGS_FILE=${TESTING_MM_DIR}/command_args.yaml
+
+KUBECONFIG_DRIVER="${KUBECONFIG_DRIVER:-$KUBECONFIG}" # cluster driving the test
+KUBECONFIG_SUTEST="${KUBECONFIG_SUTEST:-$KUBECONFIG}" # system under test
+
+DRIVER_CLUSTER=driver
+SUTEST_CLUSTER=sutest
+
+switch_sutest_cluster() {
+    switch_cluster "$SUTEST_CLUSTER"
+}
+
+switch_driver_cluster() {
+    switch_cluster "$DRIVER_CLUSTER"
+}
+
+switch_cluster() {
+    local cluster_role="$1"
+    echo "Switching to the '$cluster_role' cluster"
+    if [[ "$cluster_role" == "$DRIVER_CLUSTER" ]]; then
+        export KUBECONFIG=$KUBECONFIG_DRIVER
+    elif [[ "$cluster_role" == "$SUTEST_CLUSTER" ]]; then
+        export KUBECONFIG=$KUBECONFIG_SUTEST
+    else
+        echo "Requested to switch to an unknown cluster '$cluster_role', exiting."
+        exit 1
+    fi
+    export ARTIFACT_TOOLBOX_NAME_PREFIX="${cluster_role}_"
+}
+
+# ---
+
+prepare_driver_cluster() {
+    switch_cluster driver
+
+    local loadtest_namespace=$(get_config tests.model_mesh.namespace)
+
+    oc create namespace "$loadtest_namespace" -oyaml --dry-run=client | oc apply -f-
+
+    build_and_preload_artifacts_exporter_image() {
+        ./run_toolbox.py from_config utils build_push_image --suffix artifacts-exporter
+        ./run_toolbox.py from_config cluster preload_image --suffix artifacts-exporter
+    }
+
+    build_and_preload_api_scale_test_image() {
+        ./run_toolbox.py from_config utils build_push_image --suffix locust-scale-test
+        ./run_toolbox.py from_config cluster preload_image --suffix locust-scale-test
+    }
+
+    process_ctrl::run_in_bg build_and_preload_artifacts_exporter_image
+    process_ctrl::run_in_bg build_and_preload_api_scale_test_image
+
+    process_ctrl::run_in_bg ./run_toolbox.py from_config cluster deploy_minio_s3_server
+}
+
+prepare_sutest_cluster() {
+    switch_sutest_cluster
+
+    if [[ "$SCALE_INSTANCES" -eq 0 ]]
+    then
+        ./run_toolbox.py cluster set-scale ${INSTANCE_TYPE} ${INSTANCE_COUNT}
+    fi
+}
+
+capture_environment() {
+    switch_sutest_cluster
+    ./run_toolbox.py rhods capture_state > /dev/null || true
+    ./run_toolbox.py cluster capture_environment > /dev/null || true
+
+    switch_driver_cluster
+    ./run_toolbox.py cluster capture_environment > /dev/null || true
+}
+
+prepare_ci() {
+    cluster_helpers::connect_sutest_cluster
+}
+
+prepare() {
+    prepare_sutest_cluster
+    prepare_driver_cluster
+
+    process_ctrl::wait_bg_processes
+}
+
+run_locust_test() {
+    switch_driver_cluster
+
+    # to be customized
+    ./run_toolbox.py from_config rhods notebook_api_scale_test \
+                     --extra "{sut_cluster_kubeconfig: '$KUBECONFIG_SUTEST'}"
+}
+
+generate_plots() {
+    local BASE_ARTIFACT_DIR="$ARTIFACT_DIR"
+    local PLOT_ARTIFACT_DIR="$ARTIFACT_DIR/plotting"
+    mkdir "$PLOT_ARTIFACT_DIR"
+    if ARTIFACT_DIR="$PLOT_ARTIFACT_DIR" \
+                   ./testing/ods/generate_matrix-benchmarking.sh \
+                   from_dir "$BASE_ARTIFACT_DIR" \
+                       > "$PLOT_ARTIFACT_DIR/build-log.txt" 2>&1;
+    then
+        echo "MatrixBenchmarkings plots successfully generated."
+    else
+        local errcode=$?
+        _warning "MatrixBenchmarkings plots generated failed. See logs in \$ARTIFACT_DIR/plotting/build-log.txt"
+        return $errcode
+    fi
+}
+
+connect_ci() {
+    "$TESTING_ODS_DIR/ci_init_configure.sh"
+
+    if [[ "${CONFIG_DEST_DIR:-}" ]]; then
+        echo "Using CONFIG_DEST_DIR=$CONFIG_DEST_DIR ..."
+
+    elif [[ "${SHARED_DIR:-}" ]]; then
+        echo "Using CONFIG_DEST_DIR=\$SHARED_DIR=$SHARED_DIR ..."
+        CONFIG_DEST_DIR=$SHARED_DIR
+
+    else
+        _error "CONFIG_DEST_DIR or SHARED_DIR must be set ..."
+    fi
+
+    KUBECONFIG_DRIVER="${CONFIG_DEST_DIR}/driver_kubeconfig" # cluster driving the test
+    if [[ ! -f "$KUBECONFIG_DRIVER" ]]; then
+        KUBECONFIG_DRIVER=$KUBECONFIG
+    fi
+    KUBECONFIG_SUTEST="${CONFIG_DEST_DIR}/sutest_kubeconfig" # system under test
+    if [[ ! -f "$KUBECONFIG_SUTEST" ]]; then
+        KUBECONFIG_SUTEST=$KUBECONFIG
+    fi
+}
+
+test_ci() {
+    run_one_test
+}
+
+run_one_test() {
+    run_locust_test
+}
+
+# ---
+
+main() {
+    process_ctrl__finalizers+=("process_ctrl::kill_bg_processes")
+
+    action=${1:-}
+
+    case ${action} in
+        "prepare_ci")
+            connect_ci
+
+            prepare_ci
+
+            prepare
+
+            process_ctrl::wait_bg_processes
+            return 0
+            ;;
+        "test_ci")
+            connect_ci
+            local BASE_ARTIFACT_DIR=$ARTIFACT_DIR
+
+            process_ctrl__finalizers+=("export ARTIFACT_DIR='$BASE_ARTIFACT_DIR/999_teardown'") # switch to the 'teardown' artifacts directory
+            process_ctrl__finalizers+=("capture_environment")
+
+            test_ci
+            return 0
+            ;;
+        "prepare")
+            prepare
+            return 0
+            ;;
+        "prepare_driver_cluster")
+            prepare_driver_cluster
+            process_ctrl::wait_bg_processes
+            return 0
+            ;;
+        "run_test_and_plot")
+            run_one_test
+            generate_plots
+            return 0
+            ;;
+        "run_test")
+            run_one_test
+            return 0
+            ;;
+        "generate_plots")
+            generate_plots
+            return  0
+            ;;
+        *)
+            _error "unknown action: ${action}" "$@"
+            ;;
+    esac
+}
+
+main "$@"


### PR DESCRIPTION
/cc @fcami 

This PR adds an entrypoint stub for running Locust against RHODS/ODH model-mesh server.

Tested in https://github.com/openshift-psap/ci-artifacts/pull/581