### PR TITLE
load-aware: role to launch load-aware scale test corresponding to Poisson distribution

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ jinja2==3.0.*
 flake8
 pylint
 awscli
+numpy
 
 jsonpath_ng
 state-signals==0.5.2

--- a/roles/load_aware_scale_test/defaults/main/config.yml
+++ b/roles/load_aware_scale_test/defaults/main/config.yml
@@ -1,0 +1,13 @@
+# Auto-generated file, do not edit manually ... 
+# Toolbox generate command: repo generate_ansible_default_settings
+# Source component: LoadAware.scale_test
+
+# what distribution to generate the load according to (poisson, normal, bimodal, gamma, or uniform)
+load_aware_scale_test_distribution: poisson
+
+# how long the test should last (seconds)
+load_aware_scale_test_duration: 60.0
+
+# how many of the workload to launch, at the moment, this is the number of test pods
+load_aware_scale_test_instances: 10
+

--- a/roles/load_aware_scale_test/files/load-aware-ns.yaml
+++ b/roles/load_aware_scale_test/files/load-aware-ns.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: load-aware
+  labels:
+    name: load-aware

--- a/roles/load_aware_scale_test/files/scheduler.py
+++ b/roles/load_aware_scale_test/files/scheduler.py
@@ -1,0 +1,44 @@
+import time, sys, sched, yaml
+import subprocess as sp
+import numpy as np
+
+scheduler = sys.argv[1]
+
+def run_pod(n, scheduler_name):
+    pod_config = {
+        "apiVersion": "v1",
+        "kind": "Pod",
+        "metadata": {
+            "name": f"test-pod-{scheduler_name}-n{n}",
+        },
+        "spec": {
+            "containers": [
+                {
+                    "name": "test",
+                    "image": "registry.access.redhat.com/ubi8/ubi",
+                    "command": ["echo", "UBI Started"],
+                },
+            ],
+            "restartPolicy": "Never",
+        },
+    }
+
+    if scheduler == "trimaran":
+        pod_config["spec"]["schedulerName"] = "trimaran-scheduler"
+
+    yaml_pod_config = yaml.dump(pod_config, default_flow_style=False)
+    start_command = ["oc", "apply", "-n", "load-aware", "-f", "-"]
+    print(f"launching workload n{n} at {time.time()}")
+    p = sp.run(start_command, input=yaml_pod_config.encode(), stdout=sp.PIPE)
+    
+
+times = list(map(float, sys.stdin.read().split(",")))
+
+s = sched.scheduler(time.monotonic, time.sleep)
+
+for i, t in enumerate(times):
+    print(f"adding n{i} to the schedule at delay={t}")
+    s.enter(t, 1, run_pod, argument=(i, scheduler))
+
+print(f"running schedule at {time.time()}")
+s.run()

--- a/roles/load_aware_scale_test/files/timeline.py
+++ b/roles/load_aware_scale_test/files/timeline.py
@@ -1,0 +1,61 @@
+import sys, time
+import numpy as np
+
+distribution = sys.argv[1]
+duration = float(sys.argv[2])
+instances = int(sys.argv[3])
+
+# https://arxiv.org/pdf/1607.05356.pdf
+# scale is 1/lamda, or target time between requests
+def poisson_times(n, rng, scale=1.0, t0=0.0, start=0.0, end=60.0):
+    t = t0
+    delays = rng.exponential(scale=scale, size=n)
+    times = []
+    for d in delays:
+        t += d
+        times.append(t)
+    times = np.array(times)
+    return times * (end/times.max()) + start
+
+def uniform_times(n, rng, start=0.0, end=60.0):
+    return rng.uniform(low=start, high=end, size=n)
+
+def gamma_times(n, rng, shape=2.0, start=0.0, end=60.0):
+    times = rng.gamma(shape, size=n)
+    return times * (end/times.max()) + start
+
+def normal_times(n, rng, mean=0.0, stddev=0.2, start=0.0, end=60.0):
+    times = rng.normal(mean, stddev, n)
+    times = times - times.min()
+    return times * (end/times.max()) + start
+
+def bimodal_times(n, rng, mean1=-1.0, mean2=1.0, stddev=0.3, start=0.0, end=60.0):
+    times1 = rng.normal(mean1, stddev, round(n/2))
+    times2 = rng.normal(mean2, stddev, round(n/2))
+    times = np.concatenate((times1, times2))
+    times = times - times.min()
+    return times * (end/times.max()) + start
+
+def serialize(a):
+    return ",".join(np.char.mod("%f", a))
+
+
+rng = np.random.default_rng(123456789)
+
+times = ""
+
+if distribution == "poisson":
+    times = serialize(poisson_times(instances, rng, end=duration))
+elif distribution == "uniform":
+    times = serialize(uniform_times(instances, rng, end=duration))
+elif distribution == "gamma":
+    times = serialize(gamma_times(instances, rng, end=duration))
+elif distribution == "normal":
+    times = serialize(normal_times(instances, rng, end=duration))
+elif distribution == "bimodal":
+    times = serialize(bimodal_times(instances, rng, end=duration))
+else:
+    print("unknown distribution")
+    sys.exit(1)
+
+print(times)

--- a/roles/load_aware_scale_test/meta/main.yml
+++ b/roles/load_aware_scale_test/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - role: check_deps

--- a/roles/load_aware_scale_test/tasks/main.yml
+++ b/roles/load_aware_scale_test/tasks/main.yml
@@ -1,0 +1,63 @@
+- name: Generate load timeline
+  shell:
+    python3 {{ load_timeline_generator }} {{ load_aware_scale_test_distribution }} {{ load_aware_scale_test_duration}} {{ load_aware_scale_test_instances }} > "{{ artifact_extra_logs_dir }}/load_aware_load_timeline.txt"
+
+- name: Create namespace for default test
+  command:
+    oc apply -f {{ load_aware_ns }}
+
+- name: Run test workload with default scheduler and load timeline
+  shell:
+    cat "{{ artifact_extra_logs_dir }}/load_aware_load_timeline.txt"
+      | python3 {{ pod_start_scheduler }} default > "{{ artifact_extra_logs_dir }}/default_workload_scheduler.txt"
+
+- name: Wait for default workloads to finish
+  shell:
+    oc get pods -n load-aware | awk 'NR > 1 { print $3 }'
+  register: load_aware_workload
+  delay: 15
+  retries: 120
+  until:
+    "'Running' not in load_aware_workload.stdout
+      and 'Pending' not in load_aware_workload.stdout
+      and 'Failed' not in load_aware_workload.stdout
+      and 'ContainerCreating' not in load_aware_workload.stdout"
+
+- name: Dump info about default scheduler resources
+  shell:
+    oc get all -n load-aware -oyaml > "{{ artifact_extra_logs_dir }}/all_default_resources.yaml"
+
+- name: Cleanup namespace for default test
+  command:
+    oc delete -f {{ load_aware_ns }}
+
+- name: Create namespace for trimaran test
+  command:
+    oc apply -f {{ load_aware_ns }}
+
+
+- name: Run test pod with trimaran scheduler and load timeline
+  shell:
+    cat "{{ artifact_extra_logs_dir }}/load_aware_load_timeline.txt"
+      | python3 {{ pod_start_scheduler }} trimaran > "{{ artifact_extra_logs_dir }}/trimaran_workload_scheduler.txt"
+
+- name: Wait for default workloads to finish
+  shell:
+    oc get pods -n load-aware | awk 'NR > 1 { print $3 }'
+  register: load_aware_workload
+  delay: 15
+  retries: 120
+  until:
+    "'Running' not in load_aware_workload.stdout
+      and 'Pending' not in load_aware_workload.stdout
+      and 'Failed' not in load_aware_workload.stdout
+      and 'ContainerCreating' not in load_aware_workload.stdout"
+
+
+- name: Dump info about trimaran resources
+  shell:
+    oc get all -n load-aware -oyaml > "{{ artifact_extra_logs_dir }}/all_trimaran_resources.yaml"
+
+- name: Cleanup namespace for test
+  command:
+    oc delete -f {{ load_aware_ns }}

--- a/roles/load_aware_scale_test/tasks/main.yml
+++ b/roles/load_aware_scale_test/tasks/main.yml
@@ -1,6 +1,6 @@
 - name: Generate load timeline
   shell:
-    python3 {{ load_timeline_generator }} {{ load_aware_scale_test_distribution }} {{ load_aware_scale_test_duration}} {{ load_aware_scale_test_instances }} > "{{ artifact_extra_logs_dir }}/load_aware_load_timeline.txt"
+    python3 {{ load_timeline_generator }} {{ load_aware_scale_test_distribution }} {{ load_aware_scale_test_duration}} {{ load_aware_scale_test_instances }} > "{{ artifact_extra_logs_dir }}/load_aware_load_timeline.log"
 
 - name: Create namespace for default test
   command:
@@ -8,8 +8,8 @@
 
 - name: Run test workload with default scheduler and load timeline
   shell:
-    cat "{{ artifact_extra_logs_dir }}/load_aware_load_timeline.txt"
-      | python3 {{ pod_start_scheduler }} default > "{{ artifact_extra_logs_dir }}/default_workload_scheduler.txt"
+    cat "{{ artifact_extra_logs_dir }}/load_aware_load_timeline.log"
+      | python3 {{ pod_start_scheduler }} default > "{{ artifact_extra_logs_dir }}/default_workload_scheduler.log"
 
 - name: Wait for default workloads to finish
   shell:
@@ -24,8 +24,9 @@
       and 'ContainerCreating' not in load_aware_workload.stdout"
 
 - name: Dump info about default scheduler resources
-  shell:
-    oc get all -n load-aware -oyaml > "{{ artifact_extra_logs_dir }}/all_default_resources.yaml"
+  shell: |
+    oc get pods -n load-aware > "{{ artifact_extra_logs_dir }}/all_default_pods.status" 
+    oc get pods -n load-aware -ojson > "{{ artifact_extra_logs_dir }}/all_default_pods.json"
 
 - name: Cleanup namespace for default test
   command:
@@ -38,8 +39,8 @@
 
 - name: Run test pod with trimaran scheduler and load timeline
   shell:
-    cat "{{ artifact_extra_logs_dir }}/load_aware_load_timeline.txt"
-      | python3 {{ pod_start_scheduler }} trimaran > "{{ artifact_extra_logs_dir }}/trimaran_workload_scheduler.txt"
+    cat "{{ artifact_extra_logs_dir }}/load_aware_load_timeline.log"
+      | python3 {{ pod_start_scheduler }} trimaran > "{{ artifact_extra_logs_dir }}/trimaran_workload_scheduler.log"
 
 - name: Wait for default workloads to finish
   shell:
@@ -55,8 +56,9 @@
 
 
 - name: Dump info about trimaran resources
-  shell:
-    oc get all -n load-aware -oyaml > "{{ artifact_extra_logs_dir }}/all_trimaran_resources.yaml"
+  shell: |
+    oc get pods -n load-aware > "{{ artifact_extra_logs_dir }}/all_trimaran_pods.status" 
+    oc get pods -n load-aware -ojson > "{{ artifact_extra_logs_dir }}/all_trimaran_pods.json"
 
 - name: Cleanup namespace for test
   command:

--- a/roles/load_aware_scale_test/vars/main/resources.yml
+++ b/roles/load_aware_scale_test/vars/main/resources.yml
@@ -1,0 +1,3 @@
+load_aware_ns: "roles/load_aware_scale_test/files/load-aware-ns.yaml"
+load_timeline_generator: "roles/load_aware_scale_test/files/timeline.py"
+pod_start_scheduler: "roles/load_aware_scale_test/files/scheduler.py"

--- a/testing/load-aware/command_args.yaml
+++ b/testing/load-aware/command_args.yaml
@@ -18,3 +18,7 @@ load_aware deploy_trimaran:
   safe_variance_margin: {{ load_aware.safe_variance_margin }}
   safe_variance_sensitivity: {{ load_aware.safe_variance_sensitivity }}
 
+load_aware scale_test:
+  distribution: {{ load_aware.scale_test.distribution }}
+  duration: {{ load_aware.scale_test.duration }}
+  instances: {{ load_aware.scale_test.instances }}

--- a/testing/load-aware/config.yaml
+++ b/testing/load-aware/config.yaml
@@ -32,6 +32,12 @@ ci_presets:
   load_variation_risk_balancing:
     load_aware.plugin: "LoadVariationRiskBalancing"
 
+  # launch 30 test pods over 5 minutes according to the poisson distribution 
+  small_poisson_load:
+    load_aware.scale_test.distribution: "poisson"
+    load_aware.scale_test.duration: 300.0
+    load_aware.scale_test.instances: 30
+
 secrets:
   dir:
     name: psap-ods-secret
@@ -96,6 +102,10 @@ load_aware:
   target_utilization: null
   safe_variance_margin: null
   safe_variance_sensitivity: null
+  scale_test:
+    distribution: null
+    duration: null
+    instances: null
 matbench:
   preset: null
   workload: load-aware

--- a/testing/load-aware/config.yaml
+++ b/testing/load-aware/config.yaml
@@ -95,17 +95,17 @@ clusters:
           effect: NoSchedule
   cleanup_on_exit: false
 load_aware:
-  log_level: null
-  plugin: null
-  default_requests_cpu: null
-  default_target_requests_multiplier: null
-  target_utilization: null
-  safe_variance_margin: null
-  safe_variance_sensitivity: null
+  log_level: 1
+  plugin: "TargetLoadPacking" 
+  default_requests_cpu: "2000m"
+  default_target_requests_multiplier: "2"
+  target_utilization: 70
+  safe_variance_margin: 1
+  safe_variance_sensitivity: 2
   scale_test:
-    distribution: null
-    duration: null
-    instances: null
+    distribution: "poisson"
+    duration: 60.0
+    instances: 10
 matbench:
   preset: null
   workload: load-aware

--- a/testing/load-aware/test.py
+++ b/testing/load-aware/test.py
@@ -74,28 +74,28 @@ def _run_test(test_artifact_dir_p):
     """
 
     next_count = env.next_artifact_index()
-    with env.TempArtifactDir(env.ARTIFACT_DIR / f"{next_count:03d}__dummy_test"):
+    with env.TempArtifactDir(env.ARTIFACT_DIR / f"{next_count:03d}__load_aware_scale_test"):
         test_artifact_dir_p[0] = env.ARTIFACT_DIR
 
         with open(env.ARTIFACT_DIR / "settings", "w") as f:
-            print(f"dummy=true", file=f)
+            print(f"load_aware_scale_test=true", file=f)
 
         with open(env.ARTIFACT_DIR / "config.yaml", "w") as f:
             yaml.dump(config.ci_artifacts.config, f, indent=4)
 
+        run.run("./run_toolbox.py cluster reset_prometheus_db > /dev/null")
+        
         failed = True
         try:
-            run.run("./run_toolbox.py cluster reset_prometheus_db")
 
-            logging.info("Waiting 5 minutes to capture some metrics in Prometheus ...")
-            time.sleep(5 * 60)
+            run.run("./run_toolbox.py load_aware scale_test")
 
-            run.run("./run_toolbox.py cluster dump_prometheus_db")
             failed = False
         finally:
             with open(env.ARTIFACT_DIR / "exit_code", "w") as f:
                 print("1" if failed else "0", file=f)
 
+            run.run("./run_toolbox.py cluster dump_prometheus_db > /dev/null")
             run.run("./run_toolbox.py from_config cluster capture_environment --suffix sample")
 
 @entrypoint()

--- a/testing/load-aware/test.py
+++ b/testing/load-aware/test.py
@@ -83,8 +83,8 @@ def _run_test(test_artifact_dir_p):
         with open(env.ARTIFACT_DIR / "config.yaml", "w") as f:
             yaml.dump(config.ci_artifacts.config, f, indent=4)
 
-        run.run("./run_toolbox.py cluster reset_prometheus_db > /dev/null")
-        
+        run.run("./run_toolbox.py cluster reset_prometheus_db")
+
         failed = True
         try:
 
@@ -95,8 +95,8 @@ def _run_test(test_artifact_dir_p):
             with open(env.ARTIFACT_DIR / "exit_code", "w") as f:
                 print("1" if failed else "0", file=f)
 
-            run.run("./run_toolbox.py cluster dump_prometheus_db > /dev/null")
             run.run("./run_toolbox.py from_config cluster capture_environment --suffix sample")
+            run.run("./run_toolbox.py cluster dump_prometheus_db")
 
 @entrypoint()
 def test_ci():

--- a/testing/load-aware/test.py
+++ b/testing/load-aware/test.py
@@ -65,7 +65,7 @@ def prepare_ci():
     install_ocp_pipelines()
 
     run.run("./run_toolbox.py from_config cluster capture_environment --suffix sample")
-    run.run("./run_toolbox.py load_aware deploy_trimaran")
+    run.run("./run_toolbox.py from_config load_aware deploy_trimaran")
 
 
 def _run_test(test_artifact_dir_p):
@@ -88,7 +88,7 @@ def _run_test(test_artifact_dir_p):
         failed = True
         try:
 
-            run.run("./run_toolbox.py load_aware scale_test")
+            run.run("./run_toolbox.py from_config load_aware scale_test")
 
             failed = False
         finally:

--- a/toolbox/load_aware.py
+++ b/toolbox/load_aware.py
@@ -54,3 +54,22 @@ class LoadAware:
         """
 
         return RunAnsibleRole(locals())
+
+
+    @AnsibleRole("load_aware_scale_test")
+    @AnsibleMappedParams
+    def scale_test(self, distribution="poisson", duration=60.0, instances=10):
+        """
+        Role to deploy the Trimaran load aware scheduler
+
+        Args:
+            distribution: what distribution to generate the load according to (poisson, normal, bimodal, gamma, or uniform)
+            duration: how long the test should last (seconds)
+            instances: how many of the workload to launch, at the moment, this is the number of test pods
+        """
+
+        if distribution not in ("poisson", "normal", "bimodal", "gamma", "uniform"):
+            print(f"Can't run scale test using unknown distribution: {distribution}")
+            sys.exit(1)
+
+        return RunAnsibleRole(locals())

--- a/visualizations/load-aware/store/parsers.py
+++ b/visualizations/load-aware/store/parsers.py
@@ -23,9 +23,9 @@ ANSIBLE_LOG_DATE_TIME_FMT = "%Y-%m-%d %H:%M:%S"
 IMPORTANT_FILES = [
     "config.yaml",
 
-    "001__cluster__dump_prometheus_db/prometheus.t*",
     "002__cluster__capture_environment/nodes.json",
-    "002__cluster__capture_environment/ocp_version.yml"
+    "002__cluster__capture_environment/ocp_version.yml",
+    "003__cluster__dump_prometheus_db/prometheus.t*"
 ]
 
 PARSER_VERSION = "2023-05-31"
@@ -169,7 +169,7 @@ def _parse_ocp_version(dirname):
 
 def _extract_metrics(dirname):
     METRICS = {
-        "sutest": ("001__cluster__dump_prometheus_db/prometheus.t*", workload_prom.get_sutest_metrics()),
+        "sutest": ("003__cluster__dump_prometheus_db/prometheus.t*", workload_prom.get_sutest_metrics()),
     }
 
     metrics = {}


### PR DESCRIPTION
This adds the role to launch load-aware scale tests according to a few different statistical distributions, specifically the Poisson. Options for gamma, uniform, normal, and a bimodal distributions are also included.

Currently this only launches test pods. The next step will be adding a real workload to the scale test.