### PR TITLE
pipelines: sample pipeline with multiple dependent stages and fixed runtime

### DIFF
--- a/testing/pipelines/config.yaml
+++ b/testing/pipelines/config.yaml
@@ -51,6 +51,9 @@ ci_presets:
     tests.pipelines.notebook_filename: kfp_hash.ipynb
     tests.pipelines.notebook_directory: testing/pipelines/notebooks/hash
 
+  pipeline_timed_multistage:
+    tests.pipelines.notebook_filename: kfp_timed_multistage.ipynb
+    tests.pipelines.notebook_directory: testing/pipelines/notebooks/timed-multistage
 
 secrets:
   dir:

--- a/testing/pipelines/notebooks/timed-multistage/kfp_timed_multistage.ipynb
+++ b/testing/pipelines/notebooks/timed-multistage/kfp_timed_multistage.ipynb
@@ -1,0 +1,95 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5e542637-b5ac-4460-99a1-25031eae9a0d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "#TOKEN_FILE = \"/run/secrets/kubernetes.io/serviceaccount/token\" # not working in RHODS 1.25\n",
+    "TOKEN_FILE = \"/mnt/secret_token/token\"\n",
+    "with open(TOKEN_FILE) as f:\n",
+    "  token = f.read().strip()\n",
+    "route = os.environ[\"DSP_ROUTE\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a4540a32-f1e5-44c4-9c61-fa51e1ee2130",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import kfp_tekton\n",
+    "from timed_multistage import timed_multistage_pipeline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a694095e-f78d-4022-aab9-14785cfba8e9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cert=\"/run/secrets/kubernetes.io/serviceaccount/ca.crt\"\n",
+    "ex = None\n",
+    "for i in range(5):\n",
+    "  try:\n",
+    "    print(f'try #{i}')\n",
+    "    client = kfp_tekton.TektonClient(host=route, existing_token=token, ssl_ca_cert=cert)\n",
+    "    print(f'try #{i} succeeded :)')\n",
+    "    break\n",
+    "  except Exception as e:\n",
+    "    import time;time.sleep(5)\n",
+    "    ex = e\n",
+    "else:\n",
+    "  raise Exception('Could not connect to TektonClient the after multiple tries :/') from ex"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5930c2f2-e9f1-4c82-8e38-baafc5f9e939",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from kfp_tekton.compiler import TektonCompiler\n",
+    "TektonCompiler().compile(timed_multistage_pipeline, \"results/pipeline.yaml\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "54be79f0-40c0-45f7-99f8-9c0dc29757a1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "client.create_run_from_pipeline_func(pipeline_func=timed_multistage_pipeline, arguments={})"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3.9.14",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.14"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/testing/pipelines/notebooks/timed-multistage/timed_multistage.py
+++ b/testing/pipelines/notebooks/timed-multistage/timed_multistage.py
@@ -1,0 +1,60 @@
+from kfp import dsl
+from kfp import components
+
+def cbrt_loop(n:int, x:int) -> int:
+    import math, time
+    
+    i = 0
+    end_time = time.time() + n
+    while end_time >= time.time():
+        math.sqrt(float(x))
+        i += 1
+
+    return i
+
+
+def print_msg(msg: str):
+    """Print a message."""
+    print(msg)
+
+
+cbrt_op = components.create_component_from_func(
+    cbrt_loop, base_image='quay.io/hukhan/python:alpine3.6')
+print_op = components.create_component_from_func(
+    print_msg, base_image='quay.io/hukhan/python:alpine3.6')
+
+
+@dsl.pipeline(
+    name='timed-multistage-workload',
+    description='a simple pipeline with multiple stages that have defined runtimes'
+)
+def timed_multistage_pipeline():   
+    # 4 pipelines that each have 3 stages. Each should last 2 minutes.
+    duration = 2 * 60
+    x = 123456789
+
+    h1_s1 = cbrt_op(duration, x)
+    h2_s1 = cbrt_op(duration, x)
+    h3_s1 = cbrt_op(duration, x)
+    h4_s1 = cbrt_op(duration, x)
+
+    h1_s2 = cbrt_op(duration, h1_s1.output)
+    h2_s2 = cbrt_op(duration, h2_s1.output)
+    h3_s2 = cbrt_op(duration, h3_s1.output)
+    h4_s2 = cbrt_op(duration, h4_s1.output)
+
+    h1_s3 = cbrt_op(duration, h1_s2.output)
+    h2_s3 = cbrt_op(duration, h2_s2.output)
+    h3_s3 = cbrt_op(duration, h3_s2.output)
+    h4_s3 = cbrt_op(duration, h4_s2.output)
+
+    h1 = [h1_s1.output, h1_s2.output, h1_s3.output]
+    h2 = [h2_s1.output, h2_s2.output, h2_s3.output]
+    h3 = [h3_s1.output, h3_s2.output, h3_s3.output]
+    h4 = [h4_s1.output, h4_s2.output, h4_s3.output]
+
+    print_op(f"p1: {h1}\np2: {h2}\np3: {h3}\np4: {h4}")
+
+if __name__ == '__main__':
+    from kfp_tekton.compiler import TektonCompiler
+    TektonCompiler().compile(timed_multistage_pipeline, __file__.replace('.py', '.yaml'))


### PR DESCRIPTION
It was brought up that this pipeline might be useful for testing. It has 4 parallel pipelines, each 3 interdependent stages. Each stage should take 2 minutes and generate CPU load during that time by repeatedly taking square roots.