### PR TITLE
load-aware: always dumps statistics

### DIFF
--- a/roles/load_aware/load_aware_deploy_trimaran/tasks/main.yml
+++ b/roles/load_aware/load_aware_deploy_trimaran/tasks/main.yml
@@ -30,7 +30,6 @@
     oc get route thanos-querier -n openshift-monitoring -o json
       | jq -r '.spec.host'
   register: thanos_endpoint_cmd
-
 - name: Format the Thanos Endpoint
   set_fact:
     thanos_endpoint: "https://{{ thanos_endpoint_cmd.stdout }}"
@@ -89,21 +88,27 @@
   retries: 20
   until: trimaran_running.stdout == 'Running'
 
-- name: Deploy test pod with Trimaran
-  shell:
-    oc apply -f {{ trimaran_test_pod }} -n trimaran
+- name: Ensure a pod can be scheduled
+  block:
+  - name: Deploy test pod with Trimaran
+    shell:
+      oc apply -f {{ trimaran_test_pod }} -n trimaran
 
-- name: Ensure the Trimaran test pods completes
-  shell:
-    oc get pod trimaran-test -n trimaran
-      | awk 'NR > 1 {print $3}'
-  register: trimaran_test_pod_state
-  delay: 5
-  retries: 20
-  until: trimaran_test_pod_state.stdout == 'Completed'
+  - name: Ensure the Trimaran test pods completes
+    shell:
+      oc get pod trimaran-test -n trimaran
+        | awk 'NR > 1 {print $3}'
+    register: trimaran_test_pod_state
+    delay: 5
+    retries: 20
+    until: trimaran_test_pod_state.stdout == 'Completed'
+  always:
+  - name: Dump trimaran info
+    shell: |
+      oc get pod trimaran-test -n trimaran -oyaml > "{{ artifact_extra_logs_dir }}/trimaran-test.pod.yaml"
+      oc describe pod trimaran-test -n trimaran > "{{ artifact_extra_logs_dir }}/trimaran-test.pod.desc"
+      oc get all -n trimaran -oyaml > "{{ artifact_extra_logs_dir }}/all-trimaran.yaml"
 
-- name: Dump trimaran info
-  shell: |
-    oc get pod trimaran-test -n trimaran -oyaml > "{{ artifact_extra_logs_dir }}/trimaran-test.pod.yaml"
-    oc describe pod trimaran-test -n trimaran > "{{ artifact_extra_logs_dir }}/trimaran-test.pod.desc"
-    oc get all -n trimaran -oyaml > "{{ artifact_extra_logs_dir }}/all-trimaran.yaml"
+  - name: Dump cluster events
+    shell:
+      oc get ev -oyaml -n trimaran > "{{ artifact_extra_logs_dir }}/events.yaml"

--- a/roles/load_aware/load_aware_scale_test/tasks/main.yml
+++ b/roles/load_aware/load_aware_scale_test/tasks/main.yml
@@ -2,23 +2,25 @@
   shell:
     python3 {{ load_timeline_generator }} {{ load_aware_scale_test_distribution }} {{ load_aware_scale_test_duration}} {{ load_aware_scale_test_instances }} "{{ artifact_extra_logs_dir }}/schedule_plan.yaml"
 
-- name: Run test workload with scheduler and load timeline
-  shell:
-    python3 {{ pod_start_scheduler }} {{ load_aware_scale_test_scheduler }} {{ load_aware_scale_test_namespace }} "{{ artifact_extra_logs_dir }}/schedule_plan.yaml" "{{ artifact_extra_logs_dir }}/schedule_execution.yaml"
+- name: Run workload and dump stats
+  block:
+  - name: Run test workload with scheduler and load timeline
+    shell:
+      python3 {{ pod_start_scheduler }} {{ load_aware_scale_test_scheduler }} {{ load_aware_scale_test_namespace }} "{{ artifact_extra_logs_dir }}/schedule_plan.yaml" "{{ artifact_extra_logs_dir }}/schedule_execution.yaml"
 
-- name: Wait for workloads to finish
-  shell:
-    oc get pods -n {{ load_aware_scale_test_namespace }} | awk 'NR > 1 { print $3 }'
-  register: load_aware_workload
-  delay: 60
-  retries: 120
-  until:
-    "'Running' not in load_aware_workload.stdout
-      and 'Pending' not in load_aware_workload.stdout
-      and 'Failed' not in load_aware_workload.stdout
-      and 'ContainerCreating' not in load_aware_workload.stdout"
-
-- name: Dump info about scheduler resources
-  shell: |
-    oc get pods -n {{ load_aware_scale_test_namespace }} > "{{ artifact_extra_logs_dir }}/all_pods.status" 
-    oc get pods -n {{ load_aware_scale_test_namespace }} -ojson > "{{ artifact_extra_logs_dir }}/all_pods.json"
+  - name: Wait for workloads to finish
+    shell:
+      oc get pods -n {{ load_aware_scale_test_namespace }} | awk 'NR > 1 { print $3 }'
+    register: load_aware_workload
+    delay: 60
+    retries: 120
+    until:
+      "'Running' not in load_aware_workload.stdout
+        and 'Pending' not in load_aware_workload.stdout
+        and 'Failed' not in load_aware_workload.stdout
+        and 'ContainerCreating' not in load_aware_workload.stdout"
+  always:
+  - name: Dump info about scheduler resources
+    shell: |
+      oc get pods -n {{ load_aware_scale_test_namespace }} > "{{ artifact_extra_logs_dir }}/all_pods.status" 
+      oc get pods -n {{ load_aware_scale_test_namespace }} -ojson > "{{ artifact_extra_logs_dir }}/all_pods.json";


### PR DESCRIPTION
If scale test fails or if the trimaran-test pod can't be scheduled, continue to dump stats, logs and cluster info.