### PR TITLE
rhods-perf/lts: Add timezone information to JSON payloads

### DIFF
--- a/visualizations/rhods-notebooks-performance/store/lts.py
+++ b/visualizations/rhods-notebooks-performance/store/lts.py
@@ -1,6 +1,7 @@
 import types
 import datetime
 import logging
+import pytz
 
 import matrix_benchmarking.common as common
 
@@ -13,6 +14,11 @@ def build_lts_payloads():
 
         start_time = results.start_time
         end_time = results.end_time
+
+        if start_time.tzinfo is None:
+            start_time = start_time.replace(tzinfo=pytz.UTC)
+        if end_time.tzinfo is None:
+            end_time = end_time.replace(tzinfo=pytz.UTC)
 
         lts_payload = {
             "$schema": "urn:rhods-notebooks-perf:1.0.0",


### PR DESCRIPTION
This PR adds a default timezone to the start/end times within the JSON payloads, so it passes Horreum's datetime validation.