### PR TITLE
load-aware: add ansible role to deploy Trimaran scheduler

### DIFF
--- a/roles/load_aware_deploy_trimaran/defaults/main/config.yml
+++ b/roles/load_aware_deploy_trimaran/defaults/main/config.yml
@@ -1,0 +1,4 @@
+# Auto-generated file, do not edit manually ... 
+# Toolbox generate command: repo generate_ansible_default_settings
+# Source component: LoadAware.deploy_trimaran
+

--- a/roles/load_aware_deploy_trimaran/files/cluster-monitoring-config.yaml
+++ b/roles/load_aware_deploy_trimaran/files/cluster-monitoring-config.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-monitoring-config
+  namespace: openshift-monitoring
+data:
+  config.yaml: |
+    enableUserWorkload: true

--- a/roles/load_aware_deploy_trimaran/files/trimaran.yaml
+++ b/roles/load_aware_deploy_trimaran/files/trimaran.yaml
@@ -5,11 +5,11 @@ metadata:
   name: trimaran
 ---
 apiVersion: v1
-kind: ConfigMap
+kind: Secret
 metadata:
   name: trimaran-scheduler-config
   namespace: trimaran
-data:
+stringData:
   config.yaml: |
     apiVersion: kubescheduler.config.k8s.io/v1beta2
     kind: KubeSchedulerConfiguration
@@ -75,8 +75,8 @@ spec:
       serviceAccount: trimaran-scheduler
       volumes:
       - name: etckubernetes
-        configMap:
-          name: trimaran-scheduler-config
+        secret:
+          secretName: trimaran-scheduler-config
       containers:
         - name: trimaran-scheduler
           env:

--- a/roles/load_aware_deploy_trimaran/files/trimaran.yaml
+++ b/roles/load_aware_deploy_trimaran/files/trimaran.yaml
@@ -1,0 +1,93 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: trimaran
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: trimaran-scheduler-config
+  namespace: trimaran
+data:
+  config.yaml: |
+    apiVersion: kubescheduler.config.k8s.io/v1beta2
+    kind: KubeSchedulerConfiguration
+    leaderElection:
+      leaderElect: false
+    profiles:
+    - schedulerName: trimaran-scheduler
+      plugins:
+        score:
+          disabled:
+          - name: NodeResourcesBalancedAllocation
+          - name: NodeResourcesLeastAllocated
+          enabled:
+          - name: TargetLoadPacking
+      pluginConfig:
+      - name: TargetLoadPacking
+        args:
+          defaultRequests:
+            cpu: "2000m"
+          defaultRequestsMultiplier: "1"
+          targetUtilization: 1
+          metricProvider:
+            type: Prometheus
+            address: https://${THANOS_MONITORING_ENDPOINT}
+            token: $MONITORING_TOKEN
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: trimaran-scheduler
+  namespace: trimaran
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: trimaran
+subjects:
+- kind: ServiceAccount
+  name: trimaran-scheduler
+  namespace: trimaran
+roleRef:
+  kind: ClusterRole
+  name: system:kube-scheduler
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: trimaran-scheduler
+  namespace: trimaran
+  labels:
+    app: trimaran-scheduler
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: trimaran-scheduler
+  template:
+    metadata:
+      labels:
+        app: trimaran-scheduler
+    spec:
+      serviceAccount: trimaran-scheduler
+      volumes:
+      - name: etckubernetes
+        configMap:
+          name: trimaran-scheduler-config
+      containers:
+        - name: trimaran-scheduler
+          env:
+          - name: ENABLE_OPENSHIFT_AUTH
+            value: "true"
+          image: quay.io/chenw615/kube-scheduler:ocp
+          imagePullPolicy: Always
+          args:
+          - /bin/kube-scheduler
+          - --config=/etc/kubernetes/config.yaml
+          - -v=6
+          volumeMounts:
+          - name: etckubernetes
+            mountPath: /etc/kubernetes

--- a/roles/load_aware_deploy_trimaran/meta/main.yml
+++ b/roles/load_aware_deploy_trimaran/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - role: check_deps

--- a/roles/load_aware_deploy_trimaran/tasks/main.yml
+++ b/roles/load_aware_deploy_trimaran/tasks/main.yml
@@ -1,0 +1,36 @@
+- name: Configure user application monitoring
+  command:
+    oc apply -f {{ user_applications_monitor_config }}
+
+- name: Ensure user monitoring enabled
+  shell:
+    set -o pipefail;
+
+    oc -n openshift-user-workload-monitoring get pod
+      | awk 'NR > 1 { print $3}'
+  register: monitoring_enabled
+  delay: 3
+  retries: 20
+  # until all of the pods are in the running state
+  until: "'Completed' not in monitoring_enabled.stdout and 'Failed' not in monitoring_enabled.stdout and 'Pending' not in monitoring_enabled.stdout" 
+
+- name: Deploy Trimaran scheduler
+  shell:
+    set -o errexit;
+    set -o pipefail;
+    set -o nounset;
+    set -o errtrace;
+
+    export MONITORING_SECRET=$(oc get secret -n openshift-user-workload-monitoring
+      | grep  prometheus-user-workload-token
+      | head -n 1
+      | awk '{print $1 }'
+    )
+
+    export MONITORING_TOKEN=$(echo $(oc get secret $MONITORING_SECRET -n openshift-user-workload-monitoring -o json | jq -r '.data.token')
+      | base64 -d)
+
+    export THANOS_MONITORING_ENDPOINT=$(oc get route thanos-querier -n openshift-monitoring -o json
+      | jq -r '.spec.host')
+
+    cat {{ trimaran_setup_config }} | envsubst | oc apply -f -

--- a/roles/load_aware_deploy_trimaran/tasks/main.yml
+++ b/roles/load_aware_deploy_trimaran/tasks/main.yml
@@ -34,3 +34,11 @@
       | jq -r '.spec.host')
 
     cat {{ trimaran_setup_config }} | envsubst | oc apply -f -
+
+- name: Ensure Trimaran is Running
+  shell:
+    oc get pods -n trimaran | awk 'NR > 1 {print $3}'
+  register: trimaran_running
+  delay: 3
+  retries: 20
+  until: "trimaran_running.stdout == 'Running'"

--- a/roles/load_aware_deploy_trimaran/vars/main/resources.yml
+++ b/roles/load_aware_deploy_trimaran/vars/main/resources.yml
@@ -1,0 +1,2 @@
+user_applications_monitor_config: "roles/load_aware_deploy_trimaran/files/cluster-monitoring-config.yaml"
+trimaran_setup_config: "roles/load_aware_deploy_trimaran/files/trimaran.yaml"

--- a/testing/load-aware/test.py
+++ b/testing/load-aware/test.py
@@ -65,7 +65,7 @@ def prepare_ci():
     install_ocp_pipelines()
 
     run.run("./run_toolbox.py from_config cluster capture_environment --suffix sample")
-
+    run.run("./run_toolbox.py load_aware deploy_trimaran")
 
 
 def _run_test(test_artifact_dir_p):

--- a/toolbox/__init__.py
+++ b/toolbox/__init__.py
@@ -11,6 +11,7 @@ from toolbox.pipelines import Pipelines
 from toolbox.wisdom import Wisdom
 from toolbox.from_config import FromConfig
 from toolbox.local_ci import Local_CI
+from toolbox.load_aware import LoadAware
 
 class Toolbox:
     """
@@ -37,3 +38,4 @@ class Toolbox:
         self.from_config = FromConfig.run
         self.local_ci = Local_CI
         self.wisdom = Wisdom
+        self.load_aware = LoadAware

--- a/toolbox/load_aware.py
+++ b/toolbox/load_aware.py
@@ -12,12 +12,10 @@ class LoadAware:
     @AnsibleMappedParams
     def deploy_trimaran(self):
         """
-        WIP Role to deploy the Trimaran load aware scheduler
+        Role to deploy the Trimaran load aware scheduler
 
         Args:
-            arg1: ...
-            arg2: ...
-            ...
+            None
         """
 
         return RunAnsibleRole(locals())

--- a/toolbox/load_aware.py
+++ b/toolbox/load_aware.py
@@ -1,0 +1,23 @@
+import sys
+
+from toolbox._common import RunAnsibleRole, AnsibleRole, AnsibleMappedParams, AnsibleConstant, AnsibleSkipConfigGeneration
+
+
+class LoadAware:
+    """
+    Commands relating to Trimaran and LoadAware testing
+    """
+
+    @AnsibleRole("load_aware_deploy_trimaran")
+    @AnsibleMappedParams
+    def deploy_trimaran(self):
+        """
+        WIP Role to deploy the Trimaran load aware scheduler
+
+        Args:
+            arg1: ...
+            arg2: ...
+            ...
+        """
+
+        return RunAnsibleRole(locals())


### PR DESCRIPTION
This should cover the basics of deploying the Trimaran scheduler.

Trimaran can be deployed to enable load aware scheduling using:

```
./run_toolbox.py load_aware deploy_trimaran
```