### PR TITLE
cluster_deploy_nginx_server: add https

### DIFF
--- a/roles/cluster_deploy_nginx_server/tasks/main.yml
+++ b/roles/cluster_deploy_nginx_server/tasks/main.yml
@@ -70,10 +70,18 @@
        --ignore-not-found
        -n "{{ cluster_deploy_nginx_server_namespace }}"
 
-- name: Create the nginx route
+- name: Create the nginx HTTP route
   command:
-    oc expose svc/nginx
+    oc expose svc/nginx --port=http
        -n "{{ cluster_deploy_nginx_server_namespace }}"
+
+- name: Create the nginx HTTPS route
+  shell:
+    set -o pipefail;
+    oc create route passthrough nginx-secure
+       --service=nginx --port=https
+       -n "{{ cluster_deploy_nginx_server_namespace }}"
+       --dry-run=client -oyaml | oc apply -f-
 
 - name: Wait for the nginx deployment to be ready
   command:

--- a/roles/cluster_deploy_nginx_server/templates/deploy_nginx.yaml.j2
+++ b/roles/cluster_deploy_nginx_server/templates/deploy_nginx.yaml.j2
@@ -20,12 +20,17 @@ spec:
         command: ["nginx", "-g", "daemon off; error_log /dev/stdout info;"]
         ports:
         - containerPort: 8080
+          protocol: TCP
+        - containerPort: 8443
+          protocol: TCP
         volumeMounts:
         - name: data-dir
           mountPath: /opt/app-root/src
         - name: nginx-config
           mountPath: /etc/nginx/nginx.conf
           subPath: nginx.conf
+        - name: nginx-certs
+          mountPath: /mnt/nginx-certs
       volumes:
       - name: data-dir
         configMap:
@@ -38,16 +43,25 @@ spec:
           items:
           - key: nginx.conf
             path: nginx.conf
+      - name: nginx-certs
+        secret:
+          secretName: nginx-certs
 ---
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: nginx-certs
   name: nginx
 spec:
   ports:
   - name: http
     port: 80
     targetPort: 8080
+    protocol: TCP
+  - name: https
+    port: 443
+    targetPort: 8443
     protocol: TCP
   selector:
     app: nginx

--- a/roles/cluster_deploy_nginx_server/templates/nginx.conf.j2
+++ b/roles/cluster_deploy_nginx_server/templates/nginx.conf.j2
@@ -41,4 +41,25 @@ http {
             root /opt/app-root/src/;
         }
     }
+
+    server {
+        listen       8443 ssl http2;
+        listen       [::]:8443 ssl http2;
+        server_name _;
+
+        location /ready {
+            return 200;
+        }
+        location / {
+            root /opt/app-root/src/;
+        }
+
+        ssl_certificate "/mnt/nginx-certs/tls.crt";
+        ssl_verify_depth 5;
+        ssl_certificate_key "/mnt/nginx-certs/tls.key";
+        ssl_session_cache shared:SSL:1m;
+        ssl_session_timeout  10m;
+        ssl_ciphers PROFILE=SYSTEM;
+        ssl_prefer_server_ciphers on;
+    }
 }

--- a/roles/cluster_deploy_nginx_server/vars/main/resources.yml
+++ b/roles/cluster_deploy_nginx_server/vars/main/resources.yml
@@ -1,3 +1,3 @@
 ---
-cluster_deploy_nginx_server_deployment: roles/cluster_deploy_nginx_server/files/deploy_nginx.yaml
-cluster_deploy_nginx_server_config_file: roles/cluster_deploy_nginx_server/files/nginx.conf
+cluster_deploy_nginx_server_deployment: roles/cluster_deploy_nginx_server/templates/deploy_nginx.yaml.j2
+cluster_deploy_nginx_server_config_file: roles/cluster_deploy_nginx_server/templates/nginx.conf.j2


### PR DESCRIPTION
- add OCP-provided TLS certs for nginx
- add HTTPS nginx configuration, service and route For now, this is not configurable (e.g. always-on).

Signed-off-by: Kevin Pouget <kpouget@redhat.com>
Signed-off-by: François Cami <fcami@redhat.com>