### PR TITLE
Add Horreum JSON Generation to testing

### DIFF
--- a/subprojects/matrix-benchmarking-workloads/rhods-notebooks-ux/store.py
+++ b/subprojects/matrix-benchmarking-workloads/rhods-notebooks-ux/store.py
@@ -26,6 +26,7 @@ from . import k8s_quantity
 from . import store_theoretical
 from . import store_thresholds
 from .plotting import prom as rhods_plotting_prom
+from .horreum_lts_store import build_lts_payloads as horreum_build_lts_payloads
 
 K8S_EVT_TIME_FMT = "%Y-%m-%dT%H:%M:%S.%fZ"
 K8S_TIME_FMT = "%Y-%m-%dT%H:%M:%SZ"
@@ -851,3 +852,8 @@ def parse_data():
     store_simple.register_custom_parse_results(_parse_directory)
 
     return store_simple.parse_data()
+
+def build_lts_payloads():
+    store_simple.register_custom_build_lts_payloads(horreum_build_lts_payloads)
+
+    return store_simple.build_lts_payloads()

--- a/testing/notebooks/generate_matrix-benchmarking.sh
+++ b/testing/notebooks/generate_matrix-benchmarking.sh
@@ -131,8 +131,13 @@ generate_matbench::generate_visualization() {
     generate_url="stats=$(echo -n "$generate_list" | tr '\n' '&' | sed 's/&/&stats=/g')"
 
     cp -f /tmp/prometheus.yml "." || true
-    if ! matbench parse --output_lts $ARTIFACT_DIR/lts_payload.json |& tee > "$ARTIFACT_DIR/_matbench_parse.log"; then
+    if ! matbench parse |& tee > "$ARTIFACT_DIR/_matbench_parse.log"; then
         echo "An error happened during the parsing of the results (or no results were available) in $ARTIFACT_DIR, aborting."
+        return 1
+    fi
+
+    if ! matbench parse --output_lts $ARTIFACT_DIR/lts_payload.json |& tee > "$ARTIFACT_DIR/_matbench_parse.log"; then
+        echo "An error happened while encoding results into a JSON object within $ARTIFACT_DIR, aborting."
         return 1
     fi
 

--- a/testing/notebooks/generate_matrix-benchmarking.sh
+++ b/testing/notebooks/generate_matrix-benchmarking.sh
@@ -136,7 +136,7 @@ generate_matbench::generate_visualization() {
         return 1
     fi
 
-    if ! matbench parse --output_lts $ARTIFACT_DIR/lts_payload.json |& tee > "$ARTIFACT_DIR/_matbench_parse.log"; then
+    if ! matbench parse --output_lts $ARTIFACT_DIR/lts_payload.json |& tee > "$ARTIFACT_DIR/_matbench_parse_lts.log"; then
         echo "An error happened while encoding results into a JSON object within $ARTIFACT_DIR, aborting."
         return 1
     fi

--- a/testing/notebooks/generate_matrix-benchmarking.sh
+++ b/testing/notebooks/generate_matrix-benchmarking.sh
@@ -131,7 +131,7 @@ generate_matbench::generate_visualization() {
     generate_url="stats=$(echo -n "$generate_list" | tr '\n' '&' | sed 's/&/&stats=/g')"
 
     cp -f /tmp/prometheus.yml "." || true
-    if ! matbench parse |& tee > "$ARTIFACT_DIR/_matbench_parse.log"; then
+    if ! matbench parse --output_lts $ARTIFACT_DIR/lts_payload.json |& tee > "$ARTIFACT_DIR/_matbench_parse.log"; then
         echo "An error happened during the parsing of the results (or no results were available) in $ARTIFACT_DIR, aborting."
         return 1
     fi


### PR DESCRIPTION
This PR adds an option to the `matbench parse` section of `generate_matrix-benchmarking.sh` so it saves the Horreum payload to `lts_payload.json`