### PR TITLE
cluster_deploy_operator: deploy_cr: add a namespace parameter when deploying the CR

### DIFF
--- a/roles/cluster/cluster_deploy_operator/tasks/deploy_cr.yml
+++ b/roles/cluster/cluster_deploy_operator/tasks/deploy_cr.yml
@@ -8,4 +8,7 @@
     | jq .[0] > "{{ artifact_extra_logs_dir }}/003_operator_cr.json"
 
 - name: Create the operator CR
-  command: oc apply -f "{{ artifact_extra_logs_dir }}/003_operator_cr.json"
+  command:
+    oc apply
+       -f "{{ artifact_extra_logs_dir }}/003_operator_cr.json"
+       -n "{{ cluster_deploy_operator_namespace }}"


### PR DESCRIPTION
…

otherwise it will be deployed in the active namespace

and that won't work in the CI