### PR TITLE
lightspeed: update ServingRuntime and switch to using command_args

### DIFF
--- a/roles/wisdom/wisdom_deploy_model/templates/serving_runtime.yml.j2
+++ b/roles/wisdom/wisdom_deploy_model/templates/serving_runtime.yml.j2
@@ -22,6 +22,16 @@ spec:
           value: "true"
         - name: LOG_LEVEL
           value: debug3
+        # CAPACITY and DEFAULT_MODEL_SIZE numbers for pre-converted ONNX models with reported size ~41081MiB
+        - name: INFERENCE_PLUGIN_MODEL_MESH_CAPACITY
+          value: "62914560000"
+        - name: INFERENCE_PLUGIN_MODEL_MESH_DEFAULT_MODEL_SIZE
+          value: "31457280000"
+
+        # limits model loads/unloads from ModelMesh
+        - name: INFERENCE_PLUGIN_MODEL_MESH_MAX_LOADING_CONCURRENCY
+          value: "1"
+
         - name: RUNTIME_PORT
           value: "8087"
         - name: GATEWAY_PORT
@@ -30,6 +40,7 @@ spec:
           value: "2113"
         - name: RUNTIME_LOCAL_MODELS_DIR
           value: "/models/"
+
         # use RPM based scaling in ModelMesh
         # FIXME: these configs will be the default in the release after 0.21.0
         - name: INFERENCE_PLUGIN_MODEL_MESH_LATENCY_BASED_AUTOSCALING_ENABLED
@@ -37,38 +48,19 @@ spec:
         - name: RUNTIME_SERVER_THREAD_POOL_SIZE
           value: "16"
 
-        # limits model loads/unloads from ModelMesh
-        - name: INFERENCE_PLUGIN_MODEL_MESH_MAX_LOADING_CONCURRENCY
-          value: "1"
-        # CAPACITY and DEFAULT_MODEL_SIZE numbers for pre-converted ONNX models with reported size ~41081MiB
-        - name: INFERENCE_PLUGIN_MODEL_MESH_CAPACITY
-          value: "62914560000"
-        - name: INFERENCE_PLUGIN_MODEL_MESH_DEFAULT_MODEL_SIZE
-          value: "31457280000"
-        # # CAPACITY and DEFAULT_MODEL_SIZE numbers for PyTorch models with size reported size ~14442MiB
-        # - name: CAPACITY
-        #   value: "20971520000"
-        # - name: DEFAULT_MODEL_SIZE
-        #   value: "10485760000"
-
-        # # load timeout defaults to 120 which is ok for the pre-converted ONNX
-        # # models; it must be increased if doing conversion at load time
-        # - name: DISTRIBUTED_CONFIG_BACKENDS_TGIS_LOCAL_LOAD_TIMEOUT
-        #   value: "400"
-        # - name: MODEL_LOADING_TIMEOUT_MS
-        #   value: "400005"
-
         # TGIS env vars
+        - name: CUDA_PAD_TO_MULT_OF_8
+          value: "false"
         - name: MAX_BATCH_SIZE
           value: "16"
         - name: MAX_SEQUENCE_LENGTH
           value: "2048"
         - name: NUM_GPUS
           value: "1"
-        - name: CUDA_VISIBLE_DEVICES
-          value: "0"
         - name: MERGE_ONNX_GRAPHS
           value: "true"
+        - name: CUDA_VISIBLE_DEVICES
+          value: "0"
         - name: TRANSFORMERS_CACHE
           value: /tmp/transformers_cache
         - name: HUGGINGFACE_HUB_CACHE

--- a/roles/wisdom/wisdom_llm_load_test/tasks/main.yml
+++ b/roles/wisdom/wisdom_llm_load_test/tasks/main.yml
@@ -77,3 +77,7 @@
 
 - name: Delete the llm-load-test Pod if it exists
   command: oc delete --ignore-not-found -f "{{ artifact_extra_logs_dir }}/src/001_llm_load_test_pod.yml" -n {{ wisdom_llm_load_test_namespace }}
+
+- name: Ensure that llm-load-test Pod succeeded
+  fail: msg="llm-load-test Pod failed"
+  when: load_test_wait.stdout == "Error" or load_test_wait.stdout == "Failed"

--- a/roles/wisdom/wisdom_llm_load_test_multiplexed/tasks/main.yml
+++ b/roles/wisdom/wisdom_llm_load_test_multiplexed/tasks/main.yml
@@ -77,3 +77,7 @@
 
 - name: Delete the llm-load-test Pod if it exists
   command: oc delete --ignore-not-found -f "{{ artifact_extra_logs_dir }}/src/001_llm_load_test_pod.yml" -n {{ wisdom_llm_load_test_multiplexed_namespace }}
+
+- name: Ensure that llm-load-test Pod succeeded
+  fail: msg="llm-load-test Pod failed"
+  when: load_test_wait.stdout == "Error" or load_test_wait.stdout == "Failed"

--- a/roles/wisdom/wisdom_llm_load_test_multiplexed/templates/llm-load-test-config.json.j2
+++ b/roles/wisdom/wisdom_llm_load_test_multiplexed/templates/llm-load-test-config.json.j2
@@ -35,7 +35,7 @@
     },
     "input_dataset": {
       "filename": "/etc/load_test_dataset/dataset.json",
-      "max_size": 3
+      "max_size": 8
     }
   },
   "warmup": false,

--- a/roles/wisdom/wisdom_llm_load_test_multiplexed/templates/llm-load-test-config.json.j2
+++ b/roles/wisdom/wisdom_llm_load_test_multiplexed/templates/llm-load-test-config.json.j2
@@ -31,7 +31,7 @@
       "context": "",
       "concurrency": {{ wisdom_llm_load_test_multiplexed_concurrency }},
       "requests": {{ wisdom_llm_load_test_multiplexed_requests }},
-      "max_duration": {{ wisdom_llm_load_test_multiplexed_max_duration }},
+      "max_duration": "{{ wisdom_llm_load_test_multiplexed_max_duration }}"
     },
     "input_dataset": {
       "filename": "/etc/load_test_dataset/dataset.json",

--- a/testing/lightspeed/command_args.yaml
+++ b/testing/lightspeed/command_args.yaml
@@ -12,13 +12,36 @@ rhods deploy_ods:
   channel: {{ rhods.catalog.channel }}
   version: {{ rhods.catalog.version }}
 
-wisdom_deploy_model:
-  replicas: {{replicas}}
-  s3_secret_path: {{s3_creds_model_secret_path}}
-  quay_pull_secret_path: {{quay_secret_path}}
-  protos_path: {{protos_path}}
-  tester_imagestream_name: {{tester_imagestream_name}}
-  tester_image_tag: {{tester_image_tag}}
+wisdom deploy_model:
+  replicas: {{tests.config.replicas}}
+  s3_secret_path: {{tests.config.s3_creds_model_secret_path}}
+  quay_pull_secret_path: {{tests.config.quay_secret_path}}
+  protos_path: {{tests.config.protos_path}}
+  tester_imagestream_name: {{tests.config.tester_imagestream_name}}
+  tester_image_tag: {{tests.config.tester_image_tag}}
+  
+wisdom warmup_model:
+  protos_path: {{tests.config.protos_path}}
+  tester_imagestream_name: {{tests.config.tester_imagestream_name}}
+  tester_image_tag: {{tests.config.tester_image_tag}}
 
+wisdom run_llm_load_test:
+  requests: {{tests.config.requests}}
+  concurrency: {{tests.config.concurrency}}
+  replicas: {{tests.config.replicas}}
+  dataset_path: {{tests.config.dataset_path}}
+  s3_secret_path: {{tests.config.s3_creds_results_secret_path}}
+  protos_path: {{tests.config.protos_path}}
+  tester_imagestream_name: {{tests.config.tester_imagestream_name}}
+  tester_image_tag: {{tests.config.tester_image_tag}}
 
-            --namespace='{test_namespace}' \
+wisdom run_llm_load_test_multiplexed:
+  requests: {{tests.config.requests}}
+  concurrency: {{tests.config.concurrency}}
+  replicas: {{tests.config.replicas}}
+  max_duration: {{tests.config.max_duration}} #TODO
+  dataset_path: {{tests.config.dataset_path}}
+  s3_secret_path: {{tests.config.s3_creds_results_secret_path}}
+  protos_path: {{tests.config.protos_path}}
+  tester_imagestream_name: {{tests.config.tester_imagestream_name}}
+  tester_image_tag: {{tests.config.tester_image_tag}}

--- a/testing/lightspeed/config.yaml
+++ b/testing/lightspeed/config.yaml
@@ -8,10 +8,8 @@ ci_presets:
     clusters.create.ocp.deploy_cluster.target: cluster_light
 
   ansible_llm_light:
-    tests:
-      ansible_llm:
-        test_cases: [[1,1], [1,2], [1, 4], [1, 8], [1, 16]]
-        multiplexed_test_cases: [[1, 8], [1, 16]]
+    tests.ansible_llm.test_cases: [[1, 16]]
+    tests.ansible_llm.multiplexed_test_cases: [[1, 16]]
   
   light:
     extends: [light_cluster, ansible_llm_light]
@@ -46,9 +44,9 @@ clusters:
 rhods:
   catalog:
     image: brew.registry.redhat.io/rh-osbs/iib
-    tag: 524781
+    tag: 537294
     channel: beta
-    version: 1.29.0
+    version: 1.30.0
 secrets:
   dir:
     name: psap-ods-secret
@@ -57,7 +55,23 @@ secrets:
   s3_ldap_password_file: s3_ldap.passwords
   keep_cluster_password_file: get_cluster.password
   brew_registry_redhat_io_token_file: brew.registry.redhat.io.token
+
 tests:
+  config:
+    tester_imagestream_name: "llm-load-test"
+    tester_image_tag: "wisdom-ci"
+    test_namespace: "wisdom"
+    model_ver: "v11.4.4" #TODO use these
+    runtime_ver: "v0.27.0" #TODO use these
+    s3_creds_model_secret_path: "/work/secrets/wisdom/s3-secret.yaml"
+    quay_secret_path: "/work/secrets/wisdom/quay-secret.yaml"
+    protos_path: "/work/secrets/wisdom-protos"
+    s3_creds_results_secret_path: "/work/secrets/wisdom/credentials"
+    dataset_path: "/work/secrets/wisdom/llm-load-test-dataset.json"
+    replicas: 1
+    concurrency: 16
+    requests: 16
+    max_duration: "15m"
   ansible_llm:
     test_cases:
     - [1, 1]

--- a/testing/lightspeed/test.py
+++ b/testing/lightspeed/test.py
@@ -147,9 +147,9 @@ def run_ci():
         # There will be <concurrency> num instances of ghz. However, some instances
         # requests will be much smaller and will be answered more quickly.
         # To ensure that the requests are multiplexed throughout the run, 
-        # we set max requests high, and rely on the timeout after 15m to end the test.
+        # we set max requests high, and rely on the timeout after 10m to end the test.
         requests_per_instance = 256
-        max_duration = "15m"
+        max_duration = "10m"
         config.ci_artifacts.set_config("tests.config.max_duration", max_duration)
 
         logging.info(f"Running load_test with replicas: {replicas}, concurrency: {concurrency} and requests_per_instance: {requests_per_instance}")

--- a/testing/lightspeed/test.py
+++ b/testing/lightspeed/test.py
@@ -22,15 +22,18 @@ sys.path.append(str(TESTING_ANSIBLE_LLM_DIR.parent))
 from common import env, config, run, rhods
 
 initialized = False
-def init(ignore_secret_path=False):
+def init(ignore_secret_path=False, apply_preset_from_pr_args=True):
     global initialized
     if initialized:
-        logging.info("Already initialized.")
+        logging.debug("Already initialized.")
         return
     initialized = True
 
     env.init()
     config.init(TESTING_ANSIBLE_LLM_DIR)
+
+    if apply_preset_from_pr_args:
+        config.ci_artifacts.apply_preset_from_pr_args()
 
     if not ignore_secret_path and not PSAP_ODS_SECRET_PATH.exists():
         raise RuntimeError("Path with the secrets (PSAP_ODS_SECRET_PATH={PSAP_ODS_SECRET_PATH}) does not exists.")
@@ -38,11 +41,11 @@ def init(ignore_secret_path=False):
     config.ci_artifacts.detect_apply_light_profile(LIGHT_PROFILE)
 
 
-def entrypoint(ignore_secret_path=False):
+def entrypoint(ignore_secret_path=False, apply_preset_from_pr_args=True):
     def decorator(fct):
         @functools.wraps(fct)
         def wrapper(*args, **kwargs):
-            init(ignore_secret_path)
+            init(ignore_secret_path, apply_preset_from_pr_args)
             fct(*args, **kwargs)
 
         return wrapper
@@ -68,6 +71,7 @@ def prepare_ci():
     """
     Prepares the cluster for running pipelines scale tests.
     """
+
     install_rhods()
     run.run("./run_toolbox.py rhods wait_ods")
     max_replicas = max_gpu_nodes()
@@ -82,31 +86,21 @@ def prepare_ci():
 
     return None
 
-protos_path = WISDOM_PROTOS_SECRET_PATH
-s3_creds_model_secret_path = WISDOM_SECRET_PATH / "s3-secret.yaml"
-quay_secret_path = WISDOM_SECRET_PATH / "quay-secret.yaml"
-dataset_path = WISDOM_SECRET_PATH / "llm-load-test-dataset.json"
-s3_creds_results_secret_path = WISDOM_SECRET_PATH / "credentials"
+def init_config():
+    config.ci_artifacts.set_config("tests.config.s3_creds_model_secret_path", str(WISDOM_SECRET_PATH / "s3-secret.yaml"))
+    config.ci_artifacts.set_config("tests.config.quay_secret_path", str(WISDOM_SECRET_PATH / "quay-secret.yaml"))
+    config.ci_artifacts.set_config("tests.config.protos_path", str(WISDOM_PROTOS_SECRET_PATH))
 
-test_namespace="wisdom"
-tester_imagestream_name="llm-load-test"
-tester_image_tag="wisdom-ci"
+    config.ci_artifacts.set_config("tests.config.s3_creds_results_secret_path", str(WISDOM_SECRET_PATH / "credentials"))
+    config.ci_artifacts.set_config("tests.config.dataset_path", str(WISDOM_SECRET_PATH / "llm-load-test-dataset.json"))
+
 
 def deploy_and_warmup_model(replicas):
-    run.run(f"./run_toolbox.py wisdom deploy_model {replicas} \
-        {s3_creds_model_secret_path} \
-        {quay_secret_path} \
-        {protos_path} \
-        {tester_imagestream_name} \
-        {tester_image_tag} \
-        --namespace='{test_namespace}' \
-        --")
+    config.ci_artifacts.set_config("tests.config.replicas", replicas)
+    run.run(f"./run_toolbox.py from_config wisdom deploy_model")
 
-        # Warmup
-    run.run(f"./run_toolbox.py wisdom warmup_model {protos_path} \
-        {tester_imagestream_name} \
-        {tester_image_tag} \
-        --namespace='{test_namespace}'")
+    # Warmup
+    run.run(f"./run_toolbox.py from_config wisdom warmup_model")
 
 @entrypoint()
 def run_ci():
@@ -115,6 +109,16 @@ def run_ci():
 
     """
     logging.info("In loadtest_run")
+
+    init_config()
+
+    test_namespace=config.ci_artifacts.get_config("tests.config.test_namespace")
+    tester_imagestream_name=config.ci_artifacts.get_config("tests.config.tester_imagestream_name")
+    tester_image_tag=config.ci_artifacts.get_config("tests.config.tester_image_tag")
+
+    # Purely to test:
+    protos_path=config.ci_artifacts.get_config("tests.config.protos_path")
+    print(f"Protos path: {protos_path}")
 
     run.run(f"./run_toolbox.py utils build_push_image --namespace='{test_namespace}'  --git_repo='https://github.com/openshift-psap/llm-load-test.git' --git_ref='main' --dockerfile_path='build/Containerfile' --image_local_name='{tester_imagestream_name}' --tag='{tester_image_tag}'  --")
 
@@ -128,18 +132,12 @@ def run_ci():
         deploy_and_warmup_model(replicas)
 
         total_requests = 32 * concurrency
+        config.ci_artifacts.set_config("tests.config.concurrency", concurrency)
+        config.ci_artifacts.set_config("tests.config.requests", total_requests)
 
         logging.info(f"Running load_test with replicas: {replicas}, concurrency: {concurrency} and total_requests: {total_requests}")
 
-        run.run(f"./run_toolbox.py wisdom run_llm_load_test {total_requests} \
-            {concurrency} \
-            {replicas} \
-            {dataset_path} \
-            {s3_creds_results_secret_path} \
-            {protos_path} \
-            {tester_imagestream_name} \
-            {tester_image_tag} \
-            --namespace='{test_namespace}'")
+        run.run(f"./run_toolbox.py from_config wisdom run_llm_load_test")
         
     dataset_path = WISDOM_SECRET_PATH / "llm-load-test-multiplexed-dataset.json"
     multiplexed_test_cases = config.ci_artifacts.get_config("tests.ansible_llm.multiplexed_test_cases")
@@ -152,19 +150,11 @@ def run_ci():
         # we set max requests high, and rely on the timeout after 15m to end the test.
         requests_per_instance = 256
         max_duration = "15m"
+        config.ci_artifacts.set_config("tests.config.max_duration", max_duration)
 
-        logging.info(f"Running load_test with replicas: {replicas}, concurrency: {concurrency} and total_requests: {total_requests}")
+        logging.info(f"Running load_test with replicas: {replicas}, concurrency: {concurrency} and requests_per_instance: {requests_per_instance}")
 
-        run.run(f"./run_toolbox.py wisdom run_llm_load_test_multiplexed {requests_per_instance} \
-            {concurrency} \
-            {replicas} \
-            {max_duration} \
-            {dataset_path} \
-            {s3_creds_results_secret_path} \
-            {protos_path} \
-            {tester_imagestream_name} \
-            {tester_image_tag} \
-            --namespace='{test_namespace}'")
+        run.run(f"./run_toolbox.py from_config wisdom run_llm_load_test_multiplexed")
 
     pass
 

--- a/toolbox/wisdom.py
+++ b/toolbox/wisdom.py
@@ -119,3 +119,4 @@ class Wisdom:
         """
 
         return RunAnsibleRole(locals())
+


### PR DESCRIPTION
This PR fixes an issue in the original implementation of `roles/wisdom_llm_load_test_multiplexed`. It also switches to using command_args, though this cleanup is not yet complete. I would like to run the full suite of tests and then merge this PR as is assuming that it works. More cleanup can come in a follow-up PR.

Remaining to-dos:
- Clean up the way llm_load_test config is passed from testing/lightspeed/config.yaml is passed to llm_load_test container (may require cleanup in llm_load_test itself). Allow setting runtime/model version from testing/lightspeed/config.yaml
- Rename roles/wisdom/wisdom* to roles/lightspeed/lightspeed*
