### PR TITLE
load-aware: make trimaran log more visible

### DIFF
--- a/roles/load_aware/load_aware_deploy_trimaran/tasks/main.yml
+++ b/roles/load_aware/load_aware_deploy_trimaran/tasks/main.yml
@@ -102,10 +102,7 @@
     delay: 5
     retries: 20
     until: trimaran_test_pod_state.stdout == 'Completed'
-  rescue:
-    - name: Ensure error is raised
-      fail:
-        msg: "{{ ansible_failed_result }}"
+
   always:
   - name: Dump trimaran info
     shell: |

--- a/roles/load_aware/load_aware_scale_test/tasks/main.yml
+++ b/roles/load_aware/load_aware_scale_test/tasks/main.yml
@@ -21,12 +21,14 @@
         and 'ContainerCreating' not in load_aware_workload.stdout
         and 'ImagePullBackOff' not in load_aware_workload.stdout"
 
-  rescue:
-    - name: Ensure error is raised
-      fail:
-        msg: "{{ ansible_failed_result }}"
   always:
-  - name: Dump info about scheduler resources
+  - name: Dump info about scale test resources
     shell: |
-      oc get pods -n {{ load_aware_scale_test_namespace }} > "{{ artifact_extra_logs_dir }}/all_pods.status" 
-      oc get pods -n {{ load_aware_scale_test_namespace }} -ojson > "{{ artifact_extra_logs_dir }}/all_pods.json";
+      oc get pods -n {{ load_aware_scale_test_namespace }} > "{{ artifact_extra_logs_dir }}/scale_test_pods.status" 
+      oc get pods -n {{ load_aware_scale_test_namespace }} -ojson > "{{ artifact_extra_logs_dir }}/scale_test_pods.json"
+    ignore_errors: true
+
+  - name: Dump trimaran scheduler log
+    shell: |
+      oc logs -n trimaran $(oc get pod -n trimaran -l "app=trimaran-scheduler" | awk 'NR > 1 {print $1}') > "{{ artifact_extra_logs_dir }}/trimaran_scheduler.log"
+    ignore_errors: true

--- a/visualizations/load-aware/plotting/error_report.py
+++ b/visualizations/load-aware/plotting/error_report.py
@@ -58,6 +58,9 @@ def _get_test_setup(entry):
     else:
         setup_info += [html.Li(f"Results artifacts: NOT AVAILABLE ({entry.results.from_local_env.source_url})")]
 
+    trimaran_log_file = entry.results.from_local_env.artifacts_basedir / entry.results.file_locations.trimaran_log
+    setup_info += [html.Li(html.A("Trimaran scheduler log", href=str(trimaran_log_file), target="_blank"))]
+
     managed = list(entry.results.cluster_info.control_plane)[0].managed \
         if entry.results.cluster_info.control_plane else False
 

--- a/visualizations/load-aware/plotting/pod_times.py
+++ b/visualizations/load-aware/plotting/pod_times.py
@@ -16,11 +16,12 @@ def register():
 
 def generatePodTimes(entry):
     data = []
+
     for p in entry.results.pods_info:
         workload_phase = {
             "Start": p.creation_time,
             "End": p.container_finished,
-            "Duration": (p.container_finished - p.creation_time).seconds,
+            "Duration": (p.container_finished - p.creation_time).total_seconds(),
             "Pod": p.pod_name,
             "Node": p.hostname,
             "Workload": p.workload
@@ -31,23 +32,26 @@ def generatePodTimes(entry):
 
 def generatePodTimeline(entry):
     data = []
+
     for p in entry.results.pods_info:
+
         scheduling_phase = {
             "Start": p.creation_time,
             "End": p.pod_scheduled,
             "Creation": p.creation_time,
-            "Duration": (p.pod_scheduled - p.creation_time).seconds,
+            "Duration": (p.pod_scheduled - p.creation_time).total_seconds(),
             "Pod": p.pod_name,
             "Node": p.hostname,
             "Workload": p.workload,
             "Phase": "Scheduling"
         }
+
         data.append(scheduling_phase)
         startup_phase = {
             "Start": p.pod_scheduled,
             "End": p.container_started,
             "Creation": p.creation_time,
-            "Duration": (p.container_started - p.pod_scheduled).seconds,
+            "Duration": (p.container_started - p.pod_scheduled).total_seconds(),
             "Pod": p.pod_name,
             "Node": p.hostname,
             "Workload": p.workload,

--- a/visualizations/load-aware/plotting/pod_times.py
+++ b/visualizations/load-aware/plotting/pod_times.py
@@ -180,10 +180,10 @@ class ExecutionTimeline():
 
         fig.update_layout(title=title, title_x=0.5)
        
-        scheduling_phase = df.where(df["Phase"] == "Scheduling")
+        scheduling_phase = df[df.Phase == "Scheduling"]
         q1, med, q3 = stats.quantiles(scheduling_phase.Duration)
-        sched_min = scheduling_phase.min()
-        sched_max = scheduling_phase.max()
+        sched_min = scheduling_phase["Duration"].min()
+        sched_max = scheduling_phase["Duration"].max()
         
         msg = []
 

--- a/visualizations/load-aware/plotting/pod_times.py
+++ b/visualizations/load-aware/plotting/pod_times.py
@@ -32,11 +32,21 @@ def generatePodTimes(entry):
 def generatePodTimeline(entry):
     data = []
     for p in entry.results.pods_info:
-        startup_phase = {
+        scheduling_phase = {
             "Start": p.creation_time,
+            "End": p.pod_scheduled,
+            "Creation": p.creation_time,
+            "Duration": (p.pod_scheduled - p.creation_time).seconds,
+            "Pod": p.pod_name,
+            "Node": p.hostname,
+            "Workload": p.workload,
+            "Phase": "Scheduling"
+        }
+        startup_phase = {
+            "Start": p.pod_scheduled,
             "End": p.container_started,
             "Creation": p.creation_time,
-            "Duration": (p.container_started - p.creation_time).seconds,
+            "Duration": (p.container_started - p.pod_scheduled).seconds,
             "Pod": p.pod_name,
             "Node": p.hostname,
             "Workload": p.workload,
@@ -168,7 +178,38 @@ class ExecutionTimeline():
         title = f"Pod execution timeline"
 
         fig.update_layout(title=title, title_x=0.5)
-
+       
+        scheduling_phase = df.where(df["Phase"] == "Scheduling")
+        q1, med, q3 = stats.quantiles(scheduling_phase.Duration)
+        sched_min = scheduling_phase.min()
+        sched_max = scheduling_phase.max()
+        
         msg = []
+
+        def time(sec):
+            if sec < 0.001:
+                return f"0 seconds"
+            elif sec < 5:
+                return f"{sec:.3f} seconds"
+            if sec < 20:
+                return f"{sec:.1f} seconds"
+            elif sec <= 120:
+                return f"{sec:.0f} seconds"
+            else:
+                return f"{sec/60:.1f} minutes"
+
+        msg.append(html.Br())
+        msg.append(f"Time spend in the scheduling phase across all workloads")
+        msg.append(html.Br())
+        msg.append(f"Minimum: {time(sched_min)}")
+        msg.append(html.Br())
+        msg.append(f"25% ran in less than {time(q1)} [Q1]")
+        msg.append(html.Br())
+        msg.append(f"50% ran in less than {time(med)} (+ {time(med-q1)}) [median]")
+        msg.append(html.Br())
+        msg.append(f"75% ran in less than {time(q3)} (+ {time(q3-med)}) [Q3]")
+        msg.append(html.Br())
+        msg.append(f"Maximum: {time(sched_max)}")
+        msg.append(html.Br())
 
         return fig, msg

--- a/visualizations/load-aware/plotting/pod_times.py
+++ b/visualizations/load-aware/plotting/pod_times.py
@@ -95,10 +95,10 @@ class PodTimes():
         cfg__workload = cfg.get("workload", False)
         data = filter(lambda pod: pod["Workload"] == cfg__workload, generatePodTimes(entry))
 
-        if not data:
-            return None, "No data to plot ..."
-
         df = pd.DataFrame(data)
+
+        if df.empty:
+            return None, "No data to plot ..."
 
         fig = px.histogram(df, x="Duration",
                            marginal="box",

--- a/visualizations/load-aware/plotting/pod_times.py
+++ b/visualizations/load-aware/plotting/pod_times.py
@@ -66,7 +66,7 @@ def generatePodTimeline(entry):
             "Pod": p.pod_name,
             "Node": p.hostname,
             "Workload": p.workload,
-            "Phase": "Running"
+            "Phase": f"Running {p.workload}"
         }
         data.append(workload_phase)
 

--- a/visualizations/load-aware/plotting/pod_times.py
+++ b/visualizations/load-aware/plotting/pod_times.py
@@ -42,6 +42,7 @@ def generatePodTimeline(entry):
             "Workload": p.workload,
             "Phase": "Scheduling"
         }
+        data.append(scheduling_phase)
         startup_phase = {
             "Start": p.pod_scheduled,
             "End": p.container_started,

--- a/visualizations/load-aware/store/parsers.py
+++ b/visualizations/load-aware/store/parsers.py
@@ -29,6 +29,7 @@ artifact_paths = None # store._parse_directory will turn it into a {str: pathlib
 
 IMPORTANT_FILES = [
     "config.yaml",
+    f"{artifact_dirnames.LOAD_AWARE_SCALE_TEST_DIR}/trimaran_scheduler.log",
     f"{artifact_dirnames.LOAD_AWARE_SCALE_TEST_DIR}/scale_test_pods.json",
     f"{artifact_dirnames.CLUSTER_CAPTURE_ENV_DIR}/nodes.json",
     f"{artifact_dirnames.CLUSTER_CAPTURE_ENV_DIR}/ocp_version.yml",

--- a/visualizations/load-aware/store/parsers.py
+++ b/visualizations/load-aware/store/parsers.py
@@ -157,30 +157,30 @@ def _parse_pod_times(dirname):
     for pod in json_file["items"]:
         pod_time = types.SimpleNamespace()
         pod_times.append(pod_time)
-  
+
         pod_time.pod_name = pod["metadata"]["name"]
         pod_time.workload = pod["metadata"]["labels"]["workload"]
-  
+
         pod_time.hostname = pod["spec"].get("nodeName")
-  
+
         pod_time.creation_time = datetime.datetime.strptime(
                 pod["metadata"]["creationTimestamp"], K8S_TIME_FMT)
-  
+
         start_time_str = pod["status"].get("startTime")
         pod_time.start_time = None if not start_time_str else \
             datetime.datetime.strptime(start_time_str, K8S_TIME_FMT)
-  
+
         for condition in pod["status"].get("conditions", []):
             last_transition = datetime.datetime.strptime(condition["lastTransitionTime"], K8S_TIME_FMT)
-  
+
             if condition["type"] == "ContainersReady":
                 pod_time.containers_ready = last_transition
-  
+
             elif condition["type"] == "Initialized":
                 pod_time.pod_initialized = last_transition
             elif condition["type"] == "PodScheduled":
                 pod_time.pod_scheduled = last_transition
-  
+
         for containerStatus in pod["status"].get("containerStatuses", []):
             try:
                 finishedAt =  datetime.datetime.strptime(
@@ -190,17 +190,17 @@ def _parse_pod_times(dirname):
                         containerStatus["state"]["terminated"]["startedAt"],
                         K8S_TIME_FMT)
             except KeyError: continue
-  
+
             # take the last container_finished found
             if ("container_finished" not in pod_time.__dict__
                 or pod_time.container_finished < finishedAt):
                 pod_time.container_finished = finishedAt
-  
+
           # take the last container_finished found
             if ("container_started" not in pod_time.__dict__
                 or pod_time.container_started < startedAt):
                 pod_time.container_started = startedAt
-  
+
     return pod_times
 
 @ignore_file_not_found

--- a/visualizations/load-aware/store/parsers.py
+++ b/visualizations/load-aware/store/parsers.py
@@ -60,6 +60,7 @@ def _parse_once(results, dirname):
     results.cluster_info = _extract_cluster_info(results.nodes_info)
     results.sutest_ocp_version = _parse_ocp_version(dirname)
     results.metrics = _extract_metrics(dirname)
+    results.file_locations = _parse_file_locations(dirname)
 
 def _parse_local_env(dirname):
     from_local_env = types.SimpleNamespace()

--- a/visualizations/load-aware/store/parsers.py
+++ b/visualizations/load-aware/store/parsers.py
@@ -29,7 +29,7 @@ artifact_paths = None # store._parse_directory will turn it into a {str: pathlib
 
 IMPORTANT_FILES = [
     "config.yaml",
-    f"{artifact_dirnames.LOAD_AWARE_SCALE_TEST_DIR}/all_pods.json",
+    f"{artifact_dirnames.LOAD_AWARE_SCALE_TEST_DIR}/scale_test_pods.json",
     f"{artifact_dirnames.CLUSTER_CAPTURE_ENV_DIR}/nodes.json",
     f"{artifact_dirnames.CLUSTER_CAPTURE_ENV_DIR}/ocp_version.yml",
     f"{artifact_dirnames.CLUSTER_DUMP_PROM_DB_DIR}/prometheus.t*"
@@ -143,7 +143,7 @@ def _parse_test_config(dirname):
 @ignore_file_not_found
 def _parse_pod_times(dirname):
 
-    filename = artifact_paths.LOAD_AWARE_SCALE_TEST_DIR / "all_pods.json"
+    filename = artifact_paths.LOAD_AWARE_SCALE_TEST_DIR / "scale_test_pods.json"
 
     with open(register_important_file(dirname, filename)) as f:
         try:
@@ -234,7 +234,9 @@ def _parse_nodes_info(dirname, sutest_cluster=True):
 @ignore_file_not_found
 def _parse_ocp_version(dirname):
 
-    with open(register_important_file(dirname, pathlib.Path(artifact_dirnames.CLUSTER_CAPTURE_ENV_DIR) / "ocp_version.yml")) as f:
+    filename = artifact_paths.CLUSTER_CAPTURE_ENV_DIR / "ocp_version.yml"
+
+    with open(register_important_file(dirname, filename)) as f:
         sutest_ocp_version_yaml = yaml.safe_load(f)
 
     return sutest_ocp_version_yaml["openshiftVersion"]

--- a/visualizations/load-aware/store/parsers.py
+++ b/visualizations/load-aware/store/parsers.py
@@ -238,6 +238,17 @@ def _parse_ocp_version(dirname):
 
     return sutest_ocp_version_yaml["openshiftVersion"]
 
+def _parse_file_locations(dirname):
+    file_locations = types.SimpleNamespace()
+
+    file_locations.trimaran_log = artifact_paths.LOAD_AWARE_SCALE_TEST_DIR / "trimaran_scheduler.log"
+    register_important_file(dirname, file_locations.trimaran_log)
+
+    file_locations.test_config_file = pathlib.Path("config.yaml")
+    register_important_file(dirname, file_locations.test_config_file)
+
+    return file_locations
+
 @ignore_file_not_found
 def _extract_metrics(dirname):
 


### PR DESCRIPTION
Always dump trimaran log after scale test and link to it in the report.