### PR TITLE
[Notebooks] Fix Schema on Export

### DIFF
--- a/visualizations/rhods-notebooks-performance/models/lts.py
+++ b/visualizations/rhods-notebooks-performance/models/lts.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import List, Union, Any
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 import matrix_benchmarking.models as matbench_models
 
@@ -25,5 +25,9 @@ class Results(BaseModel):
 
 
 class Payload(BaseModel):
+    schema_name: matbench_models.create_schema_field("rhods-notebooks-perf") = Field(alias="$schema")
     metadata: Metadata
     results: Results
+
+    class Config:
+        fields = {'schema_name': '$schema'}

--- a/visualizations/rhods-notebooks-performance/store/lts.py
+++ b/visualizations/rhods-notebooks-performance/store/lts.py
@@ -15,6 +15,7 @@ def build_lts_payloads():
         end_time = results.end_time
 
         lts_payload = {
+            "$schema": "urn:rhods-notebooks-perf:1.0.0",
             "metadata": {
                 "start": start_time,
                 "end": end_time,

--- a/visualizations/rhods-notebooks/horreum_lts_store.py
+++ b/visualizations/rhods-notebooks/horreum_lts_store.py
@@ -184,7 +184,7 @@ def build_lts_payloads() -> dict:
         
         output: models.NotebookScalePayload = models.NotebookScalePayload.parse_obj(payload)
 
-        yield dict(output), start_time, end_time
+        yield output.dict(by_alias=True), start_time, end_time
 
 
 def _decode_users(results):
@@ -236,7 +236,7 @@ def _gather_prom_metrics(entry) -> dict:
         for metric_name in metric_names:
             logging.info(f"Gathering {metric_name[0]}")
             output[metric_name[0]] = {
-                'data': [promvalue.dict() for promvalue in prom.get_metrics('sutest')(entry, metric_name[0])],
+                'data': [promvalue for promvalue in prom.get_metrics('sutest')(entry, metric_name[0])],
                 'query': metric_name[1]
             }
 

--- a/visualizations/rhods-notebooks/horreum_lts_store.py
+++ b/visualizations/rhods-notebooks/horreum_lts_store.py
@@ -237,17 +237,12 @@ def _generate_pod_timings(pod_times, start, end):
 
 
 def _gather_prom_metrics(entry) -> dict:
-    replace_chars = ["=", "*", ".", "-", " "]
     output = {}
     for cluster_role, metric_names in lts_metrics.items():
         for metric_name in metric_names:
             logging.info(f"Gathering {metric_name[0]}")
-            name: str = metric_name[0]
 
-            for char in replace_chars:
-                name = name.replace(char, "_")
-
-            output[name] = {
+            output[metric_name[0]] = {
                 'data': [promvalue for promvalue in prom.get_metrics('sutest')(entry, metric_name[0])],
                 'query': metric_name[1]
             }

--- a/visualizations/rhods-notebooks/models/__init__.py
+++ b/visualizations/rhods-notebooks/models/__init__.py
@@ -4,7 +4,7 @@ from typing import List, Dict
 
 import matrix_benchmarking.models as matbench_models
 
-from pydantic import BaseModel, constr
+from pydantic import BaseModel, constr, Field
 
 class NotebookScaleMetadata(matbench_models.Metadata):
     presets: List[str]
@@ -23,7 +23,7 @@ class NotebookScaleData(matbench_models.ExclusiveModel):
 
 
 class NotebookScalePayload(matbench_models.ExclusiveModel):
-    schema_name: matbench_models.create_schema_field("rhods-notebooks")
+    schema_name: matbench_models.create_schema_field("rhods-notebooks") = Field(alias="$schema")
     data: NotebookScaleData
     metadata: NotebookScaleMetadata
 

--- a/visualizations/rhods-notebooks/models/prom.py
+++ b/visualizations/rhods-notebooks/models/prom.py
@@ -3,25 +3,9 @@ import matrix_benchmarking.models as matbench_models
 from pydantic import Field
 
 class PromValues(matbench_models.ExclusiveModel):
-    Sutest_Control_Plane_Node_CPU_idle: matbench_models.PrometheusMetric = Field(
-        ..., alias='Sutest Control Plane Node CPU idle'
-    )
-    Sutest_API_Server_Requests__server_errors_: matbench_models.PrometheusMetric = (
-        Field(..., alias='Sutest API Server Requests (server errors)')
-    )
-    sutest__container_cpu__namespace_redhat_ods_applications_pod_rhods_dashboard___container_rhods_dashboard: matbench_models.PrometheusMetric = Field(
-        ...,
-        alias='sutest__container_cpu__namespace=redhat-ods-applications_pod=rhods-dashboard.*_container=rhods-dashboard',
-    )
-    sutest__container_sum_cpu__namespace_redhat_ods_applications_pod_rhods_dashboard___container_rhods_dashboard: matbench_models.PrometheusMetric = Field(
-        ...,
-        alias='sutest__container_sum_cpu__namespace=redhat-ods-applications_pod=rhods-dashboard.*_container=rhods-dashboard',
-    )
-    sutest__container_cpu_limits__namespace_redhat_ods_applications_pod_rhods_dashboard___container_rhods_dashboard: matbench_models.PrometheusMetric = Field(
-        ...,
-        alias='sutest__container_cpu_limits__namespace=redhat-ods-applications_pod=rhods-dashboard.*_container=rhods-dashboard',
-    )
-    sutest__container_cpu_requests__namespace_redhat_ods_applications_pod_rhods_dashboard___container_rhods_dashboard: matbench_models.PrometheusMetric = Field(
-        ...,
-        alias='sutest__container_cpu_requests__namespace=redhat-ods-applications_pod=rhods-dashboard.*_container=rhods-dashboard',
-    )
+    Sutest_Control_Plane_Node_CPU_idle: matbench_models.PrometheusMetric
+    Sutest_API_Server_Requests__server_errors_: matbench_models.PrometheusMetric
+    sutest__container_cpu__namespace_redhat_ods_applications_pod_rhods_dashboard___container_rhods_dashboard: matbench_models.PrometheusMetric
+    sutest__container_sum_cpu__namespace_redhat_ods_applications_pod_rhods_dashboard___container_rhods_dashboard: matbench_models.PrometheusMetric
+    sutest__container_cpu_limits__namespace_redhat_ods_applications_pod_rhods_dashboard___container_rhods_dashboard: matbench_models.PrometheusMetric
+    sutest__container_cpu_requests__namespace_redhat_ods_applications_pod_rhods_dashboard___container_rhods_dashboard: matbench_models.PrometheusMetric

--- a/visualizations/rhods-notebooks/models/prom.py
+++ b/visualizations/rhods-notebooks/models/prom.py
@@ -3,9 +3,39 @@ import matrix_benchmarking.models as matbench_models
 from pydantic import Field
 
 class PromValues(matbench_models.ExclusiveModel):
-    Sutest_Control_Plane_Node_CPU_idle: matbench_models.PrometheusMetric
-    Sutest_API_Server_Requests__server_errors_: matbench_models.PrometheusMetric
-    sutest__container_cpu__namespace_redhat_ods_applications_pod_rhods_dashboard___container_rhods_dashboard: matbench_models.PrometheusMetric
-    sutest__container_sum_cpu__namespace_redhat_ods_applications_pod_rhods_dashboard___container_rhods_dashboard: matbench_models.PrometheusMetric
-    sutest__container_cpu_limits__namespace_redhat_ods_applications_pod_rhods_dashboard___container_rhods_dashboard: matbench_models.PrometheusMetric
-    sutest__container_cpu_requests__namespace_redhat_ods_applications_pod_rhods_dashboard___container_rhods_dashboard: matbench_models.PrometheusMetric
+    Sutest_Control_Plane_Node_CPU_idle: matbench_models.PrometheusMetric = Field(
+        ..., alias='Sutest Control Plane Node CPU idle'
+    )
+    Sutest_API_Server_Requests__server_errors_: matbench_models.PrometheusMetric = (
+        Field(..., alias='Sutest API Server Requests (server errors)')
+    )
+    sutest__container_cpu__namespace_redhat_ods_applications_pod_rhods_dashboard___container_rhods_dashboard: matbench_models.PrometheusMetric = Field(
+        ...,
+        alias='sutest__container_cpu__namespace=redhat-ods-applications_pod=rhods-dashboard.*_container=rhods-dashboard',
+    )
+    sutest__container_sum_cpu__namespace_redhat_ods_applications_pod_rhods_dashboard___container_rhods_dashboard: matbench_models.PrometheusMetric = Field(
+        ...,
+        alias='sutest__container_sum_cpu__namespace=redhat-ods-applications_pod=rhods-dashboard.*_container=rhods-dashboard',
+    )
+    sutest__container_cpu_limits__namespace_redhat_ods_applications_pod_rhods_dashboard___container_rhods_dashboard: matbench_models.PrometheusMetric = Field(
+        ...,
+        alias='sutest__container_cpu_limits__namespace=redhat-ods-applications_pod=rhods-dashboard.*_container=rhods-dashboard',
+    )
+    sutest__container_cpu_requests__namespace_redhat_ods_applications_pod_rhods_dashboard___container_rhods_dashboard: matbench_models.PrometheusMetric = Field(
+        ...,
+        alias='sutest__container_cpu_requests__namespace=redhat-ods-applications_pod=rhods-dashboard.*_container=rhods-dashboard',
+    )
+
+    class Config:
+        fields = {
+            "Sutest_Control_Plane_Node_CPU_idle": "Sutest Control Plane Node CPU idle",
+            "Sutest_API_Server_Requests__server_errors_": "Sutest API Server Requests (server errors)",
+            "sutest__container_cpu__namespace_redhat_ods_applications_pod_rhods_dashboard___container_rhods_dashboard": 
+                "sutest__container_cpu__namespace=redhat-ods-applications_pod=rhods-dashboard.*_container=rhods-dashboard",
+            "sutest__container_sum_cpu__namespace_redhat_ods_applications_pod_rhods_dashboard___container_rhods_dashboard":
+                "sutest__container_sum_cpu__namespace=redhat-ods-applications_pod=rhods-dashboard.*_container=rhods-dashboard",
+            "sutest__container_cpu_limits__namespace_redhat_ods_applications_pod_rhods_dashboard___container_rhods_dashboard": 
+                "sutest__container_cpu_limits__namespace=redhat-ods-applications_pod=rhods-dashboard.*_container=rhods-dashboard",
+            "sutest__container_cpu_requests__namespace_redhat_ods_applications_pod_rhods_dashboard___container_rhods_dashboard": 
+                "sutest__container_cpu_requests__namespace=redhat-ods-applications_pod=rhods-dashboard.*_container=rhods-dashboard"
+        }


### PR DESCRIPTION
This fixes the `$schema` field being outputted as `schema_name`
```
Traceback (most recent call last):
  File "/usr/lib64/python3.9/runpy.py", line 197, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib64/python3.9/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/opt/ci-artifacts/src/subprojects/matrix-benchmarking/matrix_benchmarking/main.py", line 12, in <module>
    import matrix_benchmarking.visualize
  File "/opt/ci-artifacts/src/subprojects/matrix-benchmarking/matrix_benchmarking/visualize.py", line 4, in <module>
    import matrix_benchmarking.matrix
  File "/opt/ci-artifacts/src/subprojects/matrix-benchmarking/matrix_benchmarking/matrix.py", line 9, in <module>
    import matrix_benchmarking.store as store
  File "/opt/ci-artifacts/src/subprojects/matrix-benchmarking/matrix_benchmarking/store/__init__.py", line 10, in <module>
    import matrix_benchmarking.models as models
  File "/opt/ci-artifacts/src/subprojects/matrix-benchmarking/matrix_benchmarking/models.py", line 7, in <module>
    from pydantic import BaseModel, ConstrainedStr, constr, Extra
  File "/opt/venv/lib/python3.9/site-packages/pydantic/__init__.py", line 206, in __getattr__
    return _getattr_migration(attr_name)
  File "/opt/venv/lib/python3.9/site-packages/pydantic/_migration.py", line 285, in wrapper
    raise PydanticImportError(f'`{import_path}` has been removed in V2.')
pydantic.errors.PydanticImportError: `pydantic:ConstrainedStr` has been removed in V2.

For further information visit https://errors.pydantic.dev/2.0/u/import-error

```