### PR TITLE
load-aware: enable configuring Trimaran plugins and settings

### DIFF
--- a/roles/load_aware_deploy_trimaran/.gitignore
+++ b/roles/load_aware_deploy_trimaran/.gitignore
@@ -1,1 +1,0 @@
-files/trimaran.yaml

--- a/roles/load_aware_deploy_trimaran/.gitignore
+++ b/roles/load_aware_deploy_trimaran/.gitignore
@@ -1,0 +1,1 @@
+files/trimaran.yaml

--- a/roles/load_aware_deploy_trimaran/defaults/main/config.yml
+++ b/roles/load_aware_deploy_trimaran/defaults/main/config.yml
@@ -2,3 +2,24 @@
 # Toolbox generate command: repo generate_ansible_default_settings
 # Source component: LoadAware.deploy_trimaran
 
+# log verbosity to set the scheduler to run with,
+load_aware_deploy_trimaran_log_level: 1
+
+# TargetLoadPacking or LoadVariationRiskBalancing
+load_aware_deploy_trimaran_plugin: TargetLoadPacking
+
+# TargetLoadPacking setting
+load_aware_deploy_trimaran_default_requests_cpu: 2000m
+
+# TargetLoadPacking setting
+load_aware_deploy_trimaran_default_target_requests_multiplier: '2'
+
+# TargetLoadPacking setting,
+load_aware_deploy_trimaran_target_utilization: 70
+
+# LoadVariationRiskBalancing setting
+load_aware_deploy_trimaran_safe_variance_margin: 1
+
+# LoadVariationRiskBalancing setting
+load_aware_deploy_trimaran_safe_variance_sensitivity: 2
+

--- a/roles/load_aware_deploy_trimaran/tasks/main.yml
+++ b/roles/load_aware_deploy_trimaran/tasks/main.yml
@@ -47,6 +47,16 @@
   retries: 30
   until: token_size.stdout | int > 1000 
 
+- name: Create the src artifacts directory
+  file:
+    path: "{{ artifact_extra_logs_dir }}/src/"
+    state: directory
+    mode: '0755'
+
+- name: Define location of Trimaran config
+  set_fact:
+    trimaran_setup_config: "{{ artifact_extra_logs_dir }}/src/trimaran-templated-config.yaml"
+
 - name: Configure Trimaran options
   template:
     src: "{{ trimaran_setup_template }}"
@@ -93,4 +103,3 @@
     oc get pod trimaran-test -n trimaran -oyaml > "{{ artifact_extra_logs_dir }}/trimaran-test.pod.yaml"
     oc describe pod trimaran-test -n trimaran > "{{ artifact_extra_logs_dir }}/trimaran-test.pod.desc"
     oc get all -n trimaran -oyaml > "{{ artifact_extra_logs_dir }}/all-trimaran.yaml"
-    cp {{ trimaran_setup_config }} "{{ artifact_extra_logs_dir }}/trimaran-templated-config.yaml"

--- a/roles/load_aware_deploy_trimaran/tasks/main.yml
+++ b/roles/load_aware_deploy_trimaran/tasks/main.yml
@@ -47,14 +47,18 @@
   retries: 30
   until: token_size.stdout | int > 1000 
 
+- name: Configure Trimaran options
+  template:
+    src: "{{ trimaran_setup_template }}"
+    dest: "{{ trimaran_setup_config }}"
+
 - name: Deploy Trimaran scheduler
   shell: | 
     set -o errexit;
     set -o pipefail;
     set -o nounset;
     set -o errtrace;
-   
-    export THANOS_MONITORING_ENDPOINT={{ thanos_endpoint.stdout }}
+
     echo "Route to thanos monitoring endpoint: {{ thanos_endpoint.stdout }}"
     export MONITORING_TOKEN=$(oc get secret {{ monitoring_secret.stdout }} -n openshift-user-workload-monitoring -o json | jq -r '.data.token' | base64 -d)
     cat {{ trimaran_setup_config }} | envsubst | oc apply -f -
@@ -89,7 +93,4 @@
     oc get pod trimaran-test -n trimaran -oyaml > "{{ artifact_extra_logs_dir }}/trimaran-test.pod.yaml"
     oc describe pod trimaran-test -n trimaran > "{{ artifact_extra_logs_dir }}/trimaran-test.pod.desc"
     oc get all -n trimaran -oyaml > "{{ artifact_extra_logs_dir }}/all-trimaran.yaml"
-
-- name: Test
-  shell: |
-    echo "Using plugin: {{ load_aware_deploy_trimaran_plugin }}"
+    cp {{ trimaran_setup_config }} "{{ artifact_extra_logs_dir }}/trimaran-templated-config.yaml"

--- a/roles/load_aware_deploy_trimaran/tasks/main.yml
+++ b/roles/load_aware_deploy_trimaran/tasks/main.yml
@@ -55,8 +55,8 @@
     set -o errtrace;
    
     export THANOS_MONITORING_ENDPOINT={{ thanos_endpoint.stdout }}
-    export MONITORING_SECRET={{ monitoring_secret.stdout }}
-    export MONITORING_TOKEN=$(oc get secret $MONITORING_SECRET -n openshift-user-workload-monitoring -o json | jq -r '.data.token' | base64 -d)
+    echo "Route to thanos monitoring endpoint: {{ thanos_endpoint.stdout }}"
+    export MONITORING_TOKEN=$(oc get secret {{ monitoring_secret.stdout }} -n openshift-user-workload-monitoring -o json | jq -r '.data.token' | base64 -d)
     cat {{ trimaran_setup_config }} | envsubst | oc apply -f -
 
   register: deploy_trimaran
@@ -84,7 +84,12 @@
   retries: 20
   until: trimaran_test_pod_state.stdout == 'Completed'
 
-- name: Dump trimaran test pod info
+- name: Dump trimaran info
   shell: |
     oc get pod trimaran-test -n trimaran -oyaml > "{{ artifact_extra_logs_dir }}/trimaran-test.pod.yaml"
     oc describe pod trimaran-test -n trimaran > "{{ artifact_extra_logs_dir }}/trimaran-test.pod.desc"
+    oc get all -n trimaran -oyaml > "{{ artifact_extra_logs_dir }}/all-trimaran.yaml"
+
+- name: Test
+  shell: |
+    echo "Using plugin: {{ load_aware_deploy_trimaran_plugin }}"

--- a/roles/load_aware_deploy_trimaran/tasks/main.yml
+++ b/roles/load_aware_deploy_trimaran/tasks/main.yml
@@ -56,18 +56,20 @@
    
     export THANOS_MONITORING_ENDPOINT={{ thanos_endpoint.stdout }}
     export MONITORING_SECRET={{ monitoring_secret.stdout }}
-    export MONITORING_TOKEN=$(echo $(oc get secret $MONITORING_SECRET -n openshift-user-workload-monitoring -o json | jq -r '.data.token') | base64 -d)
+    export MONITORING_TOKEN=$(oc get secret $MONITORING_SECRET -n openshift-user-workload-monitoring -o json | jq -r '.data.token' | base64 -d)
     cat {{ trimaran_setup_config }} | envsubst | oc apply -f -
 
   register: deploy_trimaran
 
 - name: Ensure Trimaran is Running
   shell:
-    oc get pods -n trimaran | awk 'NR > 1 {print $3}'
+    oc get pods -n trimaran
+      | grep "trimaran-scheduler"
+      | awk '{print $3}'
   register: trimaran_running
   delay: 3
   retries: 20
-  until: "trimaran_running.stdout == 'Running'"
+  until: trimaran_running.stdout == 'Running'
 
 - name: Deploy test pod with Trimaran
   shell:
@@ -81,3 +83,8 @@
   delay: 5
   retries: 20
   until: trimaran_test_pod_state.stdout == 'Completed'
+
+- name: Dump trimaran test pod info
+  shell: |
+    oc get pod trimaran-test -n trimaran -oyaml > "{{ artifact_extra_logs_dir }}/trimaran-test.pod.yaml"
+    oc describe pod trimaran-test -n trimaran > "{{ artifact_extra_logs_dir }}/trimaran-test.pod.desc"

--- a/roles/load_aware_deploy_trimaran/tasks/main.yml
+++ b/roles/load_aware_deploy_trimaran/tasks/main.yml
@@ -29,7 +29,11 @@
   shell:
     oc get route thanos-querier -n openshift-monitoring -o json
       | jq -r '.spec.host'
-  register: thanos_endpoint
+  register: thanos_endpoint_cmd
+
+- name: Format the Thanos Endpoint
+  set_fact:
+    thanos_endpoint: "https://{{ thanos_endpoint_cmd.stdout }}"
 
 - name: Checking monitoring token size
   shell:
@@ -69,7 +73,7 @@
     set -o nounset;
     set -o errtrace;
 
-    echo "Route to thanos monitoring endpoint: {{ thanos_endpoint.stdout }}"
+    echo "Route to thanos monitoring endpoint: {{ thanos_endpoint }}"
     export MONITORING_TOKEN=$(oc get secret {{ monitoring_secret.stdout }} -n openshift-user-workload-monitoring -o json | jq -r '.data.token' | base64 -d)
     cat {{ trimaran_setup_config }} | envsubst | oc apply -f -
 

--- a/roles/load_aware_deploy_trimaran/templates/trimaran.yaml.j2
+++ b/roles/load_aware_deploy_trimaran/templates/trimaran.yaml.j2
@@ -38,7 +38,7 @@ stringData:
 {% endif %}
           metricProvider:
             type: Prometheus
-            address: https://{{ thanos_endpoint.stdout }}
+            address: {{ thanos_endpoint }}
             token: $MONITORING_TOKEN
 ---
 apiVersion: v1

--- a/roles/load_aware_deploy_trimaran/templates/trimaran.yaml.j2
+++ b/roles/load_aware_deploy_trimaran/templates/trimaran.yaml.j2
@@ -23,22 +23,22 @@ stringData:
           - name: NodeResourcesBalancedAllocation
           - name: NodeResourcesLeastAllocated
           enabled:
-          - name: {{ load_aware_deploy_trimaran_plugin | default('NA') }}
+          - name: {{ load_aware_deploy_trimaran_plugin }}
       pluginConfig:
-      - name: {{ load_aware_deploy_trimaran_plugin | default('NA') }}
+      - name: {{ load_aware_deploy_trimaran_plugin }}
         args:
-{% if load_aware_deploy_trimaran_plugin | default('NA') == "TargetLoadPacking" %}
+{% if load_aware_deploy_trimaran_plugin == "TargetLoadPacking" %}
           defaultRequests:
-            cpu: "{{ load_aware_deploy_trimaran_default_requests_cpu | default('NA') }}"
-          defaultRequestsMultiplier: "{{ load_aware_deploy_trimaran_default_target_requests_multiplier | default('NA') }}"
-          targetUtilization: {{ load_aware_deploy_trimaran_target_utilization | default('NA') }}
+            cpu: "{{ load_aware_deploy_trimaran_default_requests_cpu }}"
+          defaultRequestsMultiplier: "{{ load_aware_deploy_trimaran_default_target_requests_multiplier }}"
+          targetUtilization: {{ load_aware_deploy_trimaran_target_utilization }}
 {% else %}
-          safeVarianceMargin: {{ load_aware_deploy_trimaran_safe_variance_margin | default('NA') }}
-          safeVarianceSensitivity: {{ load_aware_deploy_trimaran_safe_variance_sensitivity | default('NA') }}
+          safeVarianceMargin: {{ load_aware_deploy_trimaran_safe_variance_margin }}
+          safeVarianceSensitivity: {{ load_aware_deploy_trimaran_safe_variance_sensitivity }}
 {% endif %}
           metricProvider:
             type: Prometheus
-            address: https://{{ thanos_endpoint.stdout | default('NA') }}
+            address: https://{{ thanos_endpoint.stdout }}
             token: $MONITORING_TOKEN
 ---
 apiVersion: v1
@@ -92,7 +92,7 @@ spec:
           args:
           - /bin/kube-scheduler
           - --config=/etc/kubernetes/config.yaml
-          - -v={{ load_aware_deploy_trimaran_log_level | default('NA') }}
+          - -v={{ load_aware_deploy_trimaran_log_level }}
           volumeMounts:
           - name: etckubernetes
             mountPath: /etc/kubernetes

--- a/roles/load_aware_deploy_trimaran/templates/trimaran.yaml.j2
+++ b/roles/load_aware_deploy_trimaran/templates/trimaran.yaml.j2
@@ -23,22 +23,22 @@ stringData:
           - name: NodeResourcesBalancedAllocation
           - name: NodeResourcesLeastAllocated
           enabled:
-          - name: {{ load_aware_deploy_trimaran_plugin }}
+          - name: {{ load_aware_deploy_trimaran_plugin | default('NA') }}
       pluginConfig:
-      - name: {{ load_aware_deploy_trimaran_plugin }}
+      - name: {{ load_aware_deploy_trimaran_plugin | default('NA') }}
         args:
-{% if load_aware_deploy_trimaran_plugin == "TargetLoadPacking" %}
+{% if load_aware_deploy_trimaran_plugin | default('NA') == "TargetLoadPacking" %}
           defaultRequests:
-            cpu: "{{ load_aware_deploy_trimaran_default_requests_cpu }}"
-          defaultRequestsMultiplier: "{{ load_aware_deploy_trimaran_default_target_requests_multiplier }}"
-          targetUtilization: {{ load_aware_deploy_trimaran_target_utilization }}
+            cpu: "{{ load_aware_deploy_trimaran_default_requests_cpu | default('NA') }}"
+          defaultRequestsMultiplier: "{{ load_aware_deploy_trimaran_default_target_requests_multiplier | default('NA') }}"
+          targetUtilization: {{ load_aware_deploy_trimaran_target_utilization | default('NA') }}
 {% else %}
-          safeVarianceMargin: {{ load_aware_deploy_trimaran_safe_variance_margin }}
-          safeVarianceSensitivity: {{ load_aware_deploy_trimaran_safe_variance_sensitivity }}
+          safeVarianceMargin: {{ load_aware_deploy_trimaran_safe_variance_margin | default('NA') }}
+          safeVarianceSensitivity: {{ load_aware_deploy_trimaran_safe_variance_sensitivity | default('NA') }}
 {% endif %}
           metricProvider:
             type: Prometheus
-            address: https://{{ thanos_endpoint.stdout }}
+            address: https://{{ thanos_endpoint.stdout | default('NA') }}
             token: $MONITORING_TOKEN
 ---
 apiVersion: v1
@@ -92,7 +92,7 @@ spec:
           args:
           - /bin/kube-scheduler
           - --config=/etc/kubernetes/config.yaml
-          - -v={{ load_aware_deploy_trimaran_log_level }}
+          - -v={{ load_aware_deploy_trimaran_log_level | default('NA') }}
           volumeMounts:
           - name: etckubernetes
             mountPath: /etc/kubernetes

--- a/roles/load_aware_deploy_trimaran/templates/trimaran.yaml.j2
+++ b/roles/load_aware_deploy_trimaran/templates/trimaran.yaml.j2
@@ -23,17 +23,22 @@ stringData:
           - name: NodeResourcesBalancedAllocation
           - name: NodeResourcesLeastAllocated
           enabled:
-          - name: TargetLoadPacking
+          - name: {{ load_aware_deploy_trimaran_plugin }}
       pluginConfig:
-      - name: TargetLoadPacking
+      - name: {{ load_aware_deploy_trimaran_plugin }}
         args:
+{% if load_aware_deploy_trimaran_plugin == "TargetLoadPacking" %}
           defaultRequests:
-            cpu: "2000m"
-          defaultRequestsMultiplier: "1"
-          targetUtilization: 1
+            cpu: "{{ load_aware_deploy_trimaran_default_requests_cpu }}"
+          defaultRequestsMultiplier: "{{ load_aware_deploy_trimaran_default_target_requests_multiplier }}"
+          targetUtilization: {{ load_aware_deploy_trimaran_target_utilization }}
+{% else %}
+          safeVarianceMargin: {{ load_aware_deploy_trimaran_safe_variance_margin }}
+          safeVarianceSensitivity: {{ load_aware_deploy_trimaran_safe_variance_sensitivity }}
+{% endif %}
           metricProvider:
             type: Prometheus
-            address: https://${THANOS_MONITORING_ENDPOINT}
+            address: https://{{ thanos_endpoint.stdout }}
             token: $MONITORING_TOKEN
 ---
 apiVersion: v1
@@ -87,7 +92,7 @@ spec:
           args:
           - /bin/kube-scheduler
           - --config=/etc/kubernetes/config.yaml
-          - -v=1
+          - -v={{ load_aware_deploy_trimaran_log_level }}
           volumeMounts:
           - name: etckubernetes
             mountPath: /etc/kubernetes

--- a/roles/load_aware_deploy_trimaran/vars/main/resources.yml
+++ b/roles/load_aware_deploy_trimaran/vars/main/resources.yml
@@ -1,3 +1,4 @@
 user_applications_monitor_config: "roles/load_aware_deploy_trimaran/files/cluster-monitoring-config.yaml"
+trimaran_setup_template: "roles/load_aware_deploy_trimaran/templates/trimaran.yaml.j2"
 trimaran_setup_config: "roles/load_aware_deploy_trimaran/files/trimaran.yaml"
 trimaran_test_pod: "roles/load_aware_deploy_trimaran/files/trimaran-test-pod.yaml"

--- a/roles/load_aware_deploy_trimaran/vars/main/resources.yml
+++ b/roles/load_aware_deploy_trimaran/vars/main/resources.yml
@@ -1,4 +1,3 @@
 user_applications_monitor_config: "roles/load_aware_deploy_trimaran/files/cluster-monitoring-config.yaml"
 trimaran_setup_template: "roles/load_aware_deploy_trimaran/templates/trimaran.yaml.j2"
-trimaran_setup_config: "roles/load_aware_deploy_trimaran/files/trimaran.yaml"
 trimaran_test_pod: "roles/load_aware_deploy_trimaran/files/trimaran-test-pod.yaml"

--- a/roles/load_aware_undeploy_trimaran/defaults/main/config.yml
+++ b/roles/load_aware_undeploy_trimaran/defaults/main/config.yml
@@ -1,4 +1,4 @@
 # Auto-generated file, do not edit manually ... 
 # Toolbox generate command: repo generate_ansible_default_settings
-# Source component: LoadAware.deploy_trimaran
+# Source component: LoadAware.undeploy_trimaran
 

--- a/roles/load_aware_undeploy_trimaran/tasks/main.yml
+++ b/roles/load_aware_undeploy_trimaran/tasks/main.yml
@@ -11,10 +11,6 @@
 - name: Define the same default settings from deploy role
   include_vars: "{{ trimaran_deploy_defaults }}"
 
-- name: Dummy Thanos Endpoint
-  command: echo "NA"
-  register: thanos_endpoint
-
 - name: Configure Trimaran options
   template:
     src: "{{ trimaran_setup_template }}"

--- a/roles/load_aware_undeploy_trimaran/tasks/main.yml
+++ b/roles/load_aware_undeploy_trimaran/tasks/main.yml
@@ -1,3 +1,18 @@
+- name: Create the src artifacts directory
+  file:
+    path: "{{ artifact_extra_logs_dir }}/src/"
+    state: directory
+    mode: '0755'
+
+- name: Define the Trimaran setup config
+  set_fact:
+    trimaran_setup_config: "{{ artifact_extra_logs_dir }}/src/trimaran-templated-config.yaml"
+
+- name: Configure Trimaran options
+  template:
+    src: "{{ trimaran_setup_template }}"
+    dest: "{{ trimaran_setup_config }}"
+
 - name: Delete Trimaran resources
   command: 
     oc delete -f {{ trimaran_setup_config }} --ignore-not-found

--- a/roles/load_aware_undeploy_trimaran/tasks/main.yml
+++ b/roles/load_aware_undeploy_trimaran/tasks/main.yml
@@ -7,6 +7,7 @@
 - name: Define the Trimaran setup config
   set_fact:
     trimaran_setup_config: "{{ artifact_extra_logs_dir }}/src/trimaran-templated-config.yaml"
+    thanos_endpoint: "NA"
 
 - name: Define the same default settings from deploy role
   include_vars: "{{ trimaran_deploy_defaults }}"

--- a/roles/load_aware_undeploy_trimaran/tasks/main.yml
+++ b/roles/load_aware_undeploy_trimaran/tasks/main.yml
@@ -8,6 +8,13 @@
   set_fact:
     trimaran_setup_config: "{{ artifact_extra_logs_dir }}/src/trimaran-templated-config.yaml"
 
+- name: Define the same default settings from deploy role
+  include_vars: "{{ trimaran_deploy_defaults }}"
+
+- name: Dummy Thanos Endpoint
+  command: echo "NA"
+  register: thanos_endpoint
+
 - name: Configure Trimaran options
   template:
     src: "{{ trimaran_setup_template }}"

--- a/roles/load_aware_undeploy_trimaran/vars/main/resources.yml
+++ b/roles/load_aware_undeploy_trimaran/vars/main/resources.yml
@@ -1,3 +1,2 @@
 trimaran_setup_template: "roles/load_aware_deploy_trimaran/templates/trimaran.yaml.j2"
 trimaran_deploy_defaults: "roles/load_aware_deploy_trimaran/defaults/main/config.yml"
-thanos_endpoint: "NA"

--- a/roles/load_aware_undeploy_trimaran/vars/main/resources.yml
+++ b/roles/load_aware_undeploy_trimaran/vars/main/resources.yml
@@ -1,1 +1,2 @@
 trimaran_setup_template: "roles/load_aware_deploy_trimaran/templates/trimaran.yaml.j2"
+trimaran_deploy_defaults: "roles/load_aware_deploy_trimaran/defaults/main/config.yml"

--- a/roles/load_aware_undeploy_trimaran/vars/main/resources.yml
+++ b/roles/load_aware_undeploy_trimaran/vars/main/resources.yml
@@ -1,2 +1,3 @@
 trimaran_setup_template: "roles/load_aware_deploy_trimaran/templates/trimaran.yaml.j2"
 trimaran_deploy_defaults: "roles/load_aware_deploy_trimaran/defaults/main/config.yml"
+thanos_endpoint: "NA"

--- a/roles/load_aware_undeploy_trimaran/vars/main/resources.yml
+++ b/roles/load_aware_undeploy_trimaran/vars/main/resources.yml
@@ -1,1 +1,1 @@
-trimaran_setup_config: "roles/load_aware_deploy_trimaran/files/trimaran.yaml"
+trimaran_setup_template: "roles/load_aware_deploy_trimaran/templates/trimaran.yaml.j2"

--- a/testing/load-aware/command_args.yaml
+++ b/testing/load-aware/command_args.yaml
@@ -8,3 +8,13 @@
 
 cluster capture_environment/sample:
   _none: true # nothing to configure :/
+
+load_aware deploy_trimaran:
+  log_levl: {{ load_aware.log_levl }}
+  plugin: {{ load_aware.plugin }}
+  default_requests_cpu: {{ load_aware.default_requests_cpu }}
+  default_target_request_multiplier: {{ default_target_request_multiplier }}
+  target_utilization: {{ load_aware.target_utilization }}
+  safe_variance_margin: {{ load_aware.safe_variance_margin }}
+  safe_variance_sensitivity: {{ load_aware.safe_variance_sensitivity }}
+

--- a/testing/load-aware/command_args.yaml
+++ b/testing/load-aware/command_args.yaml
@@ -10,10 +10,10 @@ cluster capture_environment/sample:
   _none: true # nothing to configure :/
 
 load_aware deploy_trimaran:
-  log_levl: {{ load_aware.log_levl }}
+  log_level: {{ load_aware.log_level }}
   plugin: {{ load_aware.plugin }}
   default_requests_cpu: {{ load_aware.default_requests_cpu }}
-  default_target_request_multiplier: {{ default_target_request_multiplier }}
+  default_target_requests_multiplier: {{ load_aware.default_target_requests_multiplier }}
   target_utilization: {{ load_aware.target_utilization }}
   safe_variance_margin: {{ load_aware.safe_variance_margin }}
   safe_variance_sensitivity: {{ load_aware.safe_variance_sensitivity }}

--- a/testing/load-aware/config.yaml
+++ b/testing/load-aware/config.yaml
@@ -88,7 +88,14 @@ clusters:
           value: "yes"
           effect: NoSchedule
   cleanup_on_exit: false
-
+load_aware:
+  log_level: null
+  plugin: null
+  default_requests_cpu: null
+  default_target_requests_multiplier: null
+  target_utilization: null
+  safe_variance_margin: null
+  safe_variance_sensitivity: null
 matbench:
   preset: null
   workload: load-aware
@@ -102,11 +109,3 @@ matbench:
   ignore_exit_code: true
   # directory to plot. Set by testing/common/visualize.py before launching the visualization
   test_directory: null
-load_aware:
-  log_level: null
-  plugin: null
-  default_requests_cpu: null
-  default_target_requests_multiplier: null
-  target_utilization: null
-  safe_variance_margin: null
-  safe_variance_sensitivity: null

--- a/testing/load-aware/config.yaml
+++ b/testing/load-aware/config.yaml
@@ -26,6 +26,12 @@ ci_presets:
     clusters.sutest.is_metal: false
     clusters.driver.is_metal: false
 
+  target_load_packing:
+    load_aware.plugin: "TargetLoadPacking"
+  
+  load_variation_risk_balancing:
+    load_aware.plugin: "LoadVariationRiskBalancing"
+
 secrets:
   dir:
     name: psap-ods-secret
@@ -96,3 +102,11 @@ matbench:
   ignore_exit_code: true
   # directory to plot. Set by testing/common/visualize.py before launching the visualization
   test_directory: null
+load_aware:
+  log_level: null
+  plugin: null
+  default_requests_cpu: null
+  default_target_request_multiplier: null
+  target_utilization: null
+  safe_variance_margin: null
+  safe_variance_sensitivity: null

--- a/testing/load-aware/config.yaml
+++ b/testing/load-aware/config.yaml
@@ -106,7 +106,7 @@ load_aware:
   log_level: null
   plugin: null
   default_requests_cpu: null
-  default_target_request_multiplier: null
+  default_target_requests_multiplier: null
   target_utilization: null
   safe_variance_margin: null
   safe_variance_sensitivity: null

--- a/testing/load-aware/test.py
+++ b/testing/load-aware/test.py
@@ -116,6 +116,8 @@ def test_ci():
         else:
             logging.warning("Not generating the visualization as the test artifact directory hasn't been created.")
 
+        if config.ci_artifacts.get_config("clusters.cleanup_on_exit"):
+            cleanup_cluster()
 
 @entrypoint(ignore_secret_path=True, apply_preset_from_pr_args=False)
 def generate_plots_from_pr_args():

--- a/toolbox/load_aware.py
+++ b/toolbox/load_aware.py
@@ -10,13 +10,40 @@ class LoadAware:
 
     @AnsibleRole("load_aware_deploy_trimaran")
     @AnsibleMappedParams
-    def deploy_trimaran(self):
+    def deploy_trimaran(self, log_level=1,
+                        plugin="TargetLoadPacking", default_requests_cpu="2000m",
+                        default_target_request_multiplier="2", target_utilization=70,
+                        safe_variance_margin=1, safe_variance_sensitivity=2
+                        ):
         """
         Role to deploy the Trimaran load aware scheduler
 
         Args:
-            None
+            log_level: log verbosity to set the scheduler to run with,
+            plugin: TargetLoadPacking or LoadVariationRiskBalancing
+            default_requests_cpu: TargetLoadPacking setting
+            default_target_request_multiplier: TargetLoadPacking setting
+            target_utilization: TargetLoadPacking setting,
+            safe_variance_margin: LoadVariationRiskBalancing setting
+            safe_variance_sensitivity: LoadVariationRiskBalancing setting
         """
+
+        if plugin not in ("TargetLoadPacking", "LoadVariationRiskBalancing"):
+            print(f"Can't deploy Trimaran with unknown plugin: {plugin}")
+            sys.exit(1)
+
+
+        print(f"Deploying Trimaran with plugin {plugin}")
+
+        if plugin == "TargetLoadPacking":
+            print(f"default_requests_cpu: {default_requests_cpu}")
+            print(f"default_target_request_multiplier: {default_target_request_multiplier}")
+            print(f"target_utilization: {target_utilization}")
+        else:
+            print(f"safe_variance_margin: {safe_variance_margin}")
+            print(f"safe_variance_sensitivity: {safe_variance_sensitivity}")
+
+        print(f"Deploying Trimaran with log level {log_level}")
 
         return RunAnsibleRole(locals())
 

--- a/toolbox/load_aware.py
+++ b/toolbox/load_aware.py
@@ -12,7 +12,7 @@ class LoadAware:
     @AnsibleMappedParams
     def deploy_trimaran(self, log_level=1,
                         plugin="TargetLoadPacking", default_requests_cpu="2000m",
-                        default_target_request_multiplier="2", target_utilization=70,
+                        default_target_requests_multiplier="2", target_utilization=70,
                         safe_variance_margin=1, safe_variance_sensitivity=2
                         ):
         """
@@ -22,7 +22,7 @@ class LoadAware:
             log_level: log verbosity to set the scheduler to run with,
             plugin: TargetLoadPacking or LoadVariationRiskBalancing
             default_requests_cpu: TargetLoadPacking setting
-            default_target_request_multiplier: TargetLoadPacking setting
+            default_target_requests_multiplier: TargetLoadPacking setting
             target_utilization: TargetLoadPacking setting,
             safe_variance_margin: LoadVariationRiskBalancing setting
             safe_variance_sensitivity: LoadVariationRiskBalancing setting
@@ -37,7 +37,7 @@ class LoadAware:
 
         if plugin == "TargetLoadPacking":
             print(f"default_requests_cpu: {default_requests_cpu}")
-            print(f"default_target_request_multiplier: {default_target_request_multiplier}")
+            print(f"default_target_requests_multiplier: {default_target_requests_multiplier}")
             print(f"target_utilization: {target_utilization}")
         else:
             print(f"safe_variance_margin: {safe_variance_margin}")

--- a/toolbox/load_aware.py
+++ b/toolbox/load_aware.py
@@ -10,11 +10,7 @@ class LoadAware:
 
     @AnsibleRole("load_aware_deploy_trimaran")
     @AnsibleMappedParams
-    def deploy_trimaran(self, log_level=1,
-                        plugin="TargetLoadPacking", default_requests_cpu="2000m",
-                        default_target_requests_multiplier="2", target_utilization=70,
-                        safe_variance_margin=1, safe_variance_sensitivity=2
-                        ):
+    def deploy_trimaran(self, log_level=1, plugin="TargetLoadPacking", default_requests_cpu="2000m", default_target_requests_multiplier="2", target_utilization=70, safe_variance_margin=1, safe_variance_sensitivity=2):
         """
         Role to deploy the Trimaran load aware scheduler
 


### PR DESCRIPTION
Adds the ability to configure Trimaran's plugin and corresponding settings from the CI. Also adds the ability to change the log level. This PR should not affect the `undeploy` role. However, the `undeploy` role must have access to the generated `trimaran.yaml` that was used to deploy Trimaran or it might not be able to properly cleanup.