### PR TITLE
testing: retry trimaran deploy if token looks malformed

### DIFF
--- a/roles/load_aware_deploy_trimaran/files/trimaran-test-pod.yaml
+++ b/roles/load_aware_deploy_trimaran/files/trimaran-test-pod.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: trimaran-test
+spec:
+  schedulerName: trimaran-scheduler
+  containers:
+  - name: test
+    image: registry.access.redhat.com/ubi8/ubi
+    command: ["echo", "UBI Started"]
+  restartPolicy: Never

--- a/roles/load_aware_deploy_trimaran/files/trimaran.yaml
+++ b/roles/load_aware_deploy_trimaran/files/trimaran.yaml
@@ -87,7 +87,7 @@ spec:
           args:
           - /bin/kube-scheduler
           - --config=/etc/kubernetes/config.yaml
-          - -v=6
+          - -v=1
           volumeMounts:
           - name: etckubernetes
             mountPath: /etc/kubernetes

--- a/roles/load_aware_deploy_trimaran/tasks/main.yml
+++ b/roles/load_aware_deploy_trimaran/tasks/main.yml
@@ -14,7 +14,7 @@
   # until all of the pods are in the running state
   until: "'Completed' not in monitoring_enabled.stdout and 'Failed' not in monitoring_enabled.stdout and 'Pending' not in monitoring_enabled.stdout"
 
-- name: Get Monitoring Secret
+- name: Get monitoring secret name
   shell:
     oc get secret -n openshift-user-workload-monitoring
       | grep  prometheus-user-workload-token
@@ -30,9 +30,22 @@
     oc get route thanos-querier -n openshift-monitoring -o json
       | jq -r '.spec.host'
   register: thanos_endpoint
-  delay: 3
-  retries: 20
-  until: "'thanos-querier' in thanos_endpoint.stdout"
+
+- name: Checking monitoring token size
+  shell:
+    set -o errexit;
+    set -o pipefail;
+    set -o nounset;
+    set -o errtrace;
+
+    oc get secret {{ monitoring_secret.stdout }} -n openshift-user-workload-monitoring -o json
+      | jq -r '.data.token'
+      | base64 -d
+      | wc -c
+  register: token_size
+  delay: 2
+  retries: 30
+  until: token_size.stdout | int > 1000 
 
 - name: Deploy Trimaran scheduler
   shell: | 
@@ -42,25 +55,11 @@
     set -o errtrace;
    
     export THANOS_MONITORING_ENDPOINT={{ thanos_endpoint.stdout }}
-
     export MONITORING_SECRET={{ monitoring_secret.stdout }}
-
     export MONITORING_TOKEN=$(echo $(oc get secret $MONITORING_SECRET -n openshift-user-workload-monitoring -o json | jq -r '.data.token') | base64 -d)
-
-    # Dumping stderr here can result in leaking the token 
-    export TOKEN_SIZE=$(echo $MONITORING_TOKEN | wc -c 2> /dev/null)
-
-    if [[ TOKEN_SIZE -ge 1000 ]]; then
-      echo "DEPLOYING"  
-      cat {{ trimaran_setup_config }} | envsubst | oc apply -f -
-    else
-      echo "SKIPPING: token looks malformed"
-    fi
+    cat {{ trimaran_setup_config }} | envsubst | oc apply -f -
 
   register: deploy_trimaran
-  delay: 5
-  retries: 20
-  until: "'DEPLOYING' in deploy_trimaran.stdout"
 
 - name: Ensure Trimaran is Running
   shell:
@@ -69,3 +68,16 @@
   delay: 3
   retries: 20
   until: "trimaran_running.stdout == 'Running'"
+
+- name: Deploy test pod with Trimaran
+  shell:
+    oc apply -f {{ trimaran_test_pod }} -n trimaran
+
+- name: Ensure the Trimaran test pods completes
+  shell:
+    oc get pod trimaran-test -n trimaran
+      | awk 'NR > 1 {print $3}'
+  register: trimaran_test_pod_state
+  delay: 5
+  retries: 20
+  until: trimaran_test_pod_state.stdout == 'Completed'

--- a/roles/load_aware_deploy_trimaran/tasks/main.yml
+++ b/roles/load_aware_deploy_trimaran/tasks/main.yml
@@ -12,28 +12,55 @@
   delay: 3
   retries: 20
   # until all of the pods are in the running state
-  until: "'Completed' not in monitoring_enabled.stdout and 'Failed' not in monitoring_enabled.stdout and 'Pending' not in monitoring_enabled.stdout" 
+  until: "'Completed' not in monitoring_enabled.stdout and 'Failed' not in monitoring_enabled.stdout and 'Pending' not in monitoring_enabled.stdout"
+
+- name: Get Monitoring Secret
+  shell:
+    oc get secret -n openshift-user-workload-monitoring
+      | grep  prometheus-user-workload-token
+      | head -n 1
+      | awk '{print $1 }'
+  register: monitoring_secret
+  delay: 3
+  retries: 20
+  until: "'prometheus-user-workload-token' in monitoring_secret.stdout"
+
+- name: Get Thanos Endpoint
+  shell:
+    oc get route thanos-querier -n openshift-monitoring -o json
+      | jq -r '.spec.host'
+  register: thanos_endpoint
+  delay: 3
+  retries: 20
+  until: "'thanos-querier' in thanos_endpoint.stdout"
 
 - name: Deploy Trimaran scheduler
-  shell:
+  shell: | 
     set -o errexit;
     set -o pipefail;
     set -o nounset;
     set -o errtrace;
+   
+    export THANOS_MONITORING_ENDPOINT={{ thanos_endpoint.stdout }}
 
-    export MONITORING_SECRET=$(oc get secret -n openshift-user-workload-monitoring
-      | grep  prometheus-user-workload-token
-      | head -n 1
-      | awk '{print $1 }'
-    )
+    export MONITORING_SECRET={{ monitoring_secret.stdout }}
 
-    export MONITORING_TOKEN=$(echo $(oc get secret $MONITORING_SECRET -n openshift-user-workload-monitoring -o json | jq -r '.data.token')
-      | base64 -d)
+    export MONITORING_TOKEN=$(echo $(oc get secret $MONITORING_SECRET -n openshift-user-workload-monitoring -o json | jq -r '.data.token') | base64 -d)
 
-    export THANOS_MONITORING_ENDPOINT=$(oc get route thanos-querier -n openshift-monitoring -o json
-      | jq -r '.spec.host')
+    # Dumping stderr here can result in leaking the token 
+    export TOKEN_SIZE=$(echo $MONITORING_TOKEN | wc -c 2> /dev/null)
 
-    cat {{ trimaran_setup_config }} | envsubst | oc apply -f -
+    if [[ TOKEN_SIZE -ge 1000 ]]; then
+      echo "DEPLOYING"  
+      cat {{ trimaran_setup_config }} | envsubst | oc apply -f -
+    else
+      echo "SKIPPING: token looks malformed"
+    fi
+
+  register: deploy_trimaran
+  delay: 5
+  retries: 20
+  until: "'DEPLOYING' in deploy_trimaran.stdout"
 
 - name: Ensure Trimaran is Running
   shell:

--- a/roles/load_aware_deploy_trimaran/vars/main/resources.yml
+++ b/roles/load_aware_deploy_trimaran/vars/main/resources.yml
@@ -1,2 +1,3 @@
 user_applications_monitor_config: "roles/load_aware_deploy_trimaran/files/cluster-monitoring-config.yaml"
 trimaran_setup_config: "roles/load_aware_deploy_trimaran/files/trimaran.yaml"
+trimaran_test_pod: "roles/load_aware_deploy_trimaran/files/trimaran-test-pod.yaml"


### PR DESCRIPTION
Retry grabbing the monitoring token if we see signs it doesn't look correct. Also polish the deployment tasks.