### PR TITLE
testing: ods operator panics during deployment for pipeline test

### DIFF
--- a/roles/rhods_deploy_ods/tasks/main.yml
+++ b/roles/rhods_deploy_ods/tasks/main.yml
@@ -38,7 +38,7 @@
                -oyaml --dry-run=client \
                | oc apply -f-
     oc create secret generic addon-managed-odh-parameters -n redhat-ods-operator \
-               --from-literal=notification-email=not-an-email@local.host \
+               --from-literal=notification-email=not-an-email@local.com \
                -oyaml --dry-run=client \
                | oc apply -f-
     oc create secret generic redhat-rhods-smtp -n redhat-ods-monitoring \


### PR DESCRIPTION
A small test to investigate a failing test due to ods operator panic.

https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/openshift-psap_ci-artifacts/748/pull-ci-openshift-psap-ci-artifacts-main-pipelines-light/1666899339294806016/artifacts/light/gather-extra/artifacts/pods/redhat-ods-operator_rhods-operator-5d5b7f6f9-7tb54_rhods-operator_previous.log

```
...
time="2023-06-08T20:40:14Z" level=info msg="KubeFlow Deployment Completed."
time="2023-06-08T20:40:15Z" level=info msg="Reconciling KfDef resources. Request.Namespace: redhat-ods-applications, Request.Name: rhods-data-science-pipelines-operator."
E0608 20:40:15.344012       1 runtime.go:73] Observed a panic: runtime.boundsError{x:0, y:0, signed:true, code:0x0} (runtime error: index out of range [0] with length 0)
```