### PR TITLE
load-aware: dump trimaran log during deploy

### DIFF
--- a/roles/load_aware/load_aware_deploy_trimaran/tasks/main.yml
+++ b/roles/load_aware/load_aware_deploy_trimaran/tasks/main.yml
@@ -6,8 +6,8 @@
   shell:
     set -o pipefail;
 
-    oc -n openshift-user-workload-monitoring get pod
-      | awk 'NR > 1 { print $3}'
+    oc -n openshift-user-workload-monitoring get pod --no-headers
+      | awk '{ print $3}'
   register: monitoring_enabled
   delay: 3
   retries: 20
@@ -96,8 +96,8 @@
 
   - name: Ensure the Trimaran test pods completes
     shell:
-      oc get pod trimaran-test -n trimaran
-        | awk 'NR > 1 {print $3}'
+      oc get pod trimaran-test -n trimaran --no-headers
+        | awk '{print $3}'
     register: trimaran_test_pod_state
     delay: 5
     retries: 20
@@ -112,7 +112,7 @@
 
   - name: Dump trimaran scheduler log
     shell: |
-      oc logs -n trimaran $(oc get pod -n trimaran -l "app=trimaran-scheduler" | awk 'NR > 1 {print $1}') > "{{ artifact_extra_logs_dir }}/trimaran_scheduler.log"
+      oc logs -n trimaran $(oc get pod -n trimaran -l "app=trimaran-scheduler" --no-headers | awk '{print $1}') > "{{ artifact_extra_logs_dir }}/trimaran_scheduler.log"
     ignore_errors: true
 
   - name: Dump cluster events

--- a/roles/load_aware/load_aware_deploy_trimaran/tasks/main.yml
+++ b/roles/load_aware/load_aware_deploy_trimaran/tasks/main.yml
@@ -110,6 +110,11 @@
       oc describe pod trimaran-test -n trimaran > "{{ artifact_extra_logs_dir }}/trimaran-test.pod.desc"
       oc get all -n trimaran -oyaml > "{{ artifact_extra_logs_dir }}/all-trimaran.yaml"
 
+  - name: Dump trimaran scheduler log
+    shell: |
+      oc logs -n trimaran $(oc get pod -n trimaran -l "app=trimaran-scheduler" | awk 'NR > 1 {print $1}') > "{{ artifact_extra_logs_dir }}/trimaran_scheduler.log"
+    ignore_errors: true
+
   - name: Dump cluster events
     shell:
       oc get ev -oyaml -n trimaran > "{{ artifact_extra_logs_dir }}/events.yaml"

--- a/roles/load_aware/load_aware_scale_test/tasks/main.yml
+++ b/roles/load_aware/load_aware_scale_test/tasks/main.yml
@@ -10,7 +10,7 @@
 
   - name: Wait for workloads to finish
     shell:
-      oc get pods -n {{ load_aware_scale_test_namespace }} | awk 'NR > 1 { print $3 }'
+      oc get pods -n {{ load_aware_scale_test_namespace }} --no-headers | awk '{ print $3 }'
     register: load_aware_workload
     delay: 60
     retries: 120
@@ -30,5 +30,5 @@
 
   - name: Dump trimaran scheduler log
     shell: |
-      oc logs -n trimaran $(oc get pod -n trimaran -l "app=trimaran-scheduler" | awk 'NR > 1 {print $1}') > "{{ artifact_extra_logs_dir }}/trimaran_scheduler.log"
+      oc logs -n trimaran $(oc get pod -n trimaran -l "app=trimaran-scheduler" --no-headers | awk '{print $1}') > "{{ artifact_extra_logs_dir }}/trimaran_scheduler.log"
     ignore_errors: true

--- a/testing/load-aware/config.yaml
+++ b/testing/load-aware/config.yaml
@@ -18,8 +18,8 @@ ci_presets:
   light:
     extends: [light_cluster]
     cluster.sutest.compute.machineset.count: 1
-    load_aware.scale_test.duration: 60.0
-    load_aware.scale_test.instances: 5
+    load_aware.scale_test.duration: 10.0
+    load_aware.scale_test.instances: 1
 
   metal:
     clusters.sutest.is_metal: true

--- a/visualizations/load-aware/plotting/comparison.py
+++ b/visualizations/load-aware/plotting/comparison.py
@@ -86,9 +86,13 @@ def ExecutionTimeComparison_generatePodTimes(entry, variables, exclude_workload=
 
 def ExecutionTimeComparison_generateStats(entry, variables, data):
     df = pd.DataFrame(data)
-    q1, med, q3 = stats.quantiles(df.Duration)
-    q90 = stats.quantiles(df.Duration, n=10)[8] # 90th percentile
-    q100 = df.Duration.max()
+    q1, med, q3 = (0.0, 0.0, 0.0)
+    q90 = 0.0
+    q100 = 0.0
+    if len(df) >= 2:
+        q1, med, q3 = stats.quantiles(df.Duration)
+        q90 = stats.quantiles(df.Duration, n=10)[8] # 90th percentile
+        q100 = df.Duration.max()
 
     def time(sec):
         if sec < 0.001:

--- a/visualizations/load-aware/plotting/pod_times.py
+++ b/visualizations/load-aware/plotting/pod_times.py
@@ -111,10 +111,14 @@ class PodTimes():
         fig.update_layout(title=title, title_x=0.5)
 
         msg = []
-
-        q1, med, q3 = stats.quantiles(df.Duration)
-        q90 = stats.quantiles(df.Duration, n=10)[8] # 90th percentile
-        q100 = df.Duration.max()
+        
+        q1, med, q3 = (0.0, 0.0, 0.0)
+        q90 = 0.0
+        q100 = 0.0
+        if len(df) >= 2:
+            q1, med, q3 = stats.quantiles(df.Duration)
+            q90 = stats.quantiles(df.Duration, n=10)[8] # 90th percentile
+            q100 = df.Duration.max()
 
         def time(sec):
             if sec < 0.001:
@@ -185,9 +189,9 @@ class ExecutionTimeline():
         fig.update_layout(title=title, title_x=0.5)
        
         scheduling_phase = df[df.Phase == "Scheduling"]
-        q1, med, q3 = stats.quantiles(scheduling_phase.Duration)
-        sched_min = scheduling_phase["Duration"].min()
-        sched_max = scheduling_phase["Duration"].max()
+        q1, med, q3 = (0, 0, 0) if len(df) < 2 else stats.quantiles(scheduling_phase.Duration)
+        sched_min = 0 if len(df) < 1 else scheduling_phase["Duration"].min()
+        sched_max = 0 if len(df) < 1 else scheduling_phase["Duration"].max()
         
         msg = []
 

--- a/visualizations/load-aware/plotting/pod_times.py
+++ b/visualizations/load-aware/plotting/pod_times.py
@@ -189,9 +189,9 @@ class ExecutionTimeline():
         fig.update_layout(title=title, title_x=0.5)
        
         scheduling_phase = df[df.Phase == "Scheduling"]
-        q1, med, q3 = (0, 0, 0) if len(df) < 2 else stats.quantiles(scheduling_phase.Duration)
-        sched_min = 0 if len(df) < 1 else scheduling_phase["Duration"].min()
-        sched_max = 0 if len(df) < 1 else scheduling_phase["Duration"].max()
+        q1, med, q3 = (0, 0, 0) if len(scheduling_phase) < 2 else stats.quantiles(scheduling_phase.Duration)
+        sched_min = 0 if len(scheduling_phase) < 1 else scheduling_phase["Duration"].min()
+        sched_max = 0 if len(scheduling_phase) < 1 else scheduling_phase["Duration"].max()
         
         msg = []
 


### PR DESCRIPTION
This should fix the suggestions in #855 and #863.