### PR TITLE
Rhods-notebooks-ux: Limit Horreum data output

### DIFF
--- a/subprojects/matrix-benchmarking-workloads/rhods-notebooks-ux/horreum_lts_store.py
+++ b/subprojects/matrix-benchmarking-workloads/rhods-notebooks-ux/horreum_lts_store.py
@@ -131,14 +131,25 @@ def build_lts_payloads() -> dict:
 def build_limited_lts_payload() -> dict:
     for(_, entry) in common.Matrix.processed_map.items():
         RESULTS = entry.results
+        
+        start_time: datetime.datetime = RESULTS.start_time
+        end_time: datetime.datetime = RESULTS.end_time
+
         output = {
             "$schema": "urn:rhods-matbench-upload:3.0.0",
-            "users": _decode_limited_users(RESULTS.ods_ci, RESULTS.testpod_hostnames, RESULTS.notebook_pod_times),
-            'rhods_version': RESULTS.rhods_info.version,
-            'ocp_version': RESULTS.sutest_ocp_version
+            "data": {
+                "users": _decode_limited_users(RESULTS.ods_ci, RESULTS.testpod_hostnames, RESULTS.notebook_pod_times),
+                'rhods_version': RESULTS.rhods_info.version,
+                'ocp_version': RESULTS.sutest_ocp_version
+            },
+            "metadata": {
+                "test": "rhods-notebooks-ux",
+                "start": start_time.isoformat(),
+                "end": end_time.isoformat()
+            }
         }
         
-        yield output, 0, 0
+        yield output, start_time, end_time
 
 
 def _decode_limited_users(users, hostnames, pod_times):

--- a/subprojects/matrix-benchmarking-workloads/rhods-notebooks-ux/horreum_lts_store.py
+++ b/subprojects/matrix-benchmarking-workloads/rhods-notebooks-ux/horreum_lts_store.py
@@ -169,12 +169,13 @@ def _decode_limited_steps(steps, pod_times):
     return out_steps
 
 def _generate_pod_timings(pod_times, start, end):
-    output = {
-        'user_notification': (end - pod_times.containers_ready).total_seconds()
-    }
+    output = {}
+
     if hasattr(pod_times, "pod_scheduled"):
         output['resource_init_time'] = (pod_times.pod_scheduled - start).total_seconds()
     if hasattr(pod_times, "containers_ready"):
         output['container_ready_time'] = (pod_times.containers_ready - pod_times.pod_initialized).total_seconds()
+    if hasattr(pod_times, 'containers_ready'):
+        output['user_notification'] = (end - pod_times.containers_ready).total_seconds()
     
     return output

--- a/subprojects/matrix-benchmarking-workloads/rhods-notebooks-ux/horreum_lts_store.py
+++ b/subprojects/matrix-benchmarking-workloads/rhods-notebooks-ux/horreum_lts_store.py
@@ -141,7 +141,9 @@ def build_limited_lts_payload() -> dict:
                 "users": _decode_limited_users(RESULTS.ods_ci, RESULTS.testpod_hostnames, RESULTS.notebook_pod_times),
                 'rhods_version': RESULTS.rhods_info.version,
                 'ocp_version': RESULTS.sutest_ocp_version,
-                'metrics': _gather_prom_metrics(RESULTS.metrics)
+                'metrics': _gather_prom_metrics(RESULTS.metrics),
+                'thresholds': RESULTS.thresholds,
+                'config': RESULTS.test_config.yaml_file
             },
             "metadata": {
                 "test": "rhods-notebooks-ux",

--- a/subprojects/matrix-benchmarking-workloads/rhods-notebooks-ux/plotting/prom.py
+++ b/subprojects/matrix-benchmarking-workloads/rhods-notebooks-ux/plotting/prom.py
@@ -129,6 +129,7 @@ def _get_cluster_mem_cpu(cluster_role, register):
 
 
 def _get_container_mem_cpu(cluster_role, register, label_sets):
+    from ..horreum_lts_store import register_lts_metric
     all_metrics = []
 
     for plot_name_labels in label_sets:
@@ -141,6 +142,12 @@ def _get_container_mem_cpu(cluster_role, register, label_sets):
         all_metrics += cpu
 
         if not register: continue
+
+        if cluster_role == 'sutest':
+            for metric in cpu:
+                for key in metric.keys():
+                    if 'container=rhods-dashboard' in key:
+                        register_lts_metric(cluster_role, metric)
 
         container = labels.get("container", "all")
 
@@ -182,8 +189,13 @@ def _get_control_plane_nodes_cpu_usage(cluster_role, register):
             yield metric
 
     if register:
+        from ..horreum_lts_store import register_lts_metric
         for metric in all_metrics:
             name, rq = list(metric.items())[0]
+
+            if 'CPU idle' in name and cluster_role == 'sutest':
+                register_lts_metric(cluster_role, metric)
+
             plotting_prom.Plot({name: rq},
                                f"Prom: {name}",
                                None,
@@ -248,8 +260,13 @@ def _get_apiserver_errcodes(cluster_role, register):
         return res, None
 
     if register:
+        from ..horreum_lts_store import register_lts_metric
         for metric in apiserver_request_metrics:
             name, rq = list(metric.items())[0]
+
+            if 'server errors' in name and cluster_role == 'sutest':
+                register_lts_metric(cluster_role, metric)
+
             plotting_prom.Plot({name: rq},
                                f"Prom: {name}",
                                None,

--- a/subprojects/matrix-benchmarking-workloads/rhods-notebooks-ux/store.py
+++ b/subprojects/matrix-benchmarking-workloads/rhods-notebooks-ux/store.py
@@ -26,7 +26,7 @@ from . import k8s_quantity
 from . import store_theoretical
 from . import store_thresholds
 from .plotting import prom as rhods_plotting_prom
-from .horreum_lts_store import build_limited_lts_payload as horreum_build_lts_payloads
+from .horreum_lts_store import build_lts_payloads as horreum_build_lts_payloads
 
 K8S_EVT_TIME_FMT = "%Y-%m-%dT%H:%M:%S.%fZ"
 K8S_TIME_FMT = "%Y-%m-%dT%H:%M:%SZ"

--- a/subprojects/matrix-benchmarking-workloads/rhods-notebooks-ux/store.py
+++ b/subprojects/matrix-benchmarking-workloads/rhods-notebooks-ux/store.py
@@ -26,7 +26,7 @@ from . import k8s_quantity
 from . import store_theoretical
 from . import store_thresholds
 from .plotting import prom as rhods_plotting_prom
-from .horreum_lts_store import build_lts_payloads as horreum_build_lts_payloads
+from .horreum_lts_store import build_limited_lts_payload as horreum_build_lts_payloads
 
 K8S_EVT_TIME_FMT = "%Y-%m-%dT%H:%M:%S.%fZ"
 K8S_TIME_FMT = "%Y-%m-%dT%H:%M:%SZ"


### PR DESCRIPTION
This PR is meant to start reducing the amount of information that is going to be stored in Horreum.

Example output:

```json5
{
   "metadata": {
       "test": "rhods-notebooks-ux",
       "start": "2023-04-20T10:21:00-04:00", //Start time of test, tz info automatically generated
       "end": "2023-04-20T10:21:00-04:00" //End time of test, tz info automatically generated
    },
    "data": {
        "rhods_version": 1.21.0", //RHODS version that the test was using
        "ocp_version": "4.12.9", //OpenShift version that was the cluster under test was using
        "users": [
            {
                 "hostname": "host0", //hostname of the node that ran the pod
                 "steps": [
                      {
                           "name": "<NAME OF STEP>",
                           "duration": 12, //Seconds taken to complete step
                           "status": "FAILED" //Can be COMPLETE or FAILED,
                           "substeps": [] //Optional, contains sub steps for "Wait for Notebook Spawn" and "Create and Start the Workbench"
                       }
                       //...
                  ],
                  "succeeded": false //Checks if exit code of this user is 0
              }
              //...
          ]
}
```