### PR TITLE
testing: improve cluster creation control

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -5,3 +5,9 @@ reviewers:
   - jmencak
   - dagrayvid
   - kpouget
+cluster_create: # who is allowed to create clusters in the PSAP account
+  # github handle -> RH kerberos handle
+  kpouget: kpouget
+  kdvalin: kvalin
+  drewrip: dripberg
+  dagrayvid: dagray

--- a/testing/utils/configure.sh
+++ b/testing/utils/configure.sh
@@ -18,12 +18,12 @@ get_config() {
 }
 
 set_config() {
-    key=${1:-}
-    value=${2:-}
-
-    if [[ -z "$key" || -z "$value" ]]; then
-        _error "set_config key value are both mandatory"
+    if ! [[ -v 1 && -v 2 ]]; then
+        _error "set_config 'key' 'value' parameters are both mandatory"
     fi
+
+    key=${1}
+    value=${2}
 
     yq --yaml-roundtrip --in-place --argjson value "$(echo "$value" | yq)" ".$key = \$value" "$CI_ARTIFACTS_FROM_CONFIG_FILE"
 

--- a/testing/utils/openshift_clusters/ocp_cluster.sh
+++ b/testing/utils/openshift_clusters/ocp_cluster.sh
@@ -121,6 +121,10 @@ create_cluster() {
         machine_tags=$((echo "$cluster_tags") | jq . --compact-output)
     fi
 
+    author_kerberos=$(cat OWNERS| yq ".cluster_create.$author" -r) # gh id -> RH kerb id
+    if [[ "$author_kerberos" == null ]]; then
+        _error "PR author '$author' not found in the OWNERS's file 'cluster_create' group."
+    fi
 
     # ensure that the cluster's 'metadata.json' is copied
     # to the CONFIG_DEST_DIR even in case of errors

--- a/testing/utils/openshift_clusters/ocp_cluster.sh
+++ b/testing/utils/openshift_clusters/ocp_cluster.sh
@@ -114,7 +114,7 @@ create_cluster() {
         machine_tags=$((echo "$cluster_tags") | jq . --compact-output)
     fi
 
-    local
+
     # ensure that the cluster's 'metadata.json' is copied
     # to the CONFIG_DEST_DIR even in case of errors
     trap "save_install_artifacts error" ERR SIGTERM SIGINT

--- a/testing/utils/openshift_clusters/ocp_cluster.sh
+++ b/testing/utils/openshift_clusters/ocp_cluster.sh
@@ -126,6 +126,8 @@ create_cluster() {
         _error "PR author '$author' not found in the OWNERS's file 'cluster_create' group."
     fi
 
+    machine_tags=$(echo "$machine_tags" | jq ". += {User: \"$author_kerberos\"}" --compact-output)
+
     # ensure that the cluster's 'metadata.json' is copied
     # to the CONFIG_DEST_DIR even in case of errors
     trap "save_install_artifacts error" ERR SIGTERM SIGINT

--- a/testing/utils/openshift_clusters/ocp_cluster.sh
+++ b/testing/utils/openshift_clusters/ocp_cluster.sh
@@ -52,8 +52,6 @@ create_cluster() {
     if test_config clusters.create.keep; then
         local author=$(echo "$JOB_SPEC" | jq -r .refs.pulls[0].author)
         cluster_name="${author}-${cluster_role}-$(date +%Y%m%d-%Hh%M)"
-
-        export AWS_DEFAULT_PROFILE="${author}_ci-artifact"
     elif [[ "${PULL_NUMBER:-}" ]]; then
         cluster_name="${cluster_name}-pr${PULL_NUMBER}-${cluster_role}-${BUILD_ID}"
     else

--- a/testing/utils/openshift_clusters/ocp_cluster.sh
+++ b/testing/utils/openshift_clusters/ocp_cluster.sh
@@ -126,6 +126,11 @@ create_cluster() {
         _error "PR author '$author' not found in the OWNERS's file 'cluster_create' group."
     fi
 
+    ticketId=$(echo "$machine_tags" | jq .TicketId)
+    if [[ "$ticketId" == null ]]; then
+        _error "clusters.create.ocp.tags.TicketId must be defined to create the cluster"
+    fi
+
     machine_tags=$(echo "$machine_tags" | jq ". += {User: \"$author_kerberos\"}" --compact-output)
 
     # ensure that the cluster's 'metadata.json' is copied

--- a/testing/utils/openshift_clusters/ocp_cluster.sh
+++ b/testing/utils/openshift_clusters/ocp_cluster.sh
@@ -48,9 +48,18 @@ create_cluster() {
     export AWS_DEFAULT_PROFILE=${AWS_DEFAULT_PROFILE:-ci-artifact}
     # ---
 
+    if [[ "${OPENSHIFT_CI:-}" == true ]]; then
+        local author=$(echo "$JOB_SPEC" | jq -r .refs.pulls[0].author)
+
+        if [[ -z "$author" ]]; then
+            _error "Couldn't figure out the test author from $JOB_SPEC ..."
+        fi
+    else
+        _error "Don't know how to find out the PR author outside of OpenShift CI ..."
+    fi
+
     local cluster_name="$(get_config clusters.create.name_prefix)"
     if test_config clusters.create.keep; then
-        local author=$(echo "$JOB_SPEC" | jq -r .refs.pulls[0].author)
         cluster_name="${author}-${cluster_role}-$(date +%Y%m%d-%Hh%M)"
     elif [[ "${PULL_NUMBER:-}" ]]; then
         cluster_name="${cluster_name}-pr${PULL_NUMBER}-${cluster_role}-${BUILD_ID}"


### PR DESCRIPTION
- refuse to create clusters without a `TicketId`
- set the users' Kerberos ID as `User` tag
- define the list of users allowed to create clusters (under the PSAP AWS account)
- refuse to create clusters for users not listed
- only use the `ci-artifact` AWS account