### PR TITLE
Add Start/End times to MatrixEntries

### DIFF
--- a/subprojects/matrix-benchmarking-workloads/rhods-notebooks-ux/horreum_lts_store.py
+++ b/subprojects/matrix-benchmarking-workloads/rhods-notebooks-ux/horreum_lts_store.py
@@ -106,10 +106,11 @@ def _convert_steps(data: dict) -> dict:
         counter = 0
         if key != "$type":
             end_dict = {}
-            for (step, val) in results[key]['output'].items():
-                end_dict[f"{counter}. {step}"] = val
-                counter += 1
-            results[key]['output'] = end_dict
+            if 'output' in results[key].keys():
+                for (step, val) in results[key]['output'].items():
+                    end_dict[f"{counter}. {step}"] = val
+                    counter += 1
+                results[key]['output'] = end_dict
     return data
 
 

--- a/subprojects/matrix-benchmarking-workloads/rhods-notebooks-ux/horreum_lts_store.py
+++ b/subprojects/matrix-benchmarking-workloads/rhods-notebooks-ux/horreum_lts_store.py
@@ -108,8 +108,8 @@ def _convert_steps(data: dict) -> dict:
 def build_lts_payloads() -> dict:
     entry: common.MatrixEntry = None
     for (_, entry) in common.Matrix.processed_map.items():
-        start_time = entry.results.tester_job.creation_time
-        end_time = entry.results.tester_job.completion_time
+        start_time = entry.results.start_time
+        end_time = entry.results.end_time
         data = _decode_ci_items(entry)
 
         yield {

--- a/subprojects/matrix-benchmarking-workloads/rhods-notebooks-ux/horreum_lts_store.py
+++ b/subprojects/matrix-benchmarking-workloads/rhods-notebooks-ux/horreum_lts_store.py
@@ -84,7 +84,7 @@ def _decode_steps(data: dict) -> dict:
     try:
         results: dict = data['results']['ods_ci']
     except KeyError:
-        return {}
+        return data
     
     for (key, _) in results.items():
         if key != "$type":
@@ -97,7 +97,11 @@ def _decode_steps(data: dict) -> dict:
 
 
 def _convert_steps(data: dict) -> dict:
-    results: dict = data['results']['ods_ci']
+    try:
+        results: dict = data['results']['ods_ci']
+    except KeyError:
+        return data
+
     for (key, _) in results.items():
         counter = 0
         if key != "$type":

--- a/subprojects/matrix-benchmarking-workloads/rhods-notebooks-ux/horreum_lts_store.py
+++ b/subprojects/matrix-benchmarking-workloads/rhods-notebooks-ux/horreum_lts_store.py
@@ -81,7 +81,11 @@ def _encode_json(obj, name, settings):
 
 
 def _decode_steps(data: dict) -> dict:
-    results: dict = data['results']['ods_ci']
+    try:
+        results: dict = data['results']['ods_ci']
+    except KeyError:
+        return {}
+    
     for (key, _) in results.items():
         if key != "$type":
             end_dict = {}

--- a/subprojects/matrix-benchmarking-workloads/rhods-notebooks-ux/store.py
+++ b/subprojects/matrix-benchmarking-workloads/rhods-notebooks-ux/store.py
@@ -850,22 +850,29 @@ def _parse_directory(fn_add_to_matrix, dirname, import_settings):
 
     print("parsing done :)")
 
+@ignore_file_not_found
 def _parse_start_end_times(dirname):
-    with open(dirname / '_ansible.log', 'rb') as file:
-        first = file.readline().decode('utf-8').strip()
-        file.seek(-20, 2)
-        while file.read(1) != b'\n':
-            file.seek(-2, 1)
-        last = file.readline().decode('utf-8').strip()
-        start_time = ' '.join(first.split(' ')[0:2]).split(',')[0]
-        end_time = ' '.join(last.split(' ')[0:2]).split(',')[0]
+    ISO_FORMAT="%Y-%m-%d %H:%M:%S"
+    with open(dirname / '_ansible.log', 'r') as file:
+        first = None
+        last = None
+        for line in file:
+            if not first:
+                first = line
+            last = line
+        
+        start_time = datetime.datetime.strptime(
+            first.partition(',')[0],
+            ISO_FORMAT
+        )
+        end_time = datetime.datetime.strptime(
+            last.partition(',')[0],
+            ISO_FORMAT
+        )
         logging.debug(f'Start time: {start_time}')
         logging.debug(f'End time: {end_time}')
 
-        return (
-            datetime.datetime.strptime(start_time, "%Y-%m-%d %H:%M:%S"),
-            datetime.datetime.strptime(end_time, "%Y-%m-%d %H:%M:%S"),
-        )
+        return (start_time, end_time)
     
 
 def parse_data():

--- a/subprojects/matrix-benchmarking-workloads/rhods-notebooks-ux/store.py
+++ b/subprojects/matrix-benchmarking-workloads/rhods-notebooks-ux/store.py
@@ -861,10 +861,12 @@ def _parse_start_end_times(dirname):
                 first = line
             last = line
         
+        # first = "2023-04-14 17:19:19,808 p=770 u=psap-ci-runner n=ansible | ansible-playbook 2.9.27"
         start_time = datetime.datetime.strptime(
             first.partition(',')[0],
             ISO_FORMAT
         )
+        # last = 2023-04-14 17:25:31,697 p=770 u=psap-ci-runner n=ansible |...
         end_time = datetime.datetime.strptime(
             last.partition(',')[0],
             ISO_FORMAT


### PR DESCRIPTION
This PR adds start/end times to MatrixEntries, parsed from `_ansible.log`.

This also updates the LTS payload generator to use these times